### PR TITLE
Instance name is now configurable

### DIFF
--- a/Hazelcast.Net/Hazelcast.Client/HazelcastClient.cs
+++ b/Hazelcast.Net/Hazelcast.Client/HazelcastClient.cs
@@ -74,7 +74,16 @@ namespace Hazelcast.Client
         {
             _config = config;
             var groupConfig = config.GetGroupConfig();
-            _instanceName = "hz.client_" + _id + (groupConfig != null ? "_" + groupConfig.GetName() : string.Empty);
+
+            var instanceName = config.GetInstanceName();
+            if (string.IsNullOrWhiteSpace(instanceName) == false)
+            {
+                _instanceName = instanceName;
+            }
+            else
+            {
+                _instanceName = "hz.client_" + _id + (groupConfig != null ? "_" + groupConfig.GetName() : string.Empty);
+            }
 
             _lifecycleService = new LifecycleService(this);
             try

--- a/Hazelcast.Net/Hazelcast.Config/ClientConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/ClientConfig.cs
@@ -71,6 +71,8 @@ namespace Hazelcast.Config
 
         private SerializationConfig _serializationConfig = new SerializationConfig();
 
+        private string _instanceName;
+
         /// <summary>
         /// Helper method to add a new ListenerConfig.
         /// </summary>
@@ -332,6 +334,26 @@ namespace Hazelcast.Config
         public ClientConfig SetSecurityConfig(ClientSecurityConfig securityConfig) {
             _securityConfig = securityConfig;
             return this;
+        }
+
+        /// <summary>
+        /// Sets the instance name.
+        /// </summary>
+        /// <param name="instanceName"></param>
+        /// <returns><see cref="ClientConfig"/> for chaining</returns>
+        public ClientConfig SetInstanceName(string instanceName)
+        {
+            _instanceName = instanceName;
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the instance name.
+        /// </summary>
+        /// <returns>The instance name.</returns>
+        public string GetInstanceName()
+        {
+            return _instanceName;
         }
 
         internal virtual ILoadBalancer GetLoadBalancer()

--- a/Hazelcast.Net/Hazelcast.Config/XmlClientConfigBuilder.cs
+++ b/Hazelcast.Net/Hazelcast.Config/XmlClientConfigBuilder.cs
@@ -182,6 +182,9 @@ namespace Hazelcast.Config
                     case "near-cache":
                         HandleNearCache(node);
                         break;
+                    case "instance-name":
+                        HandleInstanceName(node);
+                        break;
                 }
             }
         }
@@ -427,5 +430,9 @@ namespace Hazelcast.Config
             }
         }
 
+        void HandleInstanceName(XmlNode node)
+        {
+            _clientConfig.SetInstanceName(node.InnerText);
+        }
     }
 }

--- a/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientXmlConfigTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientXmlConfigTest.cs
@@ -93,9 +93,9 @@ namespace Hazelcast.Client.Test.Config
             Assert.That(socketOptions.IsReuseAddress(), Is.True);
         }
 
-        
+
         [Test]
-        public void TestCloudConfig() 
+        public void TestCloudConfig()
         {
             var cloudConfig = _clientConfig.GetNetworkConfig().GetCloudConfig();
             Assert.That(cloudConfig, Is.Not.Null);
@@ -124,7 +124,7 @@ namespace Hazelcast.Client.Test.Config
             var credentialsClassName = _clientConfig.GetSecurityConfig().GetCredentialsClassName();
             var factoryClassName = _clientConfig.GetSecurityConfig().GetCredentialsFactoryConfig().GetClassName();
             var properties = _clientConfig.GetSecurityConfig().GetCredentialsFactoryConfig().GetProperties();
-            
+
             Assert.That(credentialsClassName, Is.EqualTo("Hazelcast.Security.UsernamePasswordCredentials"));
             Assert.That(factoryClassName, Is.EqualTo("Hazelcast.Security.DefaultCredentialsFactory"));
 
@@ -162,6 +162,12 @@ namespace Hazelcast.Client.Test.Config
             Assert.AreEqual(true, serializationConfig.IsEnableCompression());
             Assert.AreEqual(true, serializationConfig.IsEnableSharedObject());
             Assert.AreEqual(true, serializationConfig.IsUseNativeByteOrder());
+        }
+
+        [Test]
+        public void TestInstanceName()
+        {
+            Assert.AreEqual("My instance", _clientConfig.GetInstanceName());
         }
     }
 }

--- a/Hazelcast.Test/Resources/hazelcast-client-full.xml
+++ b/Hazelcast.Test/Resources/hazelcast-client-full.xml
@@ -106,5 +106,6 @@
 
   <license-key>ENTERPRISE_KEY</license-key>
 
+  <instance-name>My instance</instance-name>
 
 </hazelcast-client>

--- a/Hazelcast.Test/Resources/hazelcast.xml
+++ b/Hazelcast.Test/Resources/hazelcast.xml
@@ -62,4 +62,5 @@
     <time-to-live-seconds>180</time-to-live-seconds>
   </ringbuffer>
 
+  <instance-name>My instance name</instance-name>
 </hazelcast>

--- a/Hazelcast.Test/Resources/hazelcast.xml
+++ b/Hazelcast.Test/Resources/hazelcast.xml
@@ -61,6 +61,4 @@
     <capacity>10</capacity>
     <time-to-live-seconds>180</time-to-live-seconds>
   </ringbuffer>
-
-  <instance-name>My instance name</instance-name>
 </hazelcast>


### PR DESCRIPTION
Addresses: https://github.com/hazelcast/hazelcast-csharp-client/issues/175
Based on: https://github.com/hazelcast/hazelcast/pull/5605

### Remarks

This is a change to the public API and requires a new minor, if accepted.

Currently, this PR does not throw when a new client of the same name is registered. The original PR did it
in 

https://github.com/Fabryprog/hazelcast/blob/bcee2eba5d5f0d12e67b5a5446d7da52b62cc52d/hazelcast-client-new/src/main/java/com/hazelcast/client/HazelcastClient.java#L86-L88

but I left the .NET client with the original

https://github.com/hazelcast/hazelcast-csharp-client/blob/a3102617b8ce68e444ba9c44dc689fb5d3bb188c/Hazelcast.Net/Hazelcast.Client/HazelcastClient.cs#L364