### PR TITLE
Handling DNS resolution failures gracefully

### DIFF
--- a/Hazelcast.Net/Hazelcast.Client.Spi/ClientClusterService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ClientClusterService.cs
@@ -289,9 +289,10 @@ namespace Hazelcast.Client.Spi
             var addresses = GetPossibleMemberAddresses();
             foreach (var address in addresses)
             {
-                var inetSocketAddress = address.GetInetSocketAddress();
+                IPEndPoint inetSocketAddress = null;
                 try
                 {
+                    inetSocketAddress = address.GetInetSocketAddress();
                     triedAddresses.Add(inetSocketAddress);
                     if (Logger.IsFinestEnabled())
                     {
@@ -310,7 +311,7 @@ namespace Hazelcast.Client.Spi
                     }
                     exceptions.Add(e);
                     var level = e is AuthenticationException ? LogLevel.Warning : LogLevel.Finest;
-                    Logger.Log(level, "Exception during initial connection to " + inetSocketAddress, e);
+                    Logger.Log(level, "Exception during initial connection to " + inetSocketAddress ?? address.ToString(), e);
                 }
             }
             return false;

--- a/Hazelcast.Net/Hazelcast.IO/Address.cs
+++ b/Hazelcast.Net/Hazelcast.IO/Address.cs
@@ -87,7 +87,7 @@ namespace Hazelcast.IO
             {
                 return IPAddress.Any;
             }
-            var addresses = Dns.GetHostAddresses(name);
+            var addresses = DnsUtil.GetHostAddresses(name);
             var ipv4 = addresses.FirstOrDefault(m => m.AddressFamily == AddressFamily.InterNetwork);
             return ipv4 ?? addresses.FirstOrDefault();
         }

