### PR TITLE
Adding loaded event to the EntryAdapter

### DIFF
--- a/Hazelcast.Net/Hazelcast.Core/EntryAdapter.cs
+++ b/Hazelcast.Net/Hazelcast.Core/EntryAdapter.cs
@@ -33,7 +33,7 @@ namespace Hazelcast.Core
 
         public EntryAdapter(Action<EntryEvent<TKey, TValue>> fAdded, Action<EntryEvent<TKey, TValue>> fRemoved,
             Action<EntryEvent<TKey, TValue>> fUpdated, Action<EntryEvent<TKey, TValue>> fEvicted,
-            Action<MapEvent> fEvictAll, Action<MapEvent> fClearAll)
+            Action<MapEvent> fEvictAll, Action<MapEvent> fClearAll, Action<EntryEvent<TKey, TValue>> fLoaded)
         {
             Added = fAdded;
             Removed = fRemoved;
@@ -41,12 +41,14 @@ namespace Hazelcast.Core
             Evicted = fEvicted;
             EvictAll = fEvictAll;
             ClearAll = fClearAll;
+            Loaded = fLoaded;
         }
 
         public Action<EntryEvent<TKey, TValue>> Added { get; set; }
         public Action<EntryEvent<TKey, TValue>> Evicted { get; set; }
         public Action<EntryEvent<TKey, TValue>> Removed { get; set; }
         public Action<EntryEvent<TKey, TValue>> Updated { get; set; }
+        public Action<EntryEvent<TKey, TValue>> Loaded { get; set; }
         public Action<MapEvent> EvictAll { get; set; }
         public Action<MapEvent> ClearAll { get; set; }
 
@@ -68,6 +70,11 @@ namespace Hazelcast.Core
         public void EntryEvicted(EntryEvent<TKey, TValue> @event)
         {
             Evicted?.Invoke(@event);
+        }
+
+        public void EntryLoaded(EntryEvent<TKey, TValue> @event)
+        {
+            Loaded?.Invoke(@event);
         }
 
         public void MapEvicted(MapEvent @event)

--- a/Hazelcast.Net/Hazelcast.Core/IEntryListener.cs
+++ b/Hazelcast.Net/Hazelcast.Core/IEntryListener.cs
@@ -25,7 +25,7 @@ namespace Hazelcast.Core
     /// <typeparam name="TKey">the type of key</typeparam>
     /// <typeparam name="TValue">the type of value</typeparam>
     public interface IEntryListener<TKey, TValue> : EntryAddedListener<TKey, TValue>,
-        EntryUpdatedListener<TKey, TValue>, EntryRemovedListener<TKey, TValue>, EntryEvictedListener<TKey, TValue>,
+        EntryUpdatedListener<TKey, TValue>, EntryRemovedListener<TKey, TValue>, EntryEvictedListener<TKey, TValue>, EntryLoadedListener<TKey, TValue>,
         MapClearedListener, MapEvictedListener
 
     {

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientMapTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientMapTest.cs
@@ -23,6 +23,7 @@ using Hazelcast.Core;
 using Hazelcast.IO;
 using Hazelcast.IO.Serialization;
 using Hazelcast.Map;
+using Hazelcast.Test;
 using NUnit.Framework;
 
 namespace Hazelcast.Client.Test
@@ -676,7 +677,8 @@ namespace Hazelcast.Client.Test
                 delegate { },
                 delegate { },
                 delegate { },
-                delegate { latchClearAll.Signal(); });
+                delegate { latchClearAll.Signal(); },
+                delegate { });
 
             var reg1 = map.AddEntryListener(listener1, false);
 
@@ -822,6 +824,33 @@ namespace Hazelcast.Client.Test
             map.Put("key1", "value1");
 
             Assert.IsFalse(latch1Add.Wait(TimeSpan.FromSeconds(1)));
+        }
+
+        [Test]
+        public void TestListenerLoaded()
+        {
+            var latch1Loaded = new CountdownEvent(1);
+            var map = Client.GetMap<string, string>("mapstore-test");
+
+            var listener1 = new EntryAdapter<string, string>(
+                delegate { },
+                delegate { },
+                delegate { },
+                delegate { },
+                delegate { },
+                delegate { },
+                delegate { latch1Loaded.Signal(); });
+
+            var reg1 = map.AddEntryListener(listener1, false);
+
+            map.Put("some-key", "some-value", 1, TimeUnit.Seconds);
+
+            Thread.Sleep(2000);
+
+            var res = map.Get("some-key");
+
+            Assert.IsTrue(latch1Loaded.Wait(TimeSpan.FromSeconds(5)));
+            Assert.AreEqual("some-value", res);
         }
 
         /// <exception cref="System.Exception"></exception>

--- a/Hazelcast.Test/Hazelcast.Client.Test/ClientReplicateMapTest.cs
+++ b/Hazelcast.Test/Hazelcast.Client.Test/ClientReplicateMapTest.cs
@@ -43,6 +43,7 @@ namespace Hazelcast.Client.Test
             public CountdownEvent Update { get; set; }
             public CountdownEvent Remove { get; set; }
             public CountdownEvent Evict { get; set; }
+            public CountdownEvent Loaded { get; set; }
             public CountdownEvent ClearAll { get; set; }
 
             public void EntryAdded(EntryEvent<int?, string> @event)
@@ -63,6 +64,11 @@ namespace Hazelcast.Client.Test
             public void EntryEvicted(EntryEvent<int?, string> @event)
             {
                 Evict.Signal();
+            }
+
+            public void EntryLoaded(EntryEvent<int?, string> @event)
+            {
+                Loaded.Signal();
             }
 
             public void MapCleared(MapEvent @event)

--- a/Hazelcast.Test/Resources/hazelcast.xml
+++ b/Hazelcast.Test/Resources/hazelcast.xml
@@ -58,5 +58,10 @@
     <capacity>10</capacity>
     <time-to-live-seconds>180</time-to-live-seconds>
   </ringbuffer>
-
+  
+  <map name="mapstore-test">
+    <map-store enabled="true">
+      <class-name>com.hazelcast.client.test.SampleMapStore</class-name>
+    </map-store>
+  </map>
 </hazelcast>


### PR DESCRIPTION
Looking for some feedback, related to for https://github.com/hazelcast/hazelcast-csharp-client/issues/243

I copied the unit test method from the nodejs client. The entry is added and recorded by the map loader, then expires from the map, and then loaded from the map loader.