### PR TITLE
ClientExecutionService simplified with async-await

### DIFF
--- a/Hazelcast.Net/Hazelcast.Client.Connection/ClientConnectionManager.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Connection/ClientConnectionManager.cs
@@ -101,9 +101,8 @@ namespace Hazelcast.Client.Connection
             //start Heartbeat
             _heartbeatToken = new CancellationTokenSource();
             _client.GetClientExecutionService().ScheduleWithFixedDelay(Heartbeat,
-                (long) _heartbeatInterval.TotalMilliseconds,
-                (long) _heartbeatInterval.TotalMilliseconds,
-                TimeUnit.Milliseconds,
+                _heartbeatInterval, 
+                _heartbeatInterval,
                 _heartbeatToken.Token);
         }
 

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ClientExecutionService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ClientExecutionService.cs
@@ -41,71 +41,34 @@ using Hazelcast.Util;
             return _taskFactory.StartNew(function);
         }
 
-        public void ScheduleWithFixedDelay(Action command, long initialDelay, long period, TimeUnit unit, CancellationToken token)
+        public void ScheduleWithFixedDelay(Action command, TimeSpan initialDelay, TimeSpan period, CancellationToken ct)
         {
             if (!_live.Get())
             {
                 throw new HazelcastException("Client is shut down.");
             }
-            ScheduleWithCancellation(command, initialDelay, unit, token).ContinueWith(task =>
-            {
-                if (!task.IsCanceled)
-                {
-                    ScheduleWithFixedDelay(command, period, period, unit, token);
-                }
-            }, token).IgnoreExceptions();
-        }
 
-        public Task ScheduleWithCancellation(Action command, long delay, TimeUnit unit, CancellationToken token)
-        {
-            if (!_live.Get())
+            Task.Run(async () =>
             {
-                throw new HazelcastException("Client is shut down.");
-            }
-            var tcs = new TaskCompletionSource<object>();
-            var timer = new Timer(o =>
-            {
-                var _tcs = (TaskCompletionSource<object>) o;
-                if (token.IsCancellationRequested)
-                {
-                    _tcs.SetCanceled();
-                }
-                else
-                {
-                    _tcs.SetResult(null);
-                }
-            }, tcs, unit.ToMillis(delay), Timeout.Infinite);
-
-            var continueTask = tcs.Task.ContinueWith(t =>
-            {
-                timer.Dispose();
-                if (!t.IsCanceled)
+                await Task.Delay(initialDelay, ct);
+                while (ct.IsCancellationRequested == false)
                 {
                     command();
+                    await Task.Delay(period, ct);
                 }
-            }, token);
-            return continueTask;
+            }, ct).IgnoreExceptions();
+
         }
 
-        public Task Schedule(Action command, long delay, TimeUnit unit)
+        public async Task Schedule(Action command, TimeSpan delay, CancellationToken token)
         {
             if (!_live.Get())
             {
                 throw new HazelcastException("Client is shut down.");
             }
-            var tcs = new TaskCompletionSource<object>();
-            var timer = new Timer(o =>
-            {
-                var _tcs = (TaskCompletionSource<object>) o;
-                _tcs.SetResult(null);
-            }, tcs, unit.ToMillis(delay), Timeout.Infinite);
 
-            var continueTask = tcs.Task.ContinueWith(t =>
-            {
-                timer.Dispose();
-                command();
-            });
-            return continueTask;
+            await Task.Delay(delay, token);
+            command();
         }
 
         public void Shutdown()

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ClientPartitionService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ClientPartitionService.cs
@@ -31,7 +31,7 @@ using Hazelcast.Util;
         ClientPartitionService : IClientPartitionService, IConnectionListener
     {
         private const int PartitionTimeout = 60000;
-        private const int PartitionRefreshPeriod = 10000;
+        private static readonly TimeSpan PartitionRefreshPeriod = TimeSpan.FromSeconds(10);
 
         private static readonly ILogger Logger = Logging.Logger.GetLogger(typeof (IClientPartitionService));
         private readonly HazelcastClient _client;
@@ -99,7 +99,7 @@ using Hazelcast.Util;
             _client.GetConnectionManager().AddConnectionListener(this);
             _partitionUpdaterToken = new CancellationTokenSource();
             _client.GetClientExecutionService().ScheduleWithFixedDelay(() => GetPartitions(),
-                0, PartitionRefreshPeriod, TimeUnit.Milliseconds, _partitionUpdaterToken.Token);
+                TimeSpan.Zero, PartitionRefreshPeriod, _partitionUpdaterToken.Token);
         }
 
         public void Stop()

--- a/Hazelcast.Net/Hazelcast.Client/Statistics.cs
+++ b/Hazelcast.Net/Hazelcast.Client/Statistics.cs
@@ -45,7 +45,7 @@ namespace Hazelcast.Client
 
         private readonly HazelcastClient _client;
         private readonly bool _enabled;
-        private readonly int _period;
+        private readonly TimeSpan _period;
         private CancellationTokenSource _heartbeatToken;
 
         private readonly AtomicBoolean _live = new AtomicBoolean(false);
@@ -58,7 +58,7 @@ namespace Hazelcast.Client
         {
             _client = client;
             _enabled = EnvironmentUtil.ReadBool("hazelcast.client.statistics.enabled") ?? false;
-            _period = EnvironmentUtil.ReadInt("hazelcast.client.statistics.period.seconds") ?? 3;
+            _period = TimeSpan.FromSeconds(EnvironmentUtil.ReadInt("hazelcast.client.statistics.period.seconds") ?? 3);
         }
 
         public void Start()