--- a/Hazelcast.Net/Hazelcast.Util/AddressUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/AddressUtil.cs
@@ -102,8 +102,8 @@ namespace Hazelcast.Util
             if ((ipAddress.IsIPv6SiteLocal || ipAddress.IsIPv6LinkLocal) && ipAddress.ScopeId <= 0)
             {
                 var possibleAddresses = new List<IPAddress>();
-                var strHostName = Dns.GetHostName();
-                var ipEntry = Dns.GetHostEntry(strHostName);
+                var strHostName = DnsUtil.GetHostName();
+                var ipEntry = DnsUtil.GetHostEntry(strHostName);
                 var addr = ipEntry.AddressList;
                 foreach (var address in addr)
                 {

--- a/Hazelcast.Net/Hazelcast.Util/DnsUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/DnsUtil.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Net;
-using System.Threading;
 
 namespace Hazelcast.Util
 {

--- a/Hazelcast.Net/Hazelcast.Util/DnsUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/DnsUtil.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net;
+using System.Threading;
+
+namespace Hazelcast.Util
+{
+    /// <summary>
+    /// A simple Util class enabling fault injection for <see cref="Dns"/> method calls.
+    /// </summary>
+    static class DnsUtil
+    {
+        static Func<string> _getHostNameFunc = Dns.GetHostName;
+        static Func<string, IPHostEntry> _getHostEntryFunc = Dns.GetHostEntry;
+        static Func<string, IPAddress[]> _getHostAddressesFunc = Dns.GetHostAddresses;
+
+        /// <summary>Gets the host name of the local computer.</summary>
+        /// <returns>A string that contains the DNS host name of the local computer.</returns>
+        /// <exception cref="T:System.Net.Sockets.SocketException">An error is encountered when resolving the local host name. </exception>
+        public static string GetHostName()
+        {
+            return _getHostNameFunc();
+        }
+
+        /// <summary>Resolves a host name or IP address to an <see cref="T:System.Net.IPHostEntry" /> instance.</summary>
+        /// <param name="hostNameOrAddress">The host name or IP address to resolve.</param>
+        /// <returns>An <see cref="T:System.Net.IPHostEntry" /> instance that contains address information about the host specified in <paramref name="hostNameOrAddress" />.</returns>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="hostNameOrAddress" /> parameter is <see langword="null" />. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="hostNameOrAddress" /> parameter is greater than 255 characters. </exception>
+        /// <exception cref="T:System.Net.Sockets.SocketException">An error was encountered when resolving the <paramref name="hostNameOrAddress" /> parameter. </exception>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="hostNameOrAddress" /> parameter is an invalid IP address. </exception>
+        public static IPHostEntry GetHostEntry(string hostNameOrAddress)
+        {
+            return _getHostEntryFunc(hostNameOrAddress);
+        }
+
+        /// <summary>Returns the Internet Protocol (IP) addresses for the specified host.</summary>
+        /// <param name="hostNameOrAddress">The host name or IP address to resolve.</param>
+        /// <returns>An array of type <see cref="T:System.Net.IPAddress" /> that holds the IP addresses for the host that is specified by the <paramref name="hostNameOrAddress" /> parameter.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        /// <paramref name="hostNameOrAddress" /> is <see langword="null" />. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="hostNameOrAddress" /> is greater than 255 characters. </exception>
+        /// <exception cref="T:System.Net.Sockets.SocketException">An error is encountered when resolving <paramref name="hostNameOrAddress" />. </exception>
+        /// <exception cref="T:System.ArgumentException">
+        /// <paramref name="hostNameOrAddress" /> is an invalid IP address.</exception>
+        public static IPAddress[] GetHostAddresses(string hostNameOrAddress)
+        {
+            return _getHostAddressesFunc(hostNameOrAddress);
+        }
+
+        public static class Overrides
+        {
+            public static IDisposable GetHostName(Func<string> getHostName)
+            {
+                var f = _getHostNameFunc;
+                _getHostNameFunc = getHostName;
+                return new Disposable(() => { _getHostNameFunc = f; });
+            }
+
+            public static IDisposable GetHostEntry(Func<string, IPHostEntry> getHostEntry)
+            {
+                var f = _getHostEntryFunc;
+                _getHostEntryFunc = getHostEntry;
+                return new Disposable(() => { _getHostEntryFunc = f; });
+            }
+
+            public static IDisposable GetHostAddresses(Func<string, IPAddress[]> getHostAddresses)
+            {
+                var f = _getHostAddressesFunc;
+                _getHostAddressesFunc = getHostAddresses;
+                return new Disposable(() => { _getHostAddressesFunc = f; });
+            }
+
+            class Disposable : IDisposable
+            {
+                readonly Action _action;
+
+                public Disposable(Action action)
+                {
+                    _action = action;
+                }
+
+                public void Dispose()
+                {
+                    _action();
+                }
+            }
+        }
+    }
+}

--- a/Hazelcast.Net/Hazelcast.Util/DnsUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/DnsUtil.cs
@@ -59,44 +59,5 @@ namespace Hazelcast.Util
         {
             return _getHostAddressesFunc(hostNameOrAddress);
         }
-
-        public static class Overrides
-        {
-            public static IDisposable GetHostName(Func<string> getHostName)
-            {
-                var f = _getHostNameFunc;
-                _getHostNameFunc = getHostName;
-                return new Disposable(() => { _getHostNameFunc = f; });
-            }
-
-            public static IDisposable GetHostEntry(Func<string, IPHostEntry> getHostEntry)
-            {
-                var f = _getHostEntryFunc;
-                _getHostEntryFunc = getHostEntry;
-                return new Disposable(() => { _getHostEntryFunc = f; });
-            }
-
-            public static IDisposable GetHostAddresses(Func<string, IPAddress[]> getHostAddresses)
-            {
-                var f = _getHostAddressesFunc;
-                _getHostAddressesFunc = getHostAddresses;
-                return new Disposable(() => { _getHostAddressesFunc = f; });
-            }
-
-            class Disposable : IDisposable
-            {
-                readonly Action _action;
-
-                public Disposable(Action action)
-                {
-                    _action = action;
-                }
-
-                public void Dispose()
-                {
-                    _action();
-                }
-            }
-        }
     }
 }

--- a/Hazelcast.Test/Hazelcast.Client.Test/DnsErrorsTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/DnsErrorsTest.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Hazelcast.Config;
+using Hazelcast.Core;
+using Hazelcast.Remote;
+using Hazelcast.Util;
+using NUnit.Framework;
+
+namespace Hazelcast.Client.Test
+{
+    [TestFixture]
+    public class DnsErrorsTest : HazelcastTestSupport
+    {
+        private RemoteController.Client _remoteController;
+        private Cluster _cluster;
+
+        [SetUp]
+        public void Setup()
+        {
+            _remoteController = CreateRemoteController();
+            _cluster = CreateCluster(_remoteController);
+
+            StartMember(_remoteController, _cluster);
+        }
+
+        [Test]
+        public void FailureAtSecondHostAddressResolution()
+        {
+            using (ThrowGetHostAddressesAt(2))
+            {
+                var client = CreateClient();
+
+                client.Shutdown();
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HazelcastClient.ShutdownAll();
+            StopCluster(_remoteController, _cluster);
+            StopRemoteController(_remoteController);
+        }
+
+        protected override void ConfigureGroup(ClientConfig config)
+        {
+            config.GetGroupConfig().SetName(_cluster.Id).SetPassword(_cluster.Id);
+        }
+
+        static IDisposable ThrowGetHostAddressesAt(int failAt)
+        {
+            var count = 0;
+            Func<string, IPAddress[]> over =
+                s =>
+                {
+                    count++;
+                    if (count == failAt)
+                    {
+                        throw new SocketException((int)SocketError.HostNotFound);
+                    }
+
+                    return Dns.GetHostAddresses(s);
+                };
+
+            return DnsUtil.Overrides.GetHostAddresses(over);
+        }
+    }
+}

--- a/Hazelcast.Test/Hazelcast.Client.Test/DnsErrorsTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/DnsErrorsTest.cs
@@ -39,7 +39,7 @@ namespace Hazelcast.Client.Test
         }
 
         [Test]
-        public void FailureAtSecondHostAddressResolution()
+        public void SingleFailureAtAddressResolutionShouldNotBlowUpClient()
         {
             using (ThrowGetHostAddressesAt(2))
             {

--- a/Hazelcast.Test/Hazelcast.Client.Test/DnsErrorsTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/DnsErrorsTest.cs
@@ -16,9 +16,8 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using Hazelcast.Config;
-using Hazelcast.Core;
 using Hazelcast.Remote;
-using Hazelcast.Util;
+using Hazelcast.Test;
 using NUnit.Framework;
 
 namespace Hazelcast.Client.Test
@@ -77,7 +76,7 @@ namespace Hazelcast.Client.Test
                     return Dns.GetHostAddresses(s);
                 };
 
-            return DnsUtil.Overrides.GetHostAddresses(over);
+            return Overrides.Dns.GetHostAddresses(over);
         }
     }
 }

