### PR TITLE
Bump Copyright year to 2020

### DIFF
--- a/Hazelcast.Examples/App.cs
+++ b/Hazelcast.Examples/App.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Client/ClientStatisticsExample.cs
+++ b/Hazelcast.Examples/Client/ClientStatisticsExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Client/LifecycleExample.cs
+++ b/Hazelcast.Examples/Client/LifecycleExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Client/MemberListenerExample.cs
+++ b/Hazelcast.Examples/Client/MemberListenerExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Cloud/HazelcastCloudExample.cs
+++ b/Hazelcast.Examples/Cloud/HazelcastCloudExample.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Cloud/HazelcastCloudWithSslExample.cs
+++ b/Hazelcast.Examples/Cloud/HazelcastCloudWithSslExample.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Collections/CollectionListenerExample.cs
+++ b/Hazelcast.Examples/Collections/CollectionListenerExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Collections/ListExample.cs
+++ b/Hazelcast.Examples/Collections/ListExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Collections/QueueExample.cs
+++ b/Hazelcast.Examples/Collections/QueueExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Collections/RingbufferExample.cs
+++ b/Hazelcast.Examples/Collections/RingbufferExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Collections/SetExample.cs
+++ b/Hazelcast.Examples/Collections/SetExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapAsyncExample.cs
+++ b/Hazelcast.Examples/Map/MapAsyncExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapCustomSerializerExample.cs
+++ b/Hazelcast.Examples/Map/MapCustomSerializerExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapEntryProcessorExample.cs
+++ b/Hazelcast.Examples/Map/MapEntryProcessorExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapIdentifiedDataSerializableExample.cs
+++ b/Hazelcast.Examples/Map/MapIdentifiedDataSerializableExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapJsonExample.cs
+++ b/Hazelcast.Examples/Map/MapJsonExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapListenerExample.cs
+++ b/Hazelcast.Examples/Map/MapListenerExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapLockExample.cs
+++ b/Hazelcast.Examples/Map/MapLockExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapNearCacheExample.cs
+++ b/Hazelcast.Examples/Map/MapNearCacheExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapPartitionPredicateExample.cs
+++ b/Hazelcast.Examples/Map/MapPartitionPredicateExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapPortableExample.cs
+++ b/Hazelcast.Examples/Map/MapPortableExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MapSimpleExample.cs
+++ b/Hazelcast.Examples/Map/MapSimpleExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/MultiMapExample.cs
+++ b/Hazelcast.Examples/Map/MultiMapExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Map/ReplicatedMapExample.cs
+++ b/Hazelcast.Examples/Map/ReplicatedMapExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Models/Customer.cs
+++ b/Hazelcast.Examples/Models/Customer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Models/Employee.cs
+++ b/Hazelcast.Examples/Models/Employee.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Models/EntryProcessor.cs
+++ b/Hazelcast.Examples/Models/EntryProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Models/ExamplePortableFactory.cs
+++ b/Hazelcast.Examples/Models/ExamplePortableFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/CustomSerializerSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/CustomSerializerSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/EntryProcessorSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/EntryProcessorSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/GlobalSerializerSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/GlobalSerializerSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/IdentifiedDataSerializableSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/IdentifiedDataSerializableSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/ListSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/ListSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/MapSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/MapSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/MultiMapSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/MultiMapSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/PortableSerializableSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/PortableSerializableSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/QuerySample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/QuerySample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/QueueSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/QueueSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/ReplicatedMapSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/ReplicatedMapSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/RingBufferSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/RingBufferSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/SetSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/SetSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Org.Website.Samples/TopicSample.cs
+++ b/Hazelcast.Examples/Org.Website.Samples/TopicSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Ssl/ClientSslExample.cs
+++ b/Hazelcast.Examples/Ssl/ClientSslExample.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Ssl/ClientSslMutualAuthExample.cs
+++ b/Hazelcast.Examples/Ssl/ClientSslMutualAuthExample.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Topic/TopicExample.cs
+++ b/Hazelcast.Examples/Topic/TopicExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Transactions/SimpleTransactionExample.cs
+++ b/Hazelcast.Examples/Transactions/SimpleTransactionExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Transactions/TransactionBenchmark.cs
+++ b/Hazelcast.Examples/Transactions/TransactionBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Examples/Transactions/TransactionRollbackExample.cs
+++ b/Hazelcast.Examples/Transactions/TransactionRollbackExample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.CP/RaftGroupId.cs
+++ b/Hazelcast.Net/Hazelcast.CP/RaftGroupId.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Network/AddressProvider.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Network/AddressProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Network/Connection.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Network/Connection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Network/ConnectionManager.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Network/ConnectionManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Network/HeartbeatManager.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Network/HeartbeatManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Network/IConnectionListener.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Network/IConnectionListener.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Network/ISocketFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Network/ISocketFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Network/WaitStrategy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Network/WaitStrategy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ByteArrayCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ByteArrayCodec.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/CodecUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/CodecUtil.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/CustomTypeFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/CustomTypeFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/DataCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/DataCodec.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListIntegerGuidCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListIntegerGuidCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListIntegerIntegerCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListIntegerIntegerCodec.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListIntegerLongCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListIntegerLongCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListLongByteArrayCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListLongByteArrayCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListUUIDListIntegerCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListUUIDListIntegerCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListUUIDLongCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/EntryListUUIDLongCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ErrorsCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ErrorsCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/FixedSizeTypesCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/FixedSizeTypesCodec.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ListIntCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ListIntCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ListLongCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ListLongCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ListMultiFrameCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ListMultiFrameCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ListUUIDCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/ListUUIDCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/LongArrayCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/LongArrayCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/MapCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/MapCodec.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/StringCodec.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Codec.BuiltIn/StringCodec.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/BufferBuilder.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/BufferBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/ClientMessageDecoder.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/ClientMessageDecoder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/ClientMessageReader.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/ClientMessageReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/ClientMessageWriter.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/ClientMessageWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/IClientProtocolBuffer.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/IClientProtocolBuffer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/ParameterUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/ParameterUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol.Util/SafeBuffer.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol.Util/SafeBuffer.cs
@@ -1,11 +1,11 @@
-// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
-// 
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol/AnchorDataListHolder.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol/AnchorDataListHolder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol/AuthenticationStatus.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol/AuthenticationStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol/ClientMessage.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol/ClientMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol/ClientProtocolErrorCodes.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol/ClientProtocolErrorCodes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol/ErrorHolder.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol/ErrorHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol/EventMessageConst.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol/EventMessageConst.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol/PagingPredicateHolder.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol/PagingPredicateHolder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Protocol/ResponseMessageConst.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Protocol/ResponseMessageConst.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/AbstractClientCollectionProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/AbstractClientCollectionProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/AbstractClientTxnCollectionProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/AbstractClientTxnCollectionProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientListProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientListProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMapNearCacheProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMapNearCacheProxy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMapProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMapProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMultiMapProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientMultiMapProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientPNCounterProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientPNCounterProxy.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientQueueProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientQueueProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientReplicatedMapProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientReplicatedMapProxy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientRingbufferProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientRingbufferProxy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientSemaphoreProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientSemaphoreProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientSetProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientSetProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTopicProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTopicProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnListProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnListProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnMapProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnMapProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnMultiMapProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnMultiMapProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnQueueProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnQueueProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnSetProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/ClientTxnSetProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/TransactionContextProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/TransactionContextProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Proxy/TransactionProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Proxy/TransactionProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ClientProxy.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ClientProxy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/Cluster.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/Cluster.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ClusterService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ClusterService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ClusterViewService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ClusterViewService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/EventRegistration.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/EventRegistration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/Exception.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/Exception.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ExecutionService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ExecutionService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/HazelcastCloudDiscovery.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/HazelcastCloudDiscovery.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/IFuture.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/IFuture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/Invocation.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/Invocation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/InvocationService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/InvocationService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ListenerRegistration.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ListenerRegistration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ListenerService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ListenerService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/Partition.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/Partition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/PartitionService.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/PartitionService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/ProxyManager.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/ProxyManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client.Spi/SettableFuture.cs
+++ b/Hazelcast.Net/Hazelcast.Client.Spi/SettableFuture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/AuthenticationException.cs
+++ b/Hazelcast.Net/Hazelcast.Client/AuthenticationException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/ClientLockReferenceIdGenerator.cs
+++ b/Hazelcast.Net/Hazelcast.Client/ClientLockReferenceIdGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/ClientPrincipal.cs
+++ b/Hazelcast.Net/Hazelcast.Client/ClientPrincipal.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/DistributedObjectInfo.cs
+++ b/Hazelcast.Net/Hazelcast.Client/DistributedObjectInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/HazelcastClient.cs
+++ b/Hazelcast.Net/Hazelcast.Client/HazelcastClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/HazelcastClientInternal.cs
+++ b/Hazelcast.Net/Hazelcast.Client/HazelcastClientInternal.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/HazelcastInstance.cs
+++ b/Hazelcast.Net/Hazelcast.Client/HazelcastInstance.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/ILoadBalancer.cs
+++ b/Hazelcast.Net/Hazelcast.Client/ILoadBalancer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/LifecycleService.cs
+++ b/Hazelcast.Net/Hazelcast.Client/LifecycleService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/QueueIterator.cs
+++ b/Hazelcast.Net/Hazelcast.Client/QueueIterator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Client/Statistics.cs
+++ b/Hazelcast.Net/Hazelcast.Client/Statistics.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/AbstractXmlConfigHelper.cs
+++ b/Hazelcast.Net/Hazelcast.Config/AbstractXmlConfigHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/BitmapIndexOptions.cs
+++ b/Hazelcast.Net/Hazelcast.Config/BitmapIndexOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/ClientCloudConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/ClientCloudConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/ClientConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/ClientConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/ClientNetworkConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/ClientNetworkConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/ConnectionRetryConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/ConnectionRetryConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/ConnectionStrategyConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/ConnectionStrategyConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/GlobalSerializerConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/GlobalSerializerConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/IConfigPatternMatcher.cs
+++ b/Hazelcast.Net/Hazelcast.Config/IConfigPatternMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/InMemoryFormat.cs
+++ b/Hazelcast.Net/Hazelcast.Config/InMemoryFormat.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/IndexConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/IndexConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/IndexType.cs
+++ b/Hazelcast.Net/Hazelcast.Config/IndexType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/InvalidConfigurationException.cs
+++ b/Hazelcast.Net/Hazelcast.Config/InvalidConfigurationException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/ListenerConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/ListenerConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/MatchingPointConfigPatternMatcher.cs
+++ b/Hazelcast.Net/Hazelcast.Config/MatchingPointConfigPatternMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/NearCacheConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/NearCacheConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/NearCacheConfigReadOnly.cs
+++ b/Hazelcast.Net/Hazelcast.Config/NearCacheConfigReadOnly.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/SSLConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/SSLConfig.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/SerializationConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/SerializationConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/SerializerConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/SerializerConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/SocketInterceptorConfig.cs
+++ b/Hazelcast.Net/Hazelcast.Config/SocketInterceptorConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/SocketOptions.cs
+++ b/Hazelcast.Net/Hazelcast.Config/SocketOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Config/XmlClientConfigBuilder.cs
+++ b/Hazelcast.Net/Hazelcast.Config/XmlClientConfigBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/Aggregator.cs
+++ b/Hazelcast.Net/Hazelcast.Core/Aggregator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/Aggregators.cs
+++ b/Hazelcast.Net/Hazelcast.Core/Aggregators.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/DistributedObjectEvent.cs
+++ b/Hazelcast.Net/Hazelcast.Core/DistributedObjectEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/EntryAdapter.cs
+++ b/Hazelcast.Net/Hazelcast.Core/EntryAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/EntryEvent.cs
+++ b/Hazelcast.Net/Hazelcast.Core/EntryEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/EntryEventType.cs
+++ b/Hazelcast.Net/Hazelcast.Core/EntryEventType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/HazelcastException.cs
+++ b/Hazelcast.Net/Hazelcast.Core/HazelcastException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/HazelcastJsonValue.cs
+++ b/Hazelcast.Net/Hazelcast.Core/HazelcastJsonValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ICluster.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ICluster.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IDistributedObject.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IDistributedObject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IDistributedObjectListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IDistributedObjectListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IEntryListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IEntryListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IEntryView.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IEntryView.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IExecutionCallback.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IExecutionCallback.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IExecutorService.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IExecutorService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IHCollection.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IHCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IHList.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IHList.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IHSet.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IHSet.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IHazelcastInstance.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IHazelcastInstance.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IHazelcastInstanceAware.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IHazelcastInstanceAware.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IInitialMembershipListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IInitialMembershipListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IItemListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IItemListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ILifecycleListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ILifecycleListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ILifecycleService.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ILifecycleService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ILock.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ILock.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IMap.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IMap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IMember.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IMember.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IMembershipListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IMembershipListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IMessageListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IMessageListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IMultiExecutionCallback.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IMultiExecutionCallback.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IMultiMap.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IMultiMap.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IPNCounter.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IPNCounter.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IPartition.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IPartition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IPartitionAware.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IPartitionAware.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IPartitionService.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IPartitionService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IPartitioningStrategy.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IPartitioningStrategy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IPredicate.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IPredicate.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IQueue.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IQueue.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IReplicatedMap.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IReplicatedMap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/IRingbuffer.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IRingbuffer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ITopic.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ITopic.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/InitialMembershipEvent.cs
+++ b/Hazelcast.Net/Hazelcast.Core/InitialMembershipEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ItemEvent.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ItemEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ItemEventType.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ItemEventType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ItemListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ItemListener.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/LifecycleEvent.cs
+++ b/Hazelcast.Net/Hazelcast.Core/LifecycleEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/LifecycleListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/LifecycleListener.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/MapEvent.cs
+++ b/Hazelcast.Net/Hazelcast.Core/MapEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/Member.cs
+++ b/Hazelcast.Net/Hazelcast.Core/Member.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/MemberInfo.cs
+++ b/Hazelcast.Net/Hazelcast.Core/MemberInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/MemberVersion.cs
+++ b/Hazelcast.Net/Hazelcast.Core/MemberVersion.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/MembershipEvent.cs
+++ b/Hazelcast.Net/Hazelcast.Core/MembershipEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/MembershipListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/MembershipListener.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/Message.cs
+++ b/Hazelcast.Net/Hazelcast.Core/Message.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/OverflowPolicy.cs
+++ b/Hazelcast.Net/Hazelcast.Core/OverflowPolicy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/PagingPredicate.cs
+++ b/Hazelcast.Net/Hazelcast.Core/PagingPredicate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/PartitionPredicate.cs
+++ b/Hazelcast.Net/Hazelcast.Core/PartitionPredicate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/Predicate.cs
+++ b/Hazelcast.Net/Hazelcast.Core/Predicate.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/Projection.cs
+++ b/Hazelcast.Net/Hazelcast.Core/Projection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/ServiceNames.cs
+++ b/Hazelcast.Net/Hazelcast.Core/ServiceNames.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/TerminatedLifecycleService.cs
+++ b/Hazelcast.Net/Hazelcast.Core/TerminatedLifecycleService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/TimeUnit.cs
+++ b/Hazelcast.Net/Hazelcast.Core/TimeUnit.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Core/VectorClock.cs
+++ b/Hazelcast.Net/Hazelcast.Core/VectorClock.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/AggregatorDataSerializerHook.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/AggregatorDataSerializerHook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ArrayDataSerializableFactory.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ArrayDataSerializableFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/BufferPool.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/BufferPool.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ByteArrayInputOutputFactory.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ByteArrayInputOutputFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ByteArrayObjectDataInput.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ByteArrayObjectDataInput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ByteArrayObjectDataOutput.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ByteArrayObjectDataOutput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ByteArraySerializerAdapter.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ByteArraySerializerAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ClassDefinition.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ClassDefinition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ClassDefinitionBuilder.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ClassDefinitionBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ClassDefinitionWriter.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ClassDefinitionWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ConstantSerializers.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ConstantSerializers.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/DataSerializer.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/DataSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/DefaultPortableReader.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/DefaultPortableReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/DefaultPortableWriter.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/DefaultPortableWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/DefaultSerializers.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/DefaultSerializers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/EmptyObjectDataOutput.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/EmptyObjectDataOutput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/FieldDefinition.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/FieldDefinition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/FieldType.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/FieldType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/HazelcastSerializationException.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/HazelcastSerializationException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/HeapData.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/HeapData.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IByteArraySerializer.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IByteArraySerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IClassDefinition.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IClassDefinition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IData.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IData.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IDataSerializable.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IDataSerializable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IDataSerializableFactory.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IDataSerializableFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IDataSerializerHook.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IDataSerializerHook.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IFieldDefinition.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IFieldDefinition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IIdentifiedDataSerializable.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IIdentifiedDataSerializable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IInputOutputFactory.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IInputOutputFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IPortable.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IPortable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableContext.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableContextAware.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableContextAware.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableFactory.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableHook.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableHook.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableReader.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableWriter.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IPortableWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializationService.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializationService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializationServiceBuilder.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializationServiceBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializer.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializerAdapter.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializerAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializerHook.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ISerializerHook.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IStreamSerializer.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IStreamSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/IVersionedPortable.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/IVersionedPortable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/JavaClass.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/JavaClass.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/MorphingPortableReader.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/MorphingPortableReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/PortableContext.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/PortableContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/PortableSerializer.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/PortableSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/PortableVersionHelper.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/PortableVersionHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/PredicateDataSerializerHook.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/PredicateDataSerializerHook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/ProjectionDataSerializerHook.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/ProjectionDataSerializerHook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/SerializationConstants.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/SerializationConstants.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/SerializationService.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/SerializationService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/SerializationServiceBuilder.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/SerializationServiceBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO.Serialization/StreamSerializerAdapter.cs
+++ b/Hazelcast.Net/Hazelcast.IO.Serialization/StreamSerializerAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/Address.cs
+++ b/Hazelcast.Net/Hazelcast.IO/Address.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/Bits.cs
+++ b/Hazelcast.Net/Hazelcast.IO/Bits.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/IBufferObjectDataInput.cs
+++ b/Hazelcast.Net/Hazelcast.IO/IBufferObjectDataInput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/IBufferObjectDataOutput.cs
+++ b/Hazelcast.Net/Hazelcast.IO/IBufferObjectDataOutput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/IDataInput.cs
+++ b/Hazelcast.Net/Hazelcast.IO/IDataInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/IDataOutput.cs
+++ b/Hazelcast.Net/Hazelcast.IO/IDataOutput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/IMemberSocketInterceptor.cs
+++ b/Hazelcast.Net/Hazelcast.IO/IMemberSocketInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/IOUtil.cs
+++ b/Hazelcast.Net/Hazelcast.IO/IOUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/IObjectDataInput.cs
+++ b/Hazelcast.Net/Hazelcast.IO/IObjectDataInput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/IObjectDataOutput.cs
+++ b/Hazelcast.Net/Hazelcast.IO/IObjectDataOutput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.IO/ISocketInterceptor.cs
+++ b/Hazelcast.Net/Hazelcast.IO/ISocketInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Logging/AbstractLogger.cs
+++ b/Hazelcast.Net/Hazelcast.Logging/AbstractLogger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Logging/ConsoleLogFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Logging/ConsoleLogFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Logging/ILogger.cs
+++ b/Hazelcast.Net/Hazelcast.Logging/ILogger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Logging/LogLevel.cs
+++ b/Hazelcast.Net/Hazelcast.Logging/LogLevel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Logging/Logger.cs
+++ b/Hazelcast.Net/Hazelcast.Logging/Logger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Logging/LoggerFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Logging/LoggerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Logging/NoLogFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Logging/NoLogFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Logging/TraceLogFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Logging/TraceLogFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Map/EntryListenerAdapter.cs
+++ b/Hazelcast.Net/Hazelcast.Map/EntryListenerAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Map/IEntryProcessor.cs
+++ b/Hazelcast.Net/Hazelcast.Map/IEntryProcessor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Map/IMapInterceptor.cs
+++ b/Hazelcast.Net/Hazelcast.Map/IMapInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Map/QueryCacheEventData.cs
+++ b/Hazelcast.Net/Hazelcast.Map/QueryCacheEventData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Map/SimpleEntryView.cs
+++ b/Hazelcast.Net/Hazelcast.Map/SimpleEntryView.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.NearCache/BaseNearCache.cs
+++ b/Hazelcast.Net/Hazelcast.NearCache/BaseNearCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.NearCache/MetaDataContainer.cs
+++ b/Hazelcast.Net/Hazelcast.NearCache/MetaDataContainer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.NearCache/NearCache.cs
+++ b/Hazelcast.Net/Hazelcast.NearCache/NearCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.NearCache/NearCacheManager.cs
+++ b/Hazelcast.Net/Hazelcast.NearCache/NearCacheManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.NearCache/NearCacheRecord.cs
+++ b/Hazelcast.Net/Hazelcast.NearCache/NearCacheRecord.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.NearCache/NearCacheStatistics.cs
+++ b/Hazelcast.Net/Hazelcast.NearCache/NearCacheStatistics.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.NearCache/RepairingHandler.cs
+++ b/Hazelcast.Net/Hazelcast.NearCache/RepairingHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Net.Ext/AtomicBoolean.cs
+++ b/Hazelcast.Net/Hazelcast.Net.Ext/AtomicBoolean.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Net.Ext/AtomicInteger.cs
+++ b/Hazelcast.Net/Hazelcast.Net.Ext/AtomicInteger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Net.Ext/AtomicLong.cs
+++ b/Hazelcast.Net/Hazelcast.Net.Ext/AtomicLong.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Net.Ext/AtomicReference.cs
+++ b/Hazelcast.Net/Hazelcast.Net.Ext/AtomicReference.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Net.Ext/ByteBuffer.cs
+++ b/Hazelcast.Net/Hazelcast.Net.Ext/ByteBuffer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Net.Ext/ByteOrder.cs
+++ b/Hazelcast.Net/Hazelcast.Net.Ext/ByteOrder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Net.Ext/InputOutputStreams.cs
+++ b/Hazelcast.Net/Hazelcast.Net.Ext/InputOutputStreams.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Partition.Strategy/DefaultPartitioningStrategy.cs
+++ b/Hazelcast.Net/Hazelcast.Partition.Strategy/DefaultPartitioningStrategy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Partition.Strategy/StringPartitioningStrategy.cs
+++ b/Hazelcast.Net/Hazelcast.Partition.Strategy/StringPartitioningStrategy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Security/UsernamePasswordCredentialsFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Security/UsernamePasswordCredentialsFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/ITransactionContext.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/ITransactionContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/ITransactionalList.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/ITransactionalList.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/ITransactionalMap.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/ITransactionalMap.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/ITransactionalMultiMap.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/ITransactionalMultiMap.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/ITransactionalObject.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/ITransactionalObject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/ITransactionalQueue.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/ITransactionalQueue.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/ITransactionalSet.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/ITransactionalSet.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/ITransactionalTaskContext.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/ITransactionalTaskContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/TransactionException.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/TransactionException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/TransactionNotActiveException.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/TransactionNotActiveException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/TransactionOptions.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/TransactionOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/TransactionState.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/TransactionState.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Transaction/TransactionTimedOutException.cs
+++ b/Hazelcast.Net/Hazelcast.Transaction/TransactionTimedOutException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/AbstractLazyDictionary.cs
+++ b/Hazelcast.Net/Hazelcast.Util/AbstractLazyDictionary.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/AbstractLoadBalancer.cs
+++ b/Hazelcast.Net/Hazelcast.Util/AbstractLoadBalancer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/AddressUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/AddressUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/ClientExceptionFactory.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ClientExceptionFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/Clock.cs
+++ b/Hazelcast.Net/Hazelcast.Util/Clock.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/Delegates.cs
+++ b/Hazelcast.Net/Hazelcast.Util/Delegates.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/DnsUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/DnsUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/EnvironmentUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/EnvironmentUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/ExceptionUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ExceptionUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/HashUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/HashUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/IndexUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/IndexUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/IterationType.cs
+++ b/Hazelcast.Net/Hazelcast.Util/IterationType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/QuickMath.cs
+++ b/Hazelcast.Net/Hazelcast.Util/QuickMath.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/RandomLB.cs
+++ b/Hazelcast.Net/Hazelcast.Util/RandomLB.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/ReadOnlyLazyDictionary.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ReadOnlyLazyDictionary.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/ReadOnlyLazyEntrySet.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ReadOnlyLazyEntrySet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/ReadOnlyLazyList.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ReadOnlyLazyList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/ReadOnlyLazySet.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ReadOnlyLazySet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/RoundRobinLB.cs
+++ b/Hazelcast.Net/Hazelcast.Util/RoundRobinLB.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/SortingUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/SortingUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/StackTraceElement.cs
+++ b/Hazelcast.Net/Hazelcast.Util/StackTraceElement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/StaticLB.cs
+++ b/Hazelcast.Net/Hazelcast.Util/StaticLB.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/StripedTaskScheduler.cs
+++ b/Hazelcast.Net/Hazelcast.Util/StripedTaskScheduler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/TaskExtension.cs
+++ b/Hazelcast.Net/Hazelcast.Util/TaskExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/ThreadUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ThreadUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/ValidationUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/ValidationUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Hazelcast.Util/VersionUtil.cs
+++ b/Hazelcast.Net/Hazelcast.Util/VersionUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Properties/AssemblyInfo.cs
+++ b/Hazelcast.Net/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Net/Resources/hazelcast-client-default.xml
+++ b/Hazelcast.Net/Resources/hazelcast-client-default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/ClientQueuePerformanceTest.cs
+++ b/Hazelcast.Test/ClientQueuePerformanceTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Model/CustomComparator.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Model/CustomComparator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Model/IdentifiedEntryProcessor.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Model/IdentifiedEntryProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Model/IdentifiedFactory.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Model/IdentifiedFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Model/Item.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Model/Item.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Protocol.Codec/FixedSizeTypesCodecTests.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Protocol.Codec/FixedSizeTypesCodecTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientListenerConfigTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientListenerConfigTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientNearCacheConfigTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientNearCacheConfigTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientXmlConfigTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientXmlConfigTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientXmlTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Config/ClientXmlTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Config/MatchingPointConfigPatternMatcherTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Config/MatchingPointConfigPatternMatcherTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/BufferPoolTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/BufferPoolTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ByteArrayDataSerializable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ByteArrayDataSerializable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ByteArrayObjectDataInputTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ByteArrayObjectDataInputTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ByteArrayObjectDataOutputTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ByteArrayObjectDataOutputTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ClassAndFieldDefinitionTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ClassAndFieldDefinitionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ClientCustomSerializationTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ClientCustomSerializationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ComplexDataSerializable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ComplexDataSerializable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ConstantSerializerTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ConstantSerializerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/DataDataSerializable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/DataDataSerializable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/DataInputOutputTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/DataInputOutputTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/DataSerializableType.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/DataSerializableType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/InnerPortable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/InnerPortable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/InvalidRawDataPortable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/InvalidRawDataPortable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/InvalidRawDataPortable2.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/InvalidRawDataPortable2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/JsonValueSerializationTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/JsonValueSerializationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/KitchenSinkDataSerializable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/KitchenSinkDataSerializable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/KitchenSinkPortable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/KitchenSinkPortable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/MainPortable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/MainPortable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/MorphingPortable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/MorphingPortable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/MorphingPortableReaderTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/MorphingPortableReaderTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/NamedPortable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/NamedPortable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/NamedPortableV2.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/NamedPortableV2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ObjectCarryingPortable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/ObjectCarryingPortable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/PortableClassVersionTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/PortableClassVersionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/PortableSerializationTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/PortableSerializationTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/PortableTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/PortableTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/RawDataPortable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/RawDataPortable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/SampleIdentifiedDataSerializable.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/SampleIdentifiedDataSerializable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/SerializationConcurrencyTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/SerializationConcurrencyTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/SerializationServiceBuilderTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/SerializationServiceBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/StringSerializationTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/StringSerializationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test.Serialization/TestSerializationConstants.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test.Serialization/TestSerializationConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/AbstractLazyDictionaryTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/AbstractLazyDictionaryTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/AddressProviderTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/AddressProviderTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/AggregatorAndProjectionTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/AggregatorAndProjectionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientClusterRestartEventTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientClusterRestartEventTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientClusterServiceTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientClusterServiceTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientCredentialsTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientCredentialsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientExecutorServiceTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientExecutorServiceTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientHeartBeatDetailTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientHeartBeatDetailTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientHeartBeatForListenerTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientHeartBeatForListenerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientHeartBeatTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientHeartBeatTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientIpV6AddressTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientIpV6AddressTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientListTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientListTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientLoggingTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientLoggingTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientLongRunningTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientLongRunningTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientMapJsonTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientMapJsonTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientMapTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientMapTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientMultiMapTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientMultiMapTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientPartitionTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientPartitionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientQueueTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientQueueTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientReconnectionTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientReconnectionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientReplicateMapTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientReplicateMapTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientRetryTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientRetryTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientRingbufferTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientRingbufferTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientSetTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientSetTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientShutdownTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientShutdownTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientSslBaseTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientSslBaseTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientSslMutualAuthenticationTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientSslMutualAuthenticationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientSslTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientSslTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientStatisticsTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientStatisticsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientTopicTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientTopicTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnListTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnListTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnMapTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnMapTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnMultiMapTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnMultiMapTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnNonSmartTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnNonSmartTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnQueueTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnQueueTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnSetTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnSetTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientTxnTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/DnsErrorsTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/DnsErrorsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/EntryEventTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/EntryEventTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/EnvironmentUtilTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/EnvironmentUtilTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/GenericEvent.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/GenericEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/HazelcastClientFactory.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/HazelcastClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/HazelcastCloudDiscoveryTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/HazelcastCloudDiscoveryTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/HazelcastTestSupport.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/HazelcastTestSupport.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/MultiMemberBaseNoSetupTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/MultiMemberBaseNoSetupTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/MultiMemberBaseTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/MultiMemberBaseTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/NestedPredicateVersionedPortablesTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/NestedPredicateVersionedPortablesTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/NonSmartRoutingTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/NonSmartRoutingTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/PagingPredicateTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/PagingPredicateTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/PagingPredicateWithPrimitiveTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/PagingPredicateWithPrimitiveTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/PartitionPredicateTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/PartitionPredicateTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/PredicateExtTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/PredicateExtTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/PredicatesTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/PredicatesTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ProcessUtil.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ProcessUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ReadOnlyLazyDictionaryTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ReadOnlyLazyDictionaryTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ReadOnlyLazyEntrySetTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ReadOnlyLazyEntrySetTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ReadOnlyLazyListTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ReadOnlyLazyListTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/ReadOnlyLazySetTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ReadOnlyLazySetTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/SettableFutureTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/SettableFutureTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/SingleMemberBaseTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/SingleMemberBaseTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/TaskExtensions.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/TaskExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/TestSupport.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/TestSupport.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/VectorClockTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/VectorClockTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Client.Test/VersionUtilTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/VersionUtilTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheInvalidationTest.cs
+++ b/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheInvalidationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheMetaDataDistortionTest.cs
+++ b/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheMetaDataDistortionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheStaleReadTest.cs
+++ b/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheStaleReadTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheStalenessTest.cs
+++ b/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheStalenessTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheTest.cs
+++ b/Hazelcast.Test/Hazelcast.NearCache.Test/NearCacheTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.NearCache.Test/NearcacheTestSupport.cs
+++ b/Hazelcast.Test/Hazelcast.NearCache.Test/NearcacheTestSupport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Remote/IRemoteController.cs
+++ b/Hazelcast.Test/Hazelcast.Remote/IRemoteController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Remote/ThreadSafeRemoteController.cs
+++ b/Hazelcast.Test/Hazelcast.Remote/ThreadSafeRemoteController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Hazelcast.Remote/ThreadSafeRemoteController45.cs
+++ b/Hazelcast.Test/Hazelcast.Remote/ThreadSafeRemoteController45.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/Overrides.cs
+++ b/Hazelcast.Test/Overrides.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Hazelcast.Test/SimpleMapTestFromClient.cs
+++ b/Hazelcast.Test/SimpleMapTestFromClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2372,6 +2372,6 @@ Please see the [Licensing section](https://docs.hazelcast.org/docs/latest-dev/ma
 
 # 12. Copyright
 
-Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
 
 Visit [www.hazelcast.com](http://www.hazelcast.com) for more information.

--- a/shared.project.props
+++ b/shared.project.props
@@ -3,7 +3,7 @@
         <Version>4.0.0</Version>
         <Product>Hazelcast</Product>
         <Company>Hazelcast Inc.</Company>
-        <Copyright>Copyright (c) 2008-2019, Hazelcast, Inc</Copyright>
+        <Copyright>Copyright (c) 2008-2020, Hazelcast, Inc</Copyright>
         <Authors>Hazelcast</Authors>
         <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
         <PackageIconUrl>https://s3.amazonaws.com/hazelcast/logo/HazelcastLogo-Orange_Dark_NoText_200w.png</PackageIconUrl>


### PR DESCRIPTION
Edit all files that had `Copyright (c) 2008-2019` (or `-2018`...) and replace with `Copyright (c) 2008-2020`. No other changes.