### PR TITLE
Promote connections to owner connection if one was available

### DIFF
--- a/Hazelcast.Net/Hazelcast.Client.Connection/ClientConnection.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Connection/ClientConnection.cs
@@ -49,6 +49,7 @@ namespace Hazelcast.Client.Connection
         private volatile Socket _clientSocket;
         private volatile ISocketWritable _lastWritable;
         private volatile bool _live;
+        private bool _isOwner;
         private volatile IMember _member;
         private Thread _writeThread;
 
@@ -211,6 +212,15 @@ namespace Hazelcast.Client.Connection
             _clientSocket.Send(Encoding.UTF8.GetBytes(Protocols.ClientBinaryNew));
         }
 
+        internal void SetOwner()
+        {
+            _isOwner = true;
+        }
+
+        internal bool IsOwner()
+        {
+            return _isOwner;
+        }
         private void BeginRead()
         {
             if (!CheckLive())
@@ -246,18 +256,10 @@ namespace Hazelcast.Client.Connection
         {
             if (!_live)
             {
-                if (Logger.IsFinestEnabled())
-                {
-                    Logger.Finest("We are being asked to read, but connection is not live so we won't");
-                }
                 return false;
             }
             if (!_clientSocket.Connected)
             {
-                if (Logger.IsFinestEnabled())
-                {
-                    Logger.Finest("We are being asked to read, but connection is not connected...");
-                }
                 Task.Factory.StartNew(Close);
                 return false;
             }

--- a/Hazelcast.Net/Hazelcast.Client.Connection/ClientConnectionManager.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Connection/ClientConnectionManager.cs
@@ -283,7 +283,6 @@ namespace Hazelcast.Client.Connection
                     ClientTypes.Csharp, _client.GetSerializationService().GetVersion());
             }
 
-            connection.Init();
             IClientMessage response;
             try
             {
@@ -329,14 +328,10 @@ namespace Hazelcast.Client.Connection
                     var request = ClientPingCodec.EncodeRequest();
                     var task = ((ClientInvocationService) _client.GetInvocationService()).InvokeOnConnection(request,
                         clientConnection);
-                    // ReSharper disable once InconsistentlySynchronizedField
-                    Logger.Finest("Sending heartbeat request to " + clientConnection.GetAddress());
                     try
                     {
                         var response = ThreadUtil.GetResult(task, _heartBeatTimeout);
                         ClientPingCodec.DecodeResponse(response);
-                        // ReSharper disable once InconsistentlySynchronizedField
-                        Logger.Finest("Got heartbeat response from " + clientConnection.GetAddress());
                     }
                     catch (Exception e)
                     {
@@ -369,6 +364,7 @@ namespace Hazelcast.Client.Connection
                 connection = new ClientConnection(this, (ClientInvocationService) _client.GetInvocationService(),
                     id,
                     address, _networkConfig);
+                connection.Init();
                 if (_socketInterceptor != null)
                 {
                     _socketInterceptor.OnConnect(connection.GetSocket());

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ClientClusterService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ClientClusterService.cs
@@ -308,6 +308,11 @@ namespace Hazelcast.Client.Spi
                         Logger.Finest("Trying to connect to " + address);
                     }
                     var connection = _connectionManager.GetOrConnect(address, ManagerAuthenticator);
+                    // promote connection to owner if not already
+                    if (!connection.IsOwner())
+                    {
+                        ManagerAuthenticator(connection);
+                    }
                     FireConnectionEvent(LifecycleEvent.LifecycleState.ClientConnected);
                     _ownerConnectionAddress = connection.GetAddress();
                     return true;
@@ -457,7 +462,6 @@ namespace Hazelcast.Client.Spi
                     ClientTypes.Csharp, _client.GetSerializationService().GetVersion());
             }
 
-            connection.Init();
             IClientMessage response;
             try
             {
@@ -474,6 +478,7 @@ namespace Hazelcast.Client.Spi
             _principal = new ClientPrincipal(result.uuid, result.ownerUuid);
 
             connection.SetRemoteMember(member);
+            connection.SetOwner();
         }
     }
 }


### PR DESCRIPTION
When owner connection drops, if another connection was already available 
it should be promoted to owner