--- a/Hazelcast.Test/Overrides.cs
+++ b/Hazelcast.Test/Overrides.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net;
+using System.Reflection;
+using Hazelcast.Util;
+
+namespace Hazelcast.Test
+{
+    class Overrides
+    {
+        public static class Dns
+        {
+            static readonly StaticField GetHostNameFunc = new StaticField(typeof(DnsUtil), "_getHostNameFunc");
+            static readonly StaticField GetHostEntryFunc = new StaticField(typeof(DnsUtil), "_getHostEntryFunc");
+            static readonly StaticField GetHostAddressesFund = new StaticField(typeof(DnsUtil), "_getHostAddressesFunc");
+
+            public static IDisposable GetHostName(Func<string> getHostName)
+            {
+                var f = GetHostNameFunc.Value;
+                GetHostNameFunc.Value = getHostName;
+                return new Disposable(() => { GetHostNameFunc.Value = f; });
+            }
+
+            public static IDisposable GetHostEntry(Func<string, IPHostEntry> getHostEntry)
+            {
+                var f = GetHostEntryFunc.Value;
+                GetHostEntryFunc.Value = getHostEntry;
+                return new Disposable(() => { GetHostEntryFunc.Value = f; });
+            }
+
+            public static IDisposable GetHostAddresses(Func<string, IPAddress[]> getHostAddresses)
+            {
+                var f = GetHostAddressesFund.Value;
+                GetHostAddressesFund.Value = getHostAddresses;
+                return new Disposable(() => { GetHostAddressesFund.Value = f; });
+            }
+        }
+
+        class StaticField
+        {
+            readonly FieldInfo _field;
+
+            public StaticField(Type type, string name)
+            {
+                _field = type.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            }
+
+            public object Value
+            {
+                get { return _field.GetValue(null); }
+                set { _field.SetValue(null, value); }
+            }
+        }
+
+        class Disposable : IDisposable
+        {
+            readonly Action _action;
+
+            public Disposable(Action action)
+            {
+                _action = action;
+            }
+
+            public void Dispose()
+            {
+                _action();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses #240 
The fix is based on #233 

### Description

This PR introduces an additional layer for DNS probing that enables injecting faults to the resolution mechanism. With this it enables simulating DNS occasional problems.

`ConnectAsOwner` is fixed on basis of #233, by moving the `address.GetInetSocketAddress` to the inside of the `try` block.

### Remarks

I think that `GetPossibleIpAddressesFor` also is prone to throwing, but I'm not able to find the execution path that would fall into this category. Would be great if somebody could hive me a hint how to setup the configuration to make it fall. Now with DNS fault injection, it's easy when right params are known.
