### PR TITLE
Port 5701 usage as the preferred port in case it's not specified

### DIFF
--- a/Hazelcast.Net/Hazelcast.IO/Address.cs
+++ b/Hazelcast.Net/Hazelcast.IO/Address.cs
@@ -34,6 +34,14 @@ namespace Hazelcast.IO
         private readonly string _host;
         private readonly bool _hostSet;
         private readonly int _port = -1;
+
+        private bool _hasUserProvidedPort  = true;
+        internal bool HasUserProvidedPort
+        {
+            get { return _hasUserProvidedPort; }
+            set { _hasUserProvidedPort = value; }
+        }
+
         private readonly byte _type;
         private string _scopeId;
 

--- a/Hazelcast.Net/Hazelcast.Util/AddressUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/AddressUtil.cs
@@ -153,10 +153,12 @@ namespace Hazelcast.Util
             }
             var port = addressHolder.Port;
             var portTryCount = 1;
+            bool userProvidedPort = true;
             if (port == -1)
             {
                 portTryCount = MaxPortTries;
                 port = 5701;
+                userProvidedPort = false;
             }
             ICollection<Address> socketAddresses = new List<Address>();
             if (ipAddress == null)
@@ -165,7 +167,8 @@ namespace Hazelcast.Util
                 {
                     if (IPAddress.TryParse(scopedAddress, out ipAddress))
                     {
-                        socketAddresses.Add(new Address(scopedAddress, ipAddress, port + i));
+                        socketAddresses.Add(new Address(scopedAddress, ipAddress, port + i)
+                            {HasUserProvidedPort = userProvidedPort});
                     }
                 }
             }
@@ -175,7 +178,8 @@ namespace Hazelcast.Util
                 {
                     for (var i = 0; i < portTryCount; i++)
                     {
-                        socketAddresses.Add(new Address(scopedAddress, ipAddress, port + i));
+                        socketAddresses.Add(new Address(scopedAddress, ipAddress, port + i)
+                            {HasUserProvidedPort = userProvidedPort});
                     }
                 }
                 else
@@ -185,7 +189,8 @@ namespace Hazelcast.Util
                     {
                         for (var i = 0; i < portTryCount; i++)
                         {
-                            socketAddresses.Add(new Address(scopedAddress, ipa, port + i));
+                            socketAddresses.Add(new Address(scopedAddress, ipa, port + i)
+                                {HasUserProvidedPort = userProvidedPort});
                         }
                     }
                 }

--- a/Hazelcast.Test/Hazelcast.Client.Test/AddressProviderTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/AddressProviderTest.cs
@@ -66,5 +66,23 @@ namespace Hazelcast.Client.Test
                 addressProvider.GetAddresses();
             });
         }
+
+        [Test]
+        public void PortNumberSourceHasBeenMarkedProperly()
+        {
+            var cfg = new ClientConfig();
+            cfg.GetNetworkConfig().AddAddress("10.0.0.1", "10.0.0.2:5702", "10.0.0.3:5703", "10.0.0.4", "10.0.0.5");
+
+            var addressProvider = new AddressProvider(cfg);
+            var addresses = addressProvider.GetAddresses().ToList();
+
+            var portsSpecifiedByUser = addresses.Where(address => address.HasUserProvidedPort);
+            var primaryAutoDiscoveryAddresses= addresses.Where(address => address.GetPort()==5701 && !address.HasUserProvidedPort);
+            var secondaryAutoDiscoveryAddresses = addresses.Where(address => address.GetPort() != 5701 && !address.HasUserProvidedPort);
+
+            Assert.AreEqual(2, portsSpecifiedByUser.Count());
+            Assert.AreEqual(3, primaryAutoDiscoveryAddresses.Count());
+            Assert.AreEqual(6, secondaryAutoDiscoveryAddresses.Count());
+        }
     }
 }


### PR DESCRIPTION
Based on java client changes description and real code changes in java client I created reduced (simplified) version of the fix. This fix doesn't change any interface or public class definition.

Java fix description is [here](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1192296467/Avoid+Random+Connection+Delay+When+Port+not+Specified+-+Java+Client) and real code changes in java client are in PR [here](https://github.com/hazelcast/hazelcast/pull/14249/files)

The real change in the connection logic is in `ConnectAsOwner` method.
Please review and let me know if we can provide the fix in this form. 
