### PR TITLE
Less bytes for strings

### DIFF
--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/SafeBuffer.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/SafeBuffer.cs
@@ -64,7 +64,11 @@ namespace Hazelcast.Client.Protocol.Util
 
         public  int PutStringUtf8(int index, string value)
         {
-            return PutStringUtf8(index, value, int.MaxValue);
+            const int lengthSize = Bits.IntSizeInBytes;
+
+            var size = Encoding.UTF8.GetBytes(value, 0, value.Length, _byteArray, index + lengthSize);
+            PutInt(index, size);
+            return lengthSize + size;
         }
 
         public  int PutStringUtf8(int index, string value, int maxEncodedSize)

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/SafeBuffer.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/SafeBuffer.cs
@@ -130,9 +130,7 @@ namespace Hazelcast.Client.Protocol.Util
 
         public  string GetStringUtf8(int offset, int length)
         {
-            var stringInBytes = new byte[length];
-            GetBytes(offset + Bits.IntSizeInBytes, stringInBytes);
-            return Encoding.UTF8.GetString(stringInBytes);
+            return Encoding.UTF8.GetString(_byteArray, offset+Bits.IntSizeInBytes,length);
         }
     }
 }


### PR DESCRIPTION
This PR removes `byte[]` allocations in `SafeBuffer` whenever a UTF8 encoded string is being written or read. 

I've found it when reading through the `SafeBuffer` codebase. It's a simple removal, I didn't found that much improvement but it reduces coping encoded bytes.