### PR TITLE
Update documentation for Get(object key) to take structs into account.

### DIFF
--- a/Hazelcast.Net/Hazelcast.Core/IMap.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IMap.cs
@@ -490,10 +490,12 @@ namespace Hazelcast.Core
         void ForceUnlock(TKey key);
 
         /// <summary>
-        ///     Returns the value for the specified key, or <c>null</c> if this map does not contain this key.
+        ///     Returns the value for the specified key, or the default value for <typeparamref name="TValue"/>
+        ///     if this map does not contain this key.
         /// </summary>
         /// <remarks>
-        ///     Returns the value for the specified key, or <c>null</c> if this map does not contain this key.
+        ///     Returns the value for the specified key, or the default value for <typeparamref name="TValue"/>
+        ///     if this map does not contain this key.
         ///     <p>
         ///         <b>Warning:</b>
         ///     </p>


### PR DESCRIPTION
The documentation for `IMap<TKey,TValue>.Get(object key)` states that it will return null if the map does not contain this key.

When **TValue** is a struct, this is not correct. I've updated the doc so it applies to both reference and non-reference types.

