### PR TITLE
Various improvements to the build script

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -695,10 +695,14 @@ if ($doBuild -or -$doTests) {
   $sdks = (&dotnet --list-sdks)
   $v21 = ($sdks | select-string -pattern "^2\.1" | foreach-object { $_.ToString().Split(' ')[0] } | select -last 1)
   if ($v21 -eq $null) {
+        Write-Host ""
+        Write-Host "This script requires Microsoft .NET Core 2.1.x SDK, which can be downloaded at: https://dotnet.microsoft.com/download/dotnet-core"
         Die "Could not find dotnet SDK version 2.1.x"
   }
   $v31 = ($sdks | select-string -pattern "^3\.1" | foreach-object { $_.ToString().Split(' ')[0] } | select -last 1)
   if ($v31 -eq $null) {
+        Write-Host ""
+        Write-Host "This script requires Microsoft .NET Core 3.1.x SDK, which can be downloaded at: https://dotnet.microsoft.com/download/dotnet-core"
         Die "Could not find dotnet SDK version 3.1.x"
   }
 }

--- a/hz.ps1
+++ b/hz.ps1
@@ -91,6 +91,12 @@ if ($commands.Length -eq 1 -and $commands[0].Contains(',')) {
 # clear rogue environment variable
 $env:FrameworkPathOverride=""
 
+# this will be SystemDefault by default, and on some oldish environment (Windows 8...) it
+# may not enable Tls12 by default, and use Tls10, and that will prevent us from connecting
+# to some SSL/TLS servers (for instance, NuGet) => explicitly add Tls12
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol `
+    -bor [Net.SecurityProtocolType]::Tls12
+
 # determine platform
 $platform = "windows"
 if ($isLinux) { $platform = "linux" }

--- a/hz.ps1
+++ b/hz.ps1
@@ -97,6 +97,31 @@ $env:FrameworkPathOverride=""
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol `
     -bor [Net.SecurityProtocolType]::Tls12
 
+# determine PowerShellVersion (see also $psVersionTable)
+# PowerShell 2.0 is integrated since Windows 7 and Server 2008 R2
+#            3.0                             8            2012
+#            4.0                             8.1          2012 R2
+#            5.0                             10
+#            5.1                             10AU         2016
+$psVersion = (get-host | select-object Version).Version
+$minVersion = [System.Version]::Parse("5.1.0.0")
+if ($psVersion -lt $minVersion) {
+    Write-Output "This script requires at least version $($minVersion.Major).$($minVersion.Minor) of PowerShell, but you seem to be running version $($psVersion.Major).$($psVersion.Minor)."
+
+    try {
+        $x = (pwsh --version)
+        Write-Output "However we have detected the 'pwsh' command in your PATH, which provides $x."
+        Write-Output "Maybe you invoked PowerShell with the old 'powershell' command? Please use 'pwsh' instead."
+    }
+    catch {
+        Write-Output "We recommend you install the most recent stable version available for download at:"
+        Write-Output "https://github.com/PowerShell/PowerShell/releases"
+        Write-Output "Please note that this version will need to be invoked with 'pwsh' not 'powershell'."
+    }
+
+    Die "Unsupported PowerShell version: $($psVersion.Major).$($psVersion.Minor)"
+}
+
 # determine platform
 $platform = "windows"
 if ($isLinux) { $platform = "linux" }
@@ -109,6 +134,7 @@ foreach ($t in $commands) {
     switch ($t.Trim().ToLower()) {
         "help" {
             Write-Output "Hazelcast .NET Command Line"
+            Write-Output "PowerShell $psVersion"
             Write-Output ""
             Write-Output "usage hz.[ps1|sh] [<option>] [<commands>]"
             Write-Output ""

--- a/hz.sh
+++ b/hz.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/bash
 
-POWERSHELL=powershell
+POWERSHELL=pwsh
 if ! type $POWERSHELL >/dev/null 2>&1; then
-  POWERSHELL=pwsh
+  POWERSHELL=powershell
 fi
 if ! type $POWERSHELL >/dev/null 2>&1; then
   POWERSHELL=""


### PR DESCRIPTION
Includes:
* Ensure we can have TLS 1.2 even on old Windows 8.1 machines
* Ensure we use `pwsh` if available, before trying `powershell`
* Improve error messages if wrong versions of PowerShell or .NET were found
* Remove dependency on Maven to download artifacts