### PR TITLE
Moving to net45

### DIFF
--- a/Hazelcast.Examples/Hazelcast.Examples.csproj
+++ b/Hazelcast.Examples/Hazelcast.Examples.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\shared.project.props" />
   <PropertyGroup Label="build">
-    <TargetFrameworks>net40;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Hazelcast.Examples</AssemblyName>
     <RootNamespace>Hazelcast.Examples</RootNamespace>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <OutputType>Exe</OutputType>
-    <LangVersion>4</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hazelcast.Net\Hazelcast.Net.csproj" />

--- a/Hazelcast.Net/Hazelcast.Config/SSLConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/SSLConfig.cs
@@ -136,14 +136,15 @@ namespace Hazelcast.Config
             var sslProtocol = GetProperty(SslProtocol);
             if (sslProtocol == null)
             {
-#if NET40
+#if !NETSTANDARD
+
                 return SslProtocols.Tls;
 #else
                 return SslProtocols.None;
 #endif
             }
-            SslProtocols result;
-            if (Enum.TryParse(sslProtocol, true, out result))
+
+            if (Enum.TryParse(sslProtocol, true, out SslProtocols result))
             {
                 return result;
             }

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/BufferPool.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/BufferPool.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.IO.Serialization
         /// <summary>
         /// Thread local has a finalizer and is properly disposable. Once the thread local is disposed, it removes itself from the buckets of the ThreadStatic field.
         /// </summary>
-        readonly ThreadLocal<BufferPool> _threadLocal;
+        private readonly ThreadLocal<BufferPool> _threadLocal;
 
         public BufferPoolThreadLocal(ISerializationService serializationService)
         {

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/BufferPool.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/BufferPool.cs
@@ -29,7 +29,6 @@ namespace Hazelcast.IO.Serialization
         public BufferPoolThreadLocal(ISerializationService serializationService)
         {
             _threadLocal = new ThreadLocal<BufferPool>(() => new BufferPool(serializationService), false);
-            GC.SuppressFinalize(_threadLocal);
         }
 
         public BufferPool Get()
@@ -46,7 +45,7 @@ namespace Hazelcast.IO.Serialization
 
         public void Dispose()
         {
-            // _threadLocal.Dispose();
+            _threadLocal.Dispose();
         }
     }
 

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/BufferPool.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/BufferPool.cs
@@ -29,6 +29,7 @@ namespace Hazelcast.IO.Serialization
         public BufferPoolThreadLocal(ISerializationService serializationService)
         {
             _threadLocal = new ThreadLocal<BufferPool>(() => new BufferPool(serializationService), false);
+            GC.SuppressFinalize(_threadLocal);
         }
 
         public BufferPool Get()
@@ -45,7 +46,7 @@ namespace Hazelcast.IO.Serialization
 
         public void Dispose()
         {
-            _threadLocal.Dispose();
+            // _threadLocal.Dispose();
         }
     }
 

--- a/Hazelcast.Net/Hazelcast.Net.csproj
+++ b/Hazelcast.Net/Hazelcast.Net.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\shared.project.props" />
   <PropertyGroup Label="build">
-    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <TargetFramework />
     <AssemblyName>Hazelcast.Net</AssemblyName>
     <title>Hazelcast .Net Client</title>
     <Description>Open source .NET client for Hazelcast, the open source in memory distributed computing platform.</Description>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <LangVersion>4</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>
     </RootNamespace>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Hazelcast.Net.xml</DocumentationFile>

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/BufferPoolTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/BufferPoolTest.cs
@@ -89,7 +89,7 @@ namespace Hazelcast.Client.Test.Serialization
 
             while (poolRef.IsAlive)
             {
-                GC.Collect();
+                GC.Collect(2, GCCollectionMode.Forced, true);
             }
 
             Assert.False(poolRef.IsAlive, "The reference should be already collected");
@@ -104,7 +104,7 @@ namespace Hazelcast.Client.Test.Serialization
 
             while (poolRef.IsAlive)
             {
-                GC.Collect();
+                GC.Collect(2, GCCollectionMode.Forced, true);
                 GC.WaitForPendingFinalizers();
             }
 

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientHeartBeatDetailTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientHeartBeatDetailTest.cs
@@ -102,7 +102,9 @@ namespace Hazelcast.Client.Test
             }
             Assert.False(clientDisconnected.Wait(1000), "Client should not be disconnected");
         }