@@ -72,10 +72,9 @@ namespace Hazelcast.Client
 
             _heartbeatToken = new CancellationTokenSource();
 
-            _client.GetClientExecutionService().ScheduleWithFixedDelay(PeriodicStatisticsSendTask, _period, _period,
-                TimeUnit.Seconds, _heartbeatToken.Token);
+            _client.GetClientExecutionService().ScheduleWithFixedDelay(PeriodicStatisticsSendTask, _period, _period, _heartbeatToken.Token);
 
-            Logger.Info(string.Format("Client statistics is enabled with period {0} seconds.", _period));
+            Logger.Info($"Client statistics is enabled with period {_period} seconds.");
         }
 
         public void Destroy()
@@ -107,10 +106,8 @@ namespace Hazelcast.Client
             {
                 if (Logger.IsFinestEnabled())
                 {
-                    Logger.Finest(string.Format(
-                        "Client statistics can not be sent to server {0} since, " +
-                        "connected owner server version is less than the minimum supported server version {1}",
-                        ownerAddress, SinceVersionString));
+                    Logger.Finest($"Client statistics can not be sent to server {ownerAddress} since, " +
+                                  $"connected owner server version is less than the minimum supported server version {SinceVersionString}");
                 }
             }
 

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientClusterServiceTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientClusterServiceTest.cs
@@ -21,12 +21,11 @@ using NUnit.Framework;
 
 namespace Hazelcast.Client.Test
 {
-    internal class ClientClusterServiceTest : HazelcastTestSupport
+    public class ClientClusterServiceTest : HazelcastTestSupport
     {
         private IHazelcastInstance _client;
         private Cluster _cluster;
         private RemoteController.Client _remoteController;
-
         private InitialMembershipListener _initialMembershipListener;
 
         [SetUp]
@@ -118,33 +117,33 @@ namespace Hazelcast.Client.Test
             var listener = new InitialMembershipListener();
             _client.GetCluster().AddMembershipListener(listener);
 
-            var members = listener._membershipEvent.GetMembers();
+            var members = listener.MembershipEvent.GetMembers();
             Assert.AreEqual(1, members.Count);
 
             var member = members.FirstOrDefault();
             Assert.IsNotNull(member);
-            Assert.IsNotNull(listener._membershipEvent.GetCluster());
-            Assert.IsNotNull(listener._membershipEvent.ToString());
-            Assert.AreEqual(1, _initialMembershipListener.counter);
+            Assert.IsNotNull(listener.MembershipEvent.GetCluster());
+            Assert.IsNotNull(listener.MembershipEvent.ToString());
+            Assert.AreEqual(1, _initialMembershipListener.Counter);
         }
         
         [Test]
         public void TestInitialMembershipWithConfig()
         {
-            var members = _initialMembershipListener._membershipEvent.GetMembers();
+            var members = _initialMembershipListener.MembershipEvent.GetMembers();
             Assert.AreEqual(1, members.Count);
 
             var member = members.FirstOrDefault();
             Assert.IsNotNull(member);
-            Assert.IsNotNull(_initialMembershipListener._membershipEvent.GetCluster());
-            Assert.IsNotNull(_initialMembershipListener._membershipEvent.ToString());
-            Assert.AreEqual(1, _initialMembershipListener.counter);
+            Assert.IsNotNull(_initialMembershipListener.MembershipEvent.GetCluster());
+            Assert.IsNotNull(_initialMembershipListener.MembershipEvent.ToString());
+            Assert.AreEqual(1, _initialMembershipListener.Counter);
         }
 
         private class InitialMembershipListener : IInitialMembershipListener
         {
-            public InitialMembershipEvent _membershipEvent;
-            public long counter = 0;
+            public InitialMembershipEvent MembershipEvent;
+            public long Counter;
 
             public void MemberAdded(MembershipEvent membershipEvent)
             {
@@ -160,8 +159,8 @@ namespace Hazelcast.Client.Test
 
             public void Init(InitialMembershipEvent membershipEvent)
             {
-                _membershipEvent = membershipEvent;
-                Interlocked.Increment(ref counter);
+                MembershipEvent = membershipEvent;
+                Interlocked.Increment(ref Counter);
             }
         }
     }

--- a/Hazelcast.Test/Hazelcast.Client.Test/TaskExtensions.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/TaskExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,22 +13,26 @@
 // limitations under the License.
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Hazelcast.Core;
+using NUnit.Framework;
 
-#pragma warning disable CS1591
- namespace Hazelcast.Client.Spi
+namespace Hazelcast.Client.Test
 {
-    /// <summary>
-    /// Executor service for Hazelcast clients.
-    /// </summary>
-    public interface IClientExecutionService
+    static class TaskExtensions
     {
-        Task Schedule(Action command, TimeSpan delay, CancellationToken token);
-        void ScheduleWithFixedDelay(Action command, TimeSpan initialDelay, TimeSpan period, CancellationToken ct);
-        void Shutdown();
-        Task Submit(Action action);
-        Task<T> Submit<T>(Func<T> function);
+        public static async Task ShouldThrow<T>(this Task task)
+            where T : Exception
+        {
+            try
+            {
+                await task;
+            }
+            catch (T )
+            {
+                return;
+            }
+
+            Assert.Fail($"The exception of type '{typeof(T)}' should have been thrown but wasn't.");
+        }
     }
 }


### PR DESCRIPTION
This PR changes the implementation of `ClientExecutionService` from using a `Timer` bases approach to a direct async-await usage.