### PR TITLE
Fix build packages and NUnit version for Jenkins

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit.ConsoleRunner" version="3.10.0" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" />
-  <package id="JetBrains.dotCover.CommandLineTools" version="2019.3.4" />
-</packages>

--- a/Hazelcast.Examples/Hazelcast.Examples.csproj
+++ b/Hazelcast.Examples/Hazelcast.Examples.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Hazelcast.Examples</RootNamespace>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <OutputType>Exe</OutputType>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hazelcast.Net\Hazelcast.Net.csproj" />

--- a/Hazelcast.Net.sln
+++ b/Hazelcast.Net.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build-docs.bat = build-docs.bat
 		build-nuget.bat = build-nuget.bat
 		build.bat = build.bat
+		build.proj = build.proj
 		build.ps1 = build.ps1
 		build.sh = build.sh
 		README.md = README.md

--- a/Hazelcast.Net/Hazelcast.Net.csproj
+++ b/Hazelcast.Net/Hazelcast.Net.csproj
@@ -12,6 +12,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Hazelcast.Net.xml</DocumentationFile>
     <NoWarn>1701;1702;1591;1570</NoWarn>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   <PropertyGroup Label="sign">
     <!--Condition=" '$(OS)' != 'Windows_NT' "-->

--- a/Hazelcast.Test/Hazelcast.Test.csproj
+++ b/Hazelcast.Test/Hazelcast.Test.csproj
@@ -9,16 +9,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace />
     <IsTestProject>true</IsTestProject>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   <PropertyGroup Label="sign">
     <SignAssembly>true</SignAssembly>
     <PublicSign>true</PublicSign>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ApacheThrift" Version="0.13.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/Hazelcast.Test/Overrides.cs
+++ b/Hazelcast.Test/Overrides.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@ using Hazelcast.Util;
 
 namespace Hazelcast.Test
 {
+    //
     class Overrides
     {
         public static class Dns

--- a/build.proj
+++ b/build.proj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="shared.project.props" />
+  <PropertyGroup>
+    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <Configurations>Debug;Release</Configurations>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2019.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
~Creates a `Release-Build` configuration used by `build.ps1` - is identical to `Release` but the test project has extra dependencies for this configuration, eg the NUnit console runner, used by `build.ps1`.~

Removes the dependencies to `JetBrains.dotCover.CommandLineTools` and `NUnit.ConsoleRunner` from the test project and also removes the `.nuget/package.config` - instead, introduces a `build.proj` project file used by the `build.ps1` to explicitely restore these dependency packages when building. Cleaner and more explicit.

The `build.proj` project is *not* listed in the `.sln` file and therefore these packages are not restored by default.

Additionally, remove the NUnit 2.x output format, as Jenkins can now deal with NUnit 3.x - this needs to be configured for each Jenkins build. Currently, it's configured on the `csharp-client-pr-builder` build where it's been tested successfully.