### PR TITLE
Add StaleSequenceException for Ringbuffer 

### DIFF
--- a/Hazelcast.Net/Hazelcast.Core/HazelcastException.cs
+++ b/Hazelcast.Net/Hazelcast.Core/HazelcastException.cs
@@ -57,4 +57,20 @@ namespace Hazelcast.Core
         public DistributedObjectDestroyedException(Exception cause) : base(cause.Message) { }
  
     }
+
+    /// <summary>
+    /// An exception that is thrown when accessing an item in the <see cref="IRingbuffer{E}">IRingbuffer</see> using a 
+    /// sequence that is smaller than the current head sequence. This means that the and old item is read, 
+    /// but it isn't available anymore in the ringbuffer.
+    /// </summary>
+    public class StaleSequenceException : HazelcastException
+    {
+        public StaleSequenceException()
+        {
+        }
+
+        public StaleSequenceException(string message) : base(message)
+        {
+        }
+    }
 }

--- a/Hazelcast.Net/Hazelcast.Util/ClientExceptionFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ClientExceptionFactory.cs
@@ -68,6 +68,7 @@ namespace Hazelcast.Util
                 {ClientProtocolErrorCodes.QueryResultSizeExceeded, (m, c) => new QueryException(m)},
                 {ClientProtocolErrorCodes.Security, (m, c) => new SecurityException(m)},
                 {ClientProtocolErrorCodes.Socket, (m, c) => new IOException(m)},
+                {ClientProtocolErrorCodes.StaleSequence, (m, c) => new StaleSequenceException(m)},
                 {ClientProtocolErrorCodes.TargetDisconnected, (m, c) => new TargetDisconnectedException(m)},
                 {ClientProtocolErrorCodes.TargetNotMember, (m, c) => new TargetNotMemberException(m)},
                 {ClientProtocolErrorCodes.Timeout, (m, c) => new TimeoutException(m)},

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientRingbufferTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientRingbufferTest.cs
@@ -102,6 +102,16 @@ namespace Hazelcast.Client.Test
             Assert.AreEqual(Capacity, _ringBuffer.HeadSequence());
         }
 
+        [Test, ExpectedException(typeof(StaleSequenceException))]
+        public void TestStaleSequence()
+        {
+            for (int k = 0; k < Capacity * 2; k++)
+            {
+                _ringBuffer.Add("foo");
+            }
+            _ringBuffer.ReadOne(_ringBuffer.HeadSequence() -1);
+        }
+
         [Test, ExpectedException(typeof (ArgumentException))]
         public void TestInvalidReadCount()
         {


### PR DESCRIPTION
Exception is thrown when the read sequence is less than the head sequence.