### PR TITLE
Fixed several issues with ClientNearCache

### DIFF
--- a/Hazelcast.Net/Hazelcast.Config/InMemoryFormat.cs
+++ b/Hazelcast.Net/Hazelcast.Config/InMemoryFormat.cs
@@ -21,6 +21,6 @@ namespace Hazelcast.Config
     {
         Binary,
         Object,
-        Offheap
+        // Offheap
     }
 }

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientNearCacheTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientNearCacheTest.cs
@@ -14,132 +14,373 @@
 * limitations under the License.
 */
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using Hazelcast.Client.Proxy;
 using Hazelcast.Config;
 using Hazelcast.Core;
+using Hazelcast.IO.Serialization;
 using Hazelcast.Util;
 using NUnit.Framework;
 
 namespace Hazelcast.Client.Test
 {
-
     [TestFixture]
     public class ClientNearCacheTest : HazelcastBaseTest
     {
-        protected override void ConfigureClient(ClientConfig config)
-        {
-            base.ConfigureClient(config);
-            var nearCacheConfig = new NearCacheConfig().SetInMemoryFormat(InMemoryFormat.Object);
-            config.AddNearCacheConfig("nearCachedMap*", nearCacheConfig);
-        }
-
-        internal static IMap<object, object> map;
-
-        //
         [SetUp]
         public void Init()
         {
-            map = Client.GetMap<object, object>("nearCachedMap-" + TestSupport.RandomString());
+            _map = Client.GetMap<object, object>("nearCachedMap-" + TestSupport.RandomString());
         }
 
         [TearDown]
-        public static void Destroy()
+        public void Destroy()
         {
-            map.Clear();
-            map.Destroy();
+            _map.Clear();
+            _map.Destroy();
+        }
+
+        private const int MaxSize = 1000;
+
+        protected override void ConfigureClient(ClientConfig config)
+        {
+            base.ConfigureClient(config);
+
+            var defaultConfig = new NearCacheConfig()
+                .SetInvalidateOnChange(false)
+                .SetInMemoryFormat(InMemoryFormat.Object)
+                .SetEvictionPolicy("None")
+                .SetMaxSize(MaxSize);
+            config.AddNearCacheConfig("nearCachedMap*", defaultConfig);
+
+            var invalidateConfig = new NearCacheConfig()
+                .SetInvalidateOnChange(true);
+            config.AddNearCacheConfig("nearCacheMapInvalidate*", invalidateConfig);
+
+            var lruConfig = new NearCacheConfig()
+                .SetEvictionPolicy("Lru")
+                .SetInvalidateOnChange(false)
+                .SetMaxSize(MaxSize);
+            config.AddNearCacheConfig("nearCacheMapLru*", lruConfig);
+
+            var lfuConfig = new NearCacheConfig()
+                .SetEvictionPolicy("Lfu")
+                .SetInvalidateOnChange(false)
+                .SetMaxSize(MaxSize);
+            config.AddNearCacheConfig("nearCacheMapLfu*", lfuConfig);
+
+            var ttlConfig = new NearCacheConfig()
+                .SetInvalidateOnChange(false)
+                .SetTimeToLiveSeconds(1);
+            config.AddNearCacheConfig("nearCacheTtl*", ttlConfig);
+
+            var idleConfig = new NearCacheConfig()
+                .SetInvalidateOnChange(false)
+                .SetMaxIdleSeconds(1);
+            config.AddNearCacheConfig("nearCacheIdle*", idleConfig);
+        }
+
+        private IMap<object, object> _map;
+
+        private ClientNearCache GetNearCache<TK, TV>(IMap<TK, TV> map)
+        {
+            return (map as ClientMapProxy<TK, TV>).NearCache;
+        }
+
+        private IData ToKeyData(object k)
+        {
+            return ((HazelcastClientProxy) Client).GetClient().GetSerializationService().ToData(k);
         }
 
         [Test]
-        public void TestNearCache() 
+        public void TestNearCache()
         {
-            for (int i = 0; i < 100; i++) 
+            for (var i = 0; i < 100; i++)
             {
-                map.Put("key" + i, "value" + i);
+                _map.Put("key" + i, "value" + i);
             }
-            long begin = Clock.CurrentTimeMillis();
-            for (int i = 0; i < 100; i++) {
-                map.Get("key" + i);
+            var begin = Clock.CurrentTimeMillis();
+            for (var i = 0; i < 100; i++)
+            {
+                _map.Get("key" + i);
             }
-            long firstRead = Clock.CurrentTimeMillis() - begin;
+            var firstRead = Clock.CurrentTimeMillis() - begin;
             begin = Clock.CurrentTimeMillis();
-            for (int i = 0; i < 100; i++) {
-                map.Get("key" + i);
+            for (var i = 0; i < 100; i++)
+            {
+                _map.Get("key" + i);
             }
-            long secondRead = Clock.CurrentTimeMillis() - begin;
+            var secondRead = Clock.CurrentTimeMillis() - begin;
             Assert.IsTrue(secondRead < firstRead);
         }
 
         [Test]
-        public void testNearCacheGetAll() 
+        public void TestNearCacheGet()
         {
-            var keys=new List<object>();
-            for (int i = 0; i < 100; i++) 
+            _map.Put("key", "value");
+            _map.Get("key");
+
+            var clientNearCache = GetNearCache(_map);
+
+            Assert.AreEqual("value", clientNearCache.Get(ToKeyData("key")));
+        }
+
+        [Test]
+        public void TestNearCacheGetAll()
+        {
+            var keys = new List<object>();
+            for (var i = 0; i < 100; i++)
             {
-                map.Put("key" + i, "value" + i);
+                _map.Put("key" + i, "value" + i);
                 keys.Add("key" + i);
             }
 
-            map.GetAll(keys);
-            var mapImpl = map as ClientMapProxy<object, object>;
-            var clientNearCache = mapImpl.NearCache;
+            _map.GetAll(keys);
 
-            Assert.AreEqual(100, clientNearCache.cache.Count);
+            var clientNearCache = GetNearCache(_map);
+
+            Assert.AreEqual(100, clientNearCache.Cache.Count);
         }
 
         [Test]
-        public void TestNearCacheGetAsync() 
+        public void TestNearCacheGetAsync()
         {
-             
-            map.Put("key", "value");
+            _map.Put("key", "value");
 
-            var val = map.GetAsync("key");
+            var val = _map.GetAsync("key");
 
             var result = val.Result;
-            Assert.AreEqual("value",result);
+            Assert.AreEqual("value", result);
 
+            var clientNearCache = GetNearCache(_map);
 
-            var mapImpl = map as ClientMapProxy<object, object>;
-            var clientNearCache = mapImpl.NearCache;
+            TestSupport.AssertTrueEventually(() => { Assert.AreEqual(1, clientNearCache.Cache.Count); });
 
-            TestSupport.AssertTrueEventually(() =>
-            {
-                Assert.AreEqual(1, clientNearCache.cache.Count);
-            });
-
-            val = map.GetAsync("key");
+            val = _map.GetAsync("key");
             result = val.Result;
             Assert.AreEqual("value", result);
 
-            ClientNearCache.CacheRecord cacheRecord = clientNearCache.cache.Values.ToArray()[0];
-            Assert.AreEqual(1, cacheRecord.hit.Get());
+            var cacheRecord = clientNearCache.Cache.Values.ToArray()[0];
+            Assert.AreEqual(1, cacheRecord.Hit.Get());
         }
 
         [Test]
-        public void TestNearCacheLocalInvalidations() 
+        public void TestNearCacheContains()
         {
-             
+            _map.Put("key", "value");
+
+            _map.Get("key");
+            _map.Get("invalidKey");
+            Assert.IsTrue(_map.ContainsKey("key"));
+            Assert.IsFalse(_map.ContainsKey("invalidKey"));
+        }
+
+        [Test]
+        public void TestNearCacheIdleEviction()
+        {
+            var map = Client.GetMap<int, int>("nearCacheIdle-" + TestSupport.RandomString());
+            var keys = Enumerable.Range(0, 10).ToList();
+            foreach (var k in keys)
+            {
+                map.Put(k, k);
+            }
+            var nonIdleKey = 100;
+            map.Put(nonIdleKey, nonIdleKey);
+
+            map.GetAll(keys);
+            var cache = GetNearCache(map);
+
+            Assert.AreEqual(keys.Count, cache.Cache.Count);
+            TestSupport.AssertTrueEventually(() =>
+            {
+                map.Get(nonIdleKey); //force ttl check 
+                foreach (var k in keys)
+                {
+                    var keyData = ToKeyData(k);
+                    Assert.IsFalse(cache.Cache.ContainsKey(keyData), "key " + k + " should have expired.");
+                }
+                var nonIdleKeyData = ToKeyData(nonIdleKey);
+                Assert.IsTrue(cache.Cache.ContainsKey(nonIdleKeyData), "key 100 should not have expired.");
+            });
+        }
+
+        [Test]
+        public void TestNearCacheInvalidationOnPut()
+        {
+            TestInvalidate((m,k) => m.Remove(k));
+        }
+
+        [Test]
+        public void TestNearCacheInvalidationOnRemove()
+        {
+            TestInvalidate((m,k) => m.Remove(k));
+        }
+
+        [Test]
+        public void TestNearCacheInvalidationOnClear()
+        {
+            TestInvalidate((m,k) => m.Clear());
+        }
+
+        [Test]
+        public void TestNearCacheInvalidationOnEvict()
+        {
+            TestInvalidate((m,k) => m.EvictAll());
+        }
+
+        [Test]
+        public void TestNearCacheLfuEviction()
+        {
+            var lfuMap = Client.GetMap<object, object>("nearCacheMapLfu-" + TestSupport.RandomString());
+            var keys = new List<object>();
+            for (var i = 0; i < MaxSize - 1; i++)
+            {
+                lfuMap.Put(i, i);
+                keys.Add(i);
+            }
+
+            // make sure all keys are cached
+            lfuMap.GetAll(keys);
+
+            // make keys in sublist accessed again
+            var subList = keys.Take(MaxSize/2).ToList();
+            lfuMap.GetAll(subList);
+
+            // add another item, triggering eviction
+            lfuMap.Put(MaxSize + 1, MaxSize + 1);
+
+            var cache = GetNearCache(lfuMap);
+
+            TestSupport.AssertTrueEventually(() =>
+            {
+                Assert.IsTrue(cache.Cache.Count <= MaxSize, cache.Cache.Count + " should be less than " + MaxSize);
+                foreach (var key in subList)
+                {
+                    var keyData = ((HazelcastClientProxy) Client).GetClient().GetSerializationService().ToData(key);
+                    Assert.IsTrue(cache.Cache.ContainsKey(keyData), "key " + key + " not found in cache");
+                }
+            });
+        }
+
+        [Test]
+        public void TestNearCacheLocalInvalidations()
+        {
+            var map = Client.GetMap<string, string>("nearCacheMapInvalidate-" + TestSupport.RandomString());
             map.Put("key", "value");
 
             var val = map.Get("key");
-            Assert.AreEqual("value",val);
+            Assert.AreEqual("value", val);
 
+            var clientNearCache = GetNearCache(map);
 
-            var mapImpl = map as ClientMapProxy<object, object>;
-            var clientNearCache = mapImpl.NearCache;
-
-            Assert.AreEqual(1, clientNearCache.cache.Count);
+            Assert.AreEqual(1, clientNearCache.Cache.Count);
 
             map.Remove("key");
             Assert.Null(map.Get("key"));
-
-            //ClientNearCache.CacheRecord cacheRecord = clientNearCache.cache.Values.ToArray()[0];
-            //Assert.AreEqual(0, cacheRecord.hit.Get());
         }
 
+        [Test]
+        public void TestNearCacheLruEviction()
+        {
+            var lruMap = Client.GetMap<object, object>("nearCacheMapLru-" + TestSupport.RandomString());
+            var keys = new List<object>();
+            for (var i = 0; i < MaxSize - 1; i++)
+            {
+                lruMap.Put(i, i);
+                keys.Add(i);
+            }
+
+            // make sure all keys are cached
+            lruMap.GetAll(keys);
+
+            // make keys in sublist accessed again
+            var subList = keys.Take(MaxSize/2).ToList();
+            lruMap.GetAll(subList);
+
+            // add another item, triggering eviction
+            lruMap.Put(MaxSize + 1, MaxSize + 1);
+
+            var cache = GetNearCache(lruMap);
+
+            TestSupport.AssertTrueEventually(() =>
+            {
+                Assert.IsTrue(cache.Cache.Count <= MaxSize, cache.Cache.Count + " should be less than " + MaxSize);
+                foreach (var key in subList)
+                {
+                    var keyData = ((HazelcastClientProxy) Client).GetClient().GetSerializationService().ToData(key);
+                    Assert.IsTrue(cache.Cache.ContainsKey(keyData), "key " + key + " not found in cache");
+                }
+            });
+        }
+
+        [Test]
+        public void TestNearCacheNoEviction()
+        {
+            var keys = new List<object>();
+            for (var i = 0; i < MaxSize*2; i++)
+            {
+                _map.Put(i, i);
+                keys.Add(i);
+            }
+            _map.GetAll(keys);
+            var cache = GetNearCache(_map);
+            Assert.AreEqual(MaxSize, cache.Cache.Count);
+        }
+
+        [Test]
+        public void TestNearCacheTtlEviction()
+        {
+            var map = Client.GetMap<int, int>("nearCacheTtl-" + TestSupport.RandomString());
+            var keys = Enumerable.Range(0, 10).ToList();
+            foreach (var k in keys)
+            {
+                map.Put(k, k);
+            }
+
+            map.GetAll(keys);
+            var cache = GetNearCache(map);
+
+            Assert.AreEqual(keys.Count, cache.Cache.Count);
+            TestSupport.AssertTrueEventually(() =>
+            {
+                map.Get(100); //force ttl check 
+                foreach (var k in keys)
+                {
+                    var keyData = ((HazelcastClientProxy) Client).GetClient().GetSerializationService().ToData(k);
+                    Assert.IsFalse(cache.Cache.ContainsKey(keyData), "key " + k + " should have expired.");
+                }
+            });
+        }
+
+        private void TestInvalidate(Action<IMap<string,string>, string> invalidatingAction)
+        {
+            var map = Client.GetMap<string, string>("nearCacheMapInvalidate-" + TestSupport.RandomString());
+            map.Put("key", "value");
+
+            var val = map.Get("key");
+            Assert.AreEqual("value", val);
+
+            var clientNearCache = GetNearCache(map);
+
+            Assert.AreEqual(1, clientNearCache.Cache.Count);
+
+            var client = CreateClient();
+            try
+            {
+                invalidatingAction(client.GetMap<string, string>(map.GetName()), "key");
+            }
+            finally
+            {
+                client.Shutdown();
+            }
+
+            TestSupport.AssertTrueEventually(() =>
+            {
+                Assert.IsFalse(clientNearCache.Cache.ContainsKey(ToKeyData("key")),
+                    "key should have been invalidated");
+            });
+        }
     }
 }

--- a/Hazelcast.Test/Hazelcast.Client.Test/HazelcastNode.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/HazelcastNode.cs
@@ -17,8 +17,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Threading.Tasks;
-using Hazelcast.Logging;
+﻿using Hazelcast.Logging;
 
 namespace Hazelcast.Client.Test
 {
@@ -49,10 +48,16 @@ namespace Hazelcast.Client.Test
             if (hzhome == null) throw new Exception("HAZELCAST_HOME must be defined in order to run the unit tests.");
 
             var redirectOutput = Environment.GetEnvironmentVariable("HAZELCAST_REDIRECT_OUTPUT") != null;
+            var jarPath = Path.Combine(hzhome, HazelcastJar);
+
+            if (!File.Exists(jarPath))
+            {
+                throw new FileNotFoundException("Could not find hazelcast.jar at " + jarPath);
+            }
 
             string[] arguments =
             {
-                "-cp", Path.Combine(hzhome, HazelcastJar),
+                "-cp", jarPath,
                 "-Dhazelcast.event.queue.capacity=1100000",
                 "-Dhazelcast.config=" + Path.Combine(hzhome,"hazelcast.xml"),
                 "com.hazelcast.core.server.StartServer"


### PR DESCRIPTION
* When maximum size is reached, the eviction function should evict items according to policy
* On Map.Get() the deserialised result should be stored in the cache
* On Map.GetAll it should not remove items from the collection it is iterating on
* EntryEvents should be handled according to their type
* Disabled Offheap in memory format as it is not supported
* Add several tests for all of the above