### PR TITLE
[Backport]GetAsync call removed redundant internal task creation

### DIFF
--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMapNearCacheProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMapNearCacheProxy.cs
@@ -297,5 +297,10 @@ namespace Hazelcast.Client.Proxy
                 }
             }
         }
+
+        public override Task<TValue> GetAsync(TKey key)
+        {
+            return GetContext().GetExecutionService().Submit(() => Get(key));
+        }
     }
 }

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMapProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMapProxy.cs
@@ -164,10 +164,16 @@ namespace Hazelcast.Client.Proxy
             Invoke(request);
         }
 
-        public Task<TValue> GetAsync(TKey key)
+        public virtual Task<TValue> GetAsync(TKey key)
         {
-            var task = GetContext().GetExecutionService().Submit(() => Get(key));
-            return task;
+            ValidationUtil.CheckNotNull(key, ValidationUtil.NULL_KEY_IS_NOT_ALLOWED);
+            var keyData = ToData(key);
+            var request = MapGetCodec.EncodeRequest(GetName(), keyData, ThreadUtil.GetThreadId());
+            return InvokeAsync(request, keyData, m =>
+            {
+                var resp = MapGetCodec.DecodeResponse(m).response;
+                return ToObject<TValue>(resp);
+            });
         }
 
         public Task<TValue> PutAsync(TKey key, TValue value)

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ClientPartitionService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ClientPartitionService.cs
@@ -190,7 +190,7 @@ using Hazelcast.Util;
         {
             while (!GetPartitions() && _live.Get())
             {
-                Thread.Sleep(PartitionRefreshPeriod);
+                Thread.Sleep(100);
             }
         }
 


### PR DESCRIPTION
Backport of #223
the partition update wait time for the first time is updated to 100ms from 10sec.