### PR TITLE
Changes to bring serialization in order with the Java client

### DIFF
--- a/Hazelcast.Net/Hazelcast.Config/GlobalSerializerConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/GlobalSerializerConfig.cs
@@ -22,6 +22,7 @@ namespace Hazelcast.Config
         private string _className;
 
         private ISerializer _implementation;
+        private bool _overrideClrSerialization;
 
         public virtual string GetClassName()
         {
@@ -45,13 +46,21 @@ namespace Hazelcast.Config
             return this;
         }
 
+        public GlobalSerializerConfig SetOverrideClrSerialization(bool overrideClrSerialization)
+        {
+            _overrideClrSerialization = overrideClrSerialization;
+            return this;
+        }
+
+        public bool GetOverrideClrSerialization()
+        {
+            return _overrideClrSerialization;
+        }
+
         public override string ToString()
         {
-            var sb = new StringBuilder("GlobalSerializerConfig{");
-            sb.Append("className='").Append(_className).Append('\'');
-            sb.Append(", implementation=").Append(_implementation);
-            sb.Append('}');
-            return sb.ToString();
+            return string.Format("ClassName: {0}, Implementation: {1}, OverrideClrSerialization: {2}",
+                _className, _implementation, _overrideClrSerialization);
         }
     }
 }

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/SerializationServiceBuilder.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/SerializationServiceBuilder.cs
@@ -218,7 +218,7 @@ namespace Hazelcast.IO.Serialization
                     {
                         aware.SetHazelcastInstance(_hazelcastInstance);
                     }
-                    ss.RegisterGlobal(serializer);
+                    ss.RegisterGlobal(serializer, globalSerializerConfig.GetOverrideClrSerialization());
                 }
                 var typeSerializers = _config.GetSerializerConfigs();
                 foreach (var serializerConfig in typeSerializers)

--- a/Hazelcast.Test/Hazelcast.Test.csproj
+++ b/Hazelcast.Test/Hazelcast.Test.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{20F910E8-C1BC-4D44-8460-351FDF0DD54D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>
     </RootNamespace>

--- a/build.bat
+++ b/build.bat
@@ -13,9 +13,9 @@ call mvn dependency:get -DrepoUrl=https://oss.sonatype.org/content/repositories/
 IF %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
 IF %COVERAGE%==--coverage (
   echo Running Unit Tests with coverage...
-  dotcover analyse /TargetExecutable="packages\NUnit.Runners.2.6.4\tools\nunit-console.exe" /TargetArguments="/xml:"console-text.xml" Hazelcast.Test/bin/Release/Hazelcast.Test.exe" /TargetWorkingDir=. /Output=Coverage.html /ReportType=HTML
+  dotcover analyse /TargetExecutable="packages\NUnit.Runners.2.6.4\tools\nunit-console.exe" /TargetArguments="/xml:"console-text.xml" Hazelcast.Test/bin/Release/Hazelcast.Test.dll" /TargetWorkingDir=. /Output=Coverage.html /ReportType=HTML
 ) ELSE (
   echo Running Unit Tests...
-  packages\NUnit.Runners.2.6.4\tools\nunit-console /xml:"console-text.xml" "Hazelcast.Test/bin/Release/Hazelcast.Test.exe" /noshadow 
+  packages\NUnit.Runners.2.6.4\tools\nunit-console /xml:"console-text.xml" "Hazelcast.Test/bin/Release/Hazelcast.Test.dll" /noshadow 
 )
 popd


### PR DESCRIPTION
Global serializer should have lower priority than CLR serialization, unless
an override is specified.