### PR TITLE
Fixes interval/heartbeat mixup in ClientConnectionManager

### DIFF
--- a/Hazelcast.Net/Hazelcast.Client.Connection/ClientConnectionManager.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Connection/ClientConnectionManager.cs
@@ -83,9 +83,9 @@ namespace Hazelcast.Client.Connection
             const int defaultHeartbeatTimeout = 60000;
 
             var heartbeatTimeoutMillis =
-                EnvironmentUtil.ReadInt("hazelcast.client.heartbeat.timeout") ?? defaultHeartbeatInterval;
+                EnvironmentUtil.ReadInt("hazelcast.client.heartbeat.timeout") ?? defaultHeartbeatTimeout;
             var heartbeatIntervalMillis =
-                EnvironmentUtil.ReadInt("hazelcast.client.heartbeat.interval") ?? defaultHeartbeatTimeout;
+                EnvironmentUtil.ReadInt("hazelcast.client.heartbeat.interval") ?? defaultHeartbeatInterval;
             
             _heartbeatTimeout = TimeSpan.FromMilliseconds(heartbeatTimeoutMillis);
             _heartbeatInterval = TimeSpan.FromMilliseconds(heartbeatIntervalMillis);


### PR DESCRIPTION
The values for timeout and interval are mixed up.