-        
+
+        // TODO: bring it back for regular framework
+#if NETCOREAPP2
         [Test]
         public void TestContinuousGC()
         {
@@ -124,6 +126,6 @@ namespace Hazelcast.Client.Test
             }
             Assert.False(clientDisconnected.Wait(10000), "Client should not be disconnected");
         }
-
+#endif
     }
 }

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientShutdownTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientShutdownTest.cs
@@ -44,7 +44,7 @@ namespace Hazelcast.Client.Test
             StopCluster(_remoteController, _cluster);
             StopRemoteController(_remoteController);
         }
-        
+
         protected override void ConfigureGroup(ClientConfig config)
         {
             config.GetGroupConfig().SetName(_cluster.Id).SetPassword(_cluster.Id);
@@ -89,7 +89,7 @@ namespace Hazelcast.Client.Test
         [Test]
         public void TestOperationAfterShutdown()
         {
-            Assert.Throws<HazelcastException>(() =>
+            Assert.Throws(Is.AssignableTo<Exception>(), () =>
             {
                 var member = _remoteController.startMember(_cluster.Id);
                 var client = CreateClient();

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientShutdownTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientShutdownTest.cs
@@ -89,7 +89,7 @@ namespace Hazelcast.Client.Test
         [Test]
         public void TestOperationAfterShutdown()
         {
-            Assert.Throws(Is.AssignableTo<Exception>(), () =>
+            Assert.Throws<HazelcastInstanceNotActiveException>(() =>
             {
                 var member = _remoteController.startMember(_cluster.Id);
                 var client = CreateClient();

--- a/Hazelcast.Test/Hazelcast.Client.Test/TestSupport.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/TestSupport.cs
@@ -25,7 +25,7 @@ namespace Hazelcast.Client.Test
 {
     internal static class TestSupport
     {
-        private const int TimeoutSeconds = 30;
+        public const int TimeoutSeconds = 30;
         private static readonly Random Random = new Random();
 
         public static void AssertCompletedEventually<T>(Task<T> task, int timeoutSeconds = TimeoutSeconds, string taskName = "")

--- a/Hazelcast.Test/Hazelcast.Test.csproj
+++ b/Hazelcast.Test/Hazelcast.Test.csproj
@@ -4,10 +4,10 @@
     <AssemblyName>Hazelcast.Test</AssemblyName>
     <title>Hazelcast .Net Client Test</title>
     <Description>Hazelcast .Net Client Unit Tests Project</Description>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <LangVersion>4</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <PropertyGroup Label="sign">

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ and configuration of the client, setting up a cluster, and provides a simple app
 ## 1.1. Requirements
 
 - Windows, Linux or MacOS
-- .NET Framework 4.0 or newer, .NET core 2.0 or newer
+- .NET Framework 4.5 or newer, .NET core 2.0 or newer
 - Java 6 or newer
 - Hazelcast IMDG 3.6 or newer
 - Latest Hazelcast .NET client

--- a/build.ps1
+++ b/build.ps1
@@ -45,7 +45,7 @@ if ($netcore) {
 }
 else
 {
-    $targetFramework="net46"
+    $targetFramework="net45"
 }
 
 msbuild Hazelcast.Test\Hazelcast.Test.csproj /p:Configuration=Release /p:TargetFramework=$targetFramework /target:"Restore;Build"

--- a/build.ps1
+++ b/build.ps1
@@ -35,6 +35,9 @@ Write-Host "Exclude param: $testCategory"
 Write-Host "Net core: $netcore"
 Write-Host "Starting build..."
 
+# remove all the bins and objs recursively
+Get-ChildItem .\ -include bin,obj -Recurse | foreach ($_) { remove-item $_.fullname -Force -Recurse }
+
 nuget restore
 
 if ($netcore) {


### PR DESCRIPTION
This PR moves the solution to `net45` to enable newer features of the runtime, packages and the C# language. Additionally:

- it makes `BufferPool` tests independent from the `GC.Collect` by spinning a test in a loop and checking with `GC.GetTotalMemory(true)` is the memory size breached
- it changes the implementation of the `BufferPoolThreadLocal` simpler, by switching to `ThreadLocal` only as in .NET `ThreadLocal` will not leak no matter if they are disposed or finalized (they have a proper `Dispose(bool)` implementation.
- it changes the behavior of the disposed `BufferPool`. Previously, it was possible to still obtain a buffer when the pool is disposed and the `WeakReference`'s target is not released yet. Currently, it will always throw an exception. This changes the type of exception being thrown when the client is shut down and an action requires a serialization service to be used. To preserver the exception that was being thrown before, the `SerializationService` checks whether it's active. 