### PR TITLE
Handle orphaned subscriptions

### DIFF
--- a/src/Hazelcast.Net.Testing/StringExtensions.cs
+++ b/src/Hazelcast.Net.Testing/StringExtensions.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Hazelcast.Tests.Testing
+namespace Hazelcast.Testing
 {
     /// <summary>
     /// Provides extension methods to the <see cref="string"/> class.
@@ -20,13 +20,26 @@ namespace Hazelcast.Tests.Testing
     public static class StringExtensions
     {
         /// <summary>
-        /// Converts all cr/lf to lf.
+        /// Converts all cr/lf in this string to lf.
         /// </summary>
-        /// <param name="s">The string to convert.</param>
+        /// <param name="s">This string.</param>
         /// <returns>The converted string.</returns>
         public static string ToLf(this string s)
         {
             return s.Replace("\r\n", "\n").Replace("\r", "\n");
+        }
+
+        /// <summary>
+        /// Appends a string to this string, with a dot separator.
+        /// </summary>
+        /// <param name="s">This string.</param>
+        /// <param name="dotted">The string to append.</param>
+        /// <returns>This string, with the dotted string appended.</returns>
+        public static string Dot(this string s, string dotted)
+        {
+            return string.IsNullOrWhiteSpace(dotted)
+                ? s
+                : s + "." + dotted;
         }
     }
 }

--- a/src/Hazelcast.Net.Testing/TestServer/ServerSocketConnection.cs
+++ b/src/Hazelcast.Net.Testing/TestServer/ServerSocketConnection.cs
@@ -36,12 +36,25 @@ namespace Hazelcast.Testing.TestServer
         /// </summary>
         /// <param name="id">The unique identifier of the connection.</param>
         /// <param name="socket">The underlying network socket.</param>
-        public ServerSocketConnection(int id, Socket socket)
+        /// <param name="hcname">An HConsole name complement.</param>
+        public ServerSocketConnection(int id, Socket socket, string hcname)
             : base(id)
         {
             _acceptingSocket = socket ?? throw new ArgumentNullException(nameof(socket));
-            HConsole.Configure(x => x.Set(this, config => config.SetIndent(32).SetPrefix($"CONN.SERVER [{id}]")));
+
+            var prefix = "CONN.SERVER".Dot(hcname);
+            HConsole.Configure(x => x
+                .Set(this, xx => xx.SetIndent(32).SetPrefix($"{prefix} [{id}]")));
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerSocketConnection"/> class.
+        /// </summary>
+        /// <param name="id">The unique identifier of the connection.</param>
+        /// <param name="socket">The underlying network socket.</param>
+        public ServerSocketConnection(int id, Socket socket)
+            : this(id, socket, string.Empty)
+        { }
 
         /// <summary>
         /// Connects to the client.

--- a/src/Hazelcast.Net.Tests/Clustering/OrphanSubscriptionTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/OrphanSubscriptionTests.cs
@@ -1,0 +1,344 @@
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hazelcast.Core;
+using Hazelcast.Data;
+using Hazelcast.Exceptions;
+using Hazelcast.Messaging;
+using Hazelcast.Networking;
+using Hazelcast.Protocol;
+using Hazelcast.Protocol.Codecs;
+using Hazelcast.Protocol.Data;
+using Hazelcast.Serialization;
+using Hazelcast.Testing;
+using Hazelcast.Testing.Protocol;
+using Hazelcast.Testing.TestServer;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Hazelcast.Tests.Clustering
+{
+    [TestFixture]
+    public class OrphanSubscriptionTests
+    {
+        private IDisposable HConsoleForTest()
+
+            => HConsole.Capture(options => options
+                .ClearAll()
+                .Set(x => x.Verbose())
+                .Set(this, x => x.SetPrefix("TEST"))
+                .Set<AsyncContext>(x => x.Quiet())
+                .Set<SocketConnectionBase>(x => x.SetIndent(1).SetLevel(0).SetPrefix("SOCKET")));
+
+        [Test]
+        public async Task OrphanSubscriptionIsEventuallyRemoved()
+        {
+            var address0 = NetworkAddress.Parse("127.0.0.1:11001");
+            var address1 = NetworkAddress.Parse("127.0.0.1:11002");
+
+            var memberId0 = Guid.NewGuid();
+            var memberId1 = Guid.NewGuid();
+
+            using var __ = HConsoleForTest();
+
+            HConsole.WriteLine(this, "Begin");
+            HConsole.WriteLine(this, "Start servers");
+
+            var loggerFactory = new NullLoggerFactory();
+
+            var state0 = new ServerState
+            {
+                Id = 0,
+                MemberIds = new[] { memberId0, memberId1 },
+                Addresses = new[] { address0, address1 },
+                MemberId = memberId0,
+                Address = address0
+            };
+
+            await using var server0 = new Server(address0, ServerHandler, loggerFactory, state0, "0")
+            {
+                MemberId = state0.MemberId,
+            };
+            await server0.StartAsync();
+
+            var state1 = new ServerState
+            {
+                Id = 1,
+                MemberIds = new[] { memberId0, memberId1 },
+                Addresses = new[] { address0, address1 },
+                MemberId = memberId1,
+                Address = address1
+            };
+
+            await using var server1 = new Server(address1, ServerHandler, loggerFactory, state1, "1")
+            {
+                MemberId = state1.MemberId,
+                ClusterId = server0.ClusterId
+            };
+            await server1.StartAsync();
+
+            HConsole.WriteLine(this, "Start client");
+
+            var options = HazelcastOptions.Build(configure: (configuration, options) =>
+            {
+                options.Networking.Addresses.Add("127.0.0.1:11001");
+                options.Networking.Addresses.Add("127.0.0.1:11002");
+            });
+            await using var client = (HazelcastClient)HazelcastClientFactory.CreateClient(options);
+            await client.StartAsync().CAF();
+
+            HConsole.WriteLine(this, "Get dictionary");
+
+            var dictionary = await client.GetDictionaryAsync<string, string>("name");
+            var count = 0;
+
+            var clusterEvents = client.Cluster.Events;
+            Assert.That(clusterEvents.Subscriptions.Count, Is.EqualTo(0)); // no client subscription yet
+            Assert.That(clusterEvents.CorrelatedSubscriptions.Count, Is.EqualTo(1)); // but the cluster events subscription
+
+            HConsole.WriteLine(this, "Subscribe");
+
+            var sid = await dictionary.SubscribeAsync(events => events
+                .EntryAdded((sender, args) => Interlocked.Increment(ref count))
+            );
+
+            Assert.That(clusterEvents.Subscriptions.Count, Is.EqualTo(1)); // 1 (our) client subscription
+            Assert.That(clusterEvents.Subscriptions.TryGetValue(sid, out var subscription)); // can get our subscription
+
+            await AssertEx.SucceedsEventually(() =>
+            {
+                Assert.That(clusterEvents.CorrelatedSubscriptions.Count, Is.EqualTo(3)); // 2 more correlated
+                Assert.That(subscription.Count, Is.EqualTo(2)); // has 2 members
+                Assert.That(subscription.Active);
+            }, 4000, 200);
+
+            // get a key that targets server 0
+            var key = GetKey(0, 2, client.SerializationService);
+
+            HConsole.WriteLine(this, "Set key=" + key);
+
+            await dictionary.SetAsync(key, "value");
+            await AssertEx.SucceedsEventually(() =>
+            {
+                Assert.That(count, Is.EqualTo(1)); // event triggered
+            }, 2000, 100);
+
+            HConsole.WriteLine(this, "Unsubscribe");
+
+            var unsubscribed = await dictionary.UnsubscribeAsync(sid);
+            Assert.That(unsubscribed);
+
+            await AssertEx.SucceedsEventually(() =>
+            {
+                Assert.That(subscription.Active, Is.False);
+                Assert.That(clusterEvents.Subscriptions.Count, Is.EqualTo(0)); // is gone
+                Assert.That(clusterEvents.CorrelatedSubscriptions.Count, Is.EqualTo(2)); // only 1 is gone
+                Assert.That(subscription.Count, Is.EqualTo(1)); // 1 remains
+            }, 4000, 200);
+
+            // get a key that targets server 1 - important, else we don't get the event
+            key = GetKey(1, 2, client.SerializationService);
+
+            HConsole.WriteLine(this, "Set key=" + key);
+
+            await dictionary.SetAsync(key, "value");
+            await Task.Delay(100);
+            Assert.That(count, Is.EqualTo(1)); // no event
+
+            await AssertEx.SucceedsEventually(() =>
+            {
+                Assert.That(clusterEvents.Subscriptions.Count, Is.EqualTo(0)); // still gone
+                Assert.That(clusterEvents.CorrelatedSubscriptions.Count, Is.EqualTo(1)); // now 2 are gone
+                Assert.That(subscription.Count, Is.EqualTo(0)); // 0 remains
+            }, 4000, 200);
+        }
+
+        private static string GetKey(int partitionId, int partitionCount, ISerializationService serializationService)
+        {
+            int GetHash(string value) => serializationService.ToData(value).PartitionHash;
+
+            var key = "key0";
+            for (var i = 1; i < 100 && GetHash(key) % partitionCount != partitionId; i++) key = "key" + i;
+            return key;
+        }
+
+        private class ServerState
+        {
+            public Guid[] MemberIds { get; set; }
+            public NetworkAddress[] Addresses { get; set; }
+            public int Id { get; set; }
+            public Guid MemberId { get; set; }
+            public NetworkAddress Address { get; set; }
+            public bool Subscribed { get; set; }
+            public Guid SubscriptionId { get; set; }
+            public int UnsubscribeCount { get; set; }
+            public long SubscriptionCorrelationId { get; set; }
+        }
+
+        private async ValueTask ServerHandler(Server s, ClientMessageConnection conn, ClientMessage msg)
+        {
+            async Task SendResponseAsync(ClientMessage response)
+            {
+                response.CorrelationId = msg.CorrelationId;
+                response.Flags |= ClientMessageFlags.BeginFragment | ClientMessageFlags.EndFragment;
+                await conn.SendAsync(response).CAF();
+            }
+
+            async Task SendEventAsync(ClientMessage eventMessage, long correlationId)
+            {
+                eventMessage.CorrelationId = correlationId;
+                eventMessage.Flags |= ClientMessageFlags.BeginFragment | ClientMessageFlags.EndFragment;
+                await conn.SendAsync(eventMessage).CAF();
+            }
+
+            async Task SendErrorAsync(RemoteError error, string message)
+            {
+                var errorHolders = new List<ErrorHolder>
+                    {
+                        new ErrorHolder(error, "?", message, Enumerable.Empty<StackTraceElement>())
+                    };
+                var response = ErrorsServerCodec.EncodeResponse(errorHolders);
+                await SendResponseAsync(response).CAF();
+            }
+
+            var state = (ServerState) s.State;
+            var address = s.Address;
+
+            const int partitionsCount = 2;
+
+            switch (msg.MessageType)
+            {
+                // must handle auth
+                case ClientAuthenticationServerCodec.RequestMessageType:
+                    {
+                        HConsole.WriteLine(this, $"(server{state.Id}) Authentication");
+                        var authRequest = ClientAuthenticationServerCodec.DecodeRequest(msg);
+                        var authResponse = ClientAuthenticationServerCodec.EncodeResponse(
+                            0, address, s.MemberId, SerializationService.SerializerVersion,
+                            "4.0", partitionsCount, s.ClusterId, false);
+                        await SendResponseAsync(authResponse).CAF();
+                        break;
+                    }
+
+                // must handle events
+                case ClientAddClusterViewListenerServerCodec.RequestMessageType:
+                    {
+                        HConsole.WriteLine(this, $"(server{state.Id}) AddClusterViewListener");
+                        var addRequest = ClientAddClusterViewListenerServerCodec.DecodeRequest(msg);
+                        var addResponse = ClientAddClusterViewListenerServerCodec.EncodeResponse();
+                        await SendResponseAsync(addResponse).CAF();
+
+                        _ = Task.Run(async () =>
+                        {
+                            await Task.Delay(500).CAF();
+
+                            const int membersVersion = 1;
+                            var memberVersion = new MemberVersion(4, 0, 0);
+                            var memberAttributes = new Dictionary<string, string>();
+                            var membersEventMessage = ClientAddClusterViewListenerServerCodec.EncodeMembersViewEvent(membersVersion, new[]
+                            {
+                                new MemberInfo(state.MemberIds[0], state.Addresses[0], memberVersion, false, memberAttributes),
+                                new MemberInfo(state.MemberIds[1], state.Addresses[1], memberVersion, false, memberAttributes),
+                            });
+                            await SendEventAsync(membersEventMessage, msg.CorrelationId).CAF();
+
+                            await Task.Delay(500).CAF();
+
+                            const int partitionsVersion = 1;
+                            var partitionsEventMessage = ClientAddClusterViewListenerServerCodec.EncodePartitionsViewEvent(partitionsVersion, new[]
+                            {
+                                new KeyValuePair<Guid, IList<int>>(state.MemberIds[0], new List<int> { 0 }),
+                                new KeyValuePair<Guid, IList<int>>(state.MemberIds[1], new List<int> { 1 }),
+                            });
+                            await SendEventAsync(partitionsEventMessage, msg.CorrelationId).CAF();
+                        });
+
+                        break;
+                    }
+
+                // create object
+                case ClientCreateProxyServerCodec.RequestMessageType:
+                    {
+                        HConsole.WriteLine(this, $"(server{state.Id}) CreateProxy");
+                        var createRequest = ClientCreateProxyServerCodec.DecodeRequest(msg);
+                        var createResponse = ClientCreateProxiesServerCodec.EncodeResponse();
+                        await SendResponseAsync(createResponse).CAF();
+                        break;
+                    }
+
+                // subscribe
+                case MapAddEntryListenerServerCodec.RequestMessageType:
+                    {
+                        HConsole.WriteLine(this, $"(server{state.Id}) AddEntryListener");
+                        var addRequest = MapAddEntryListenerServerCodec.DecodeRequest(msg);
+                        state.Subscribed = true;
+                        state.SubscriptionCorrelationId = msg.CorrelationId;
+                        var addResponse = MapAddEntryListenerServerCodec.EncodeResponse(state.SubscriptionId);
+                        await SendResponseAsync(addResponse).CAF();
+                        break;
+                    }
+
+                // unsubscribe
+                // server 1 removes on first try, server 2 removes on later tries
+                case MapRemoveEntryListenerServerCodec.RequestMessageType:
+                    {
+                        HConsole.WriteLine(this, $"(server{state.Id}) RemoveEntryListener");
+                        var removeRequest = MapRemoveEntryListenerServerCodec.DecodeRequest(msg);
+                        var removed = state.Subscribed && removeRequest.RegistrationId == state.SubscriptionId;
+                        removed &= state.Id == 0 || state.UnsubscribeCount++ > 0;
+                        if (removed) state.Subscribed = false;
+                        HConsole.WriteLine(this, $"(server{state.Id}) Subscribed={state.Subscribed}");
+                        var removeResponse = MapRemoveEntryListenerServerCodec.EncodeResponse(removed);
+                        await SendResponseAsync(removeResponse).CAF();
+                        break;
+                    }
+
+                // add to map & trigger event
+                case MapSetServerCodec.RequestMessageType:
+                    {
+                        HConsole.WriteLine(this, $"(server{state.Id}) Set");
+                        var setRequest = MapSetServerCodec.DecodeRequest(msg);
+                        var setResponse = MapSetServerCodec.EncodeResponse();
+                        await SendResponseAsync(setResponse).CAF();
+
+                        HConsole.WriteLine(this, $"(server{state.Id}) Subscribed={state.Subscribed}");
+
+                        if (state.Subscribed)
+                        {
+                            HConsole.WriteLine(this, $"(server{state.Id}) Trigger event");
+                            var key = setRequest.Key;
+                            var value = setRequest.Value;
+                            var addedEvent = MapAddEntryListenerServerCodec.EncodeEntryEvent(key, value, value, value, (int)HDictionaryEventTypes.Added, state.SubscriptionId, 1);
+                            await SendEventAsync(addedEvent, state.SubscriptionCorrelationId).CAF();
+                        }
+                        break;
+                    }
+
+                // unexpected message = error
+                default:
+                    {
+                        // RemoteError.Hazelcast or RemoteError.RetryableHazelcast
+                        var messageName = CodecConstants.GetMessageTypeName(msg.MessageType);
+                        await SendErrorAsync(RemoteError.Hazelcast, $"MessageType {messageName} (0x{msg.MessageType:X}) not implemented.").CAF();
+                        break;
+                    }
+            }
+        }
+    }
+}

--- a/src/Hazelcast.Net.Tests/Core/DistributedEventSchedulerTests.cs
+++ b/src/Hazelcast.Net.Tests/Core/DistributedEventSchedulerTests.cs
@@ -7,7 +7,9 @@ using System.Threading.Tasks;
 using Hazelcast.Clustering;
 using Hazelcast.Core;
 using Hazelcast.Messaging;
+using Hazelcast.Testing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Core
@@ -59,9 +61,11 @@ namespace Hazelcast.Tests.Core
         {
             // this test verifies that the scheduler works as expected
 
+            static ValueTask OnOrphan(ClusterSubscription subscription, Guid memberId, long correlationId) => default;
+
             using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             var logger = loggerFactory.CreateLogger("TEST");
-            var scheduler = new DistributedEventScheduler(loggerFactory);
+            var scheduler = new DistributedEventScheduler(OnOrphan, loggerFactory);
 
             var pe = new ConcurrentDictionary<int, long>();
 
@@ -142,6 +146,42 @@ namespace Hazelcast.Tests.Core
 
             // all tasks are gone
             Assert.That(scheduler.PartitionTasksCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task SchedulerOrphanTest()
+        {
+            var orphaned = 0;
+
+            async ValueTask OnOrphan(ClusterSubscription subscription, Guid memberId, long correlationId)
+            {
+                await Task.Yield();
+                Interlocked.Increment(ref orphaned);
+            }
+
+            var scheduler = new DistributedEventScheduler(OnOrphan, new NullLoggerFactory());
+
+            var handled = 0;
+            var s = new ClusterSubscription(async (clientMessage, state) =>
+            {
+                await Task.Yield();
+                Interlocked.Increment(ref handled);
+            });
+
+            s.SetOrphaned();
+
+            var m = new ClientMessage(new Frame(new byte[64]))
+            {
+                PartitionId = 666,
+                CorrelationId = 1,
+            };
+
+            // can add the event
+            Assert.That(scheduler.Add(s, m), Is.True);
+
+            await AssertEx.SucceedsEventually(() => Assert.That(orphaned, Is.EqualTo(1)), 2000, 200);
+
+            Assert.That(handled, Is.Zero);
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/Core/DumpCoreExtensionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Core/DumpCoreExtensionsTests.cs
@@ -16,7 +16,7 @@ using System;
 using System.Buffers;
 using System.Text;
 using Hazelcast.Core;
-using Hazelcast.Tests.Testing;
+using Hazelcast.Testing;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Core

--- a/src/Hazelcast.Net.Tests/Messaging/ClientMessageTests.cs
+++ b/src/Hazelcast.Net.Tests/Messaging/ClientMessageTests.cs
@@ -77,6 +77,10 @@ namespace Hazelcast.Tests.Messaging
             Assert.That(m.IsRetryable, Is.False);
             m.IsRetryable = true;
             Assert.That(m.IsRetryable);
+
+            var senderId = Guid.NewGuid();
+            m.Sender = senderId;
+            Assert.That(m.Sender, Is.EqualTo(senderId));
         }
 
         [Test]

--- a/src/Hazelcast.Net.Tests/Messaging/ClientMessageTests.cs
+++ b/src/Hazelcast.Net.Tests/Messaging/ClientMessageTests.cs
@@ -77,10 +77,6 @@ namespace Hazelcast.Tests.Messaging
             Assert.That(m.IsRetryable, Is.False);
             m.IsRetryable = true;
             Assert.That(m.IsRetryable);
-
-            var senderId = Guid.NewGuid();
-            m.Sender = senderId;
-            Assert.That(m.Sender, Is.EqualTo(senderId));
         }
 
         [Test]

--- a/src/Hazelcast.Net.Tests/Messaging/DumpMessagingExtensionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Messaging/DumpMessagingExtensionsTests.cs
@@ -15,7 +15,7 @@
 using System;
 using Hazelcast.Messaging;
 using Hazelcast.Protocol.Codecs;
-using Hazelcast.Tests.Testing;
+using Hazelcast.Testing;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Messaging

--- a/src/Hazelcast.Net.Tests/Testing/LoggingTests.cs
+++ b/src/Hazelcast.Net.Tests/Testing/LoggingTests.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Text;
+using Hazelcast.Testing;
 using Hazelcast.Testing.Logging;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;

--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -310,7 +310,7 @@ namespace Hazelcast.Clustering
             address = _clusterMembers.MapAddress(address);
 
             // create the connection to the member
-            var connection = new MemberConnection(address, _clusterState.Options.Messaging, _clusterState.Options.Networking.Socket, _clusterState.Options.Networking.Ssl, _clusterState.CorrelationIdSequence, _clusterState.LoggerFactory)
+            var connection = new MemberConnection(address, _clusterState.Options.Messaging, _clusterState.Options.Networking.Socket, _clusterState.Options.Networking.Ssl, _clusterState.ConnectionIdSequence, _clusterState.CorrelationIdSequence, _clusterState.LoggerFactory)
             {
                 OnReceiveEventMessage = _clusterEvents.OnEventMessage,
                 OnShutdown = HandleConnectionTermination

--- a/src/Hazelcast.Net/Clustering/ClusterState.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterState.cs
@@ -126,6 +126,11 @@ namespace Hazelcast.Clustering
         public long GetNextCorrelationId() => CorrelationIdSequence.GetNext();
 
         /// <summary>
+        /// Gets the connection identifier sequence.
+        /// </summary>
+        public ISequence<int> ConnectionIdSequence { get; } = new Int32Sequence();
+
+        /// <summary>
         /// Throws an <see cref="InvalidOperationException"/> if properties (On...) are read-only.
         /// </summary>
         public void ThrowIfReadOnlyProperties()

--- a/src/Hazelcast.Net/Clustering/ClusterSubscription.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterSubscription.cs
@@ -105,21 +105,6 @@ namespace Hazelcast.Clustering
         public bool Active => _active;
 
         /// <summary>
-        /// Gets a value indicating whether the subscription is orphaned.
-        /// </summary>
-        /// <remarks>
-        /// <para>An orphaned subscription means that it is not active anymore,
-        /// and the unsubscribe method return, but some members which failed to
-        /// unsubscribe were left over.</para>
-        /// </remarks>
-        public bool Orphaned { get; private set; }
-
-        /// <summary>
-        /// Sets the subscription as orphaned.
-        /// </summary>
-        public void SetOrphaned() => Orphaned = true;
-
-        /// <summary>
         /// Gets the state object.
         /// </summary>
         public object State { get; }
@@ -137,8 +122,14 @@ namespace Hazelcast.Clustering
             lock (_activeLock)
             {
                 _active = false;
+                DeactivateTime = DateTime.Now;
             }
         }
+
+        /// <summary>
+        /// Gets the time the subscription was de-activated.
+        /// </summary>
+        public DateTime DeactivateTime { get; private set; }
 
         /// <summary>
         /// Tries to add a client subscription.

--- a/src/Hazelcast.Net/Clustering/ClusterSubscription.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterSubscription.cs
@@ -105,6 +105,21 @@ namespace Hazelcast.Clustering
         public bool Active => _active;
 
         /// <summary>
+        /// Gets a value indicating whether the subscription is orphaned.
+        /// </summary>
+        /// <remarks>
+        /// <para>An orphaned subscription means that it is not active anymore,
+        /// and the unsubscribe method return, but some members which failed to
+        /// unsubscribe were left over.</para>
+        /// </remarks>
+        public bool Orphaned { get; private set; }
+
+        /// <summary>
+        /// Sets the subscription as orphaned.
+        /// </summary>
+        public void SetOrphaned() => Orphaned = true;
+
+        /// <summary>
         /// Gets the state object.
         /// </summary>
         public object State { get; }
@@ -140,7 +155,7 @@ namespace Hazelcast.Clustering
             {
                 active = _active;
                 if (active)
-                    _clientSubscriptions[client] = new MemberSubscription(this, serverSubscriptionId, SubscribeRequest.CorrelationId, client);
+                    _clientSubscriptions[client] = new MemberSubscription(this, serverSubscriptionId, message.CorrelationId, client);
             }
 
             return (active, serverSubscriptionId);
@@ -186,6 +201,11 @@ namespace Hazelcast.Clustering
         /// <returns>Whether the operation was successful.</returns>
         public bool ReadUnsubscribeResponse(ClientMessage message)
             => _unsubscribeResponseReader(message, State);
+
+        /// <summary>
+        /// Gets the number of member subscriptions.
+        /// </summary>
+        public int Count => _clientSubscriptions.Count;
 
         /// <inheritdoc />
         public IEnumerator<MemberSubscription> GetEnumerator()

--- a/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
+++ b/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
@@ -38,7 +38,6 @@ namespace Hazelcast.Clustering
         /// <summary>
         /// Initializes a new instance of the <see cref="DistributedEventScheduler"/> class.
         /// </summary>
-        /// <param name="onOrphan">A method to handle orphan events.</param>
         /// <param name="loggerFactory">A logger factory.</param>
         public DistributedEventScheduler(ILoggerFactory loggerFactory)
         {

--- a/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
+++ b/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
@@ -30,7 +30,6 @@ namespace Hazelcast.Clustering
         private readonly Dictionary<int, Task> _partitionTasks = new Dictionary<int, Task>();
         private readonly Func<Task, object, Task> _continueWithHandler;
         private readonly Action<Task, object> _removeAfterUse;
-        private readonly Func<ClusterSubscription, Guid, long, ValueTask> _onOrphan;
         private readonly object _mutex = new object();
         private readonly ILogger _logger;
         private bool _disposed;
@@ -41,9 +40,8 @@ namespace Hazelcast.Clustering
         /// </summary>
         /// <param name="onOrphan">A method to handle orphan events.</param>
         /// <param name="loggerFactory">A logger factory.</param>
-        public DistributedEventScheduler(Func<ClusterSubscription, Guid, long, ValueTask>  onOrphan, ILoggerFactory loggerFactory)
+        public DistributedEventScheduler(ILoggerFactory loggerFactory)
         {
-            _onOrphan = onOrphan ?? throw new ArgumentNullException(nameof(onOrphan));
             _logger = loggerFactory?.CreateLogger<DistributedEventScheduler>() ?? throw new ArgumentNullException(nameof(loggerFactory));
 
             _continueWithHandler = ContinueWithHandler;
@@ -82,7 +80,7 @@ namespace Hazelcast.Clustering
             if (eventMessage == null) throw new ArgumentNullException(nameof(eventMessage));
 
             var partitionId = eventMessage.PartitionId;
-            var state = new State { Subscription = subscription, Orphaned = subscription.Orphaned, Message = eventMessage, PartitionId = partitionId };
+            var state = new State { Subscription = subscription, Message = eventMessage, PartitionId = partitionId };
 
             // the factories in ConcurrentDictionary.AddOrUpdate are *not* thread-safe, i.e. in order
             // to run with minimal locking, the ConcurrentDictionary may run the two of them, or one
@@ -140,8 +138,6 @@ namespace Hazelcast.Clustering
         {
             public ClusterSubscription Subscription { get; set; }
 
-            public bool Orphaned { get; set; }
-
             public ClientMessage Message { get; set; }
 
             public int PartitionId { get; set; }
@@ -168,14 +164,6 @@ namespace Hazelcast.Clustering
         private async Task ContinueWithHandler(Task task, object stateObject)
         {
             var state = (State) stateObject;
-
-            if (state.Orphaned)
-            {
-                // the subscription was orphaned when the event was scheduled
-                // we are *not* handling the event, but reporting the orphan
-                await _onOrphan(state.Subscription, state.Message.Sender, state.Message.CorrelationId).CAF();
-                return;
-            }
 
             try
             {

--- a/src/Hazelcast.Net/Clustering/IClusterOptions.cs
+++ b/src/Hazelcast.Net/Clustering/IClusterOptions.cs
@@ -14,6 +14,7 @@
 
 using System.Collections.Generic;
 using Hazelcast.Clustering.LoadBalancing;
+using Hazelcast.Events;
 using Hazelcast.Messaging;
 using Hazelcast.Networking;
 
@@ -68,5 +69,10 @@ namespace Hazelcast.Clustering
         /// Gets the networking options.
         /// </summary>
         NetworkingOptions Networking { get; }
+
+        /// <summary>
+        /// Gets the events options.
+        /// </summary>
+        EventsOptions Events { get; }
     }
 }

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -245,8 +245,6 @@ namespace Hazelcast.Clustering
         /// <returns>A task that will complete when the message has been handled.</returns>
         private void ReceiveMessage(ClientMessageConnection connection, ClientMessage message)
         {
-            message.Sender = MemberId;
-
             if (message.IsEvent)
             {
                 HConsole.WriteLine(this, $"Receive event [{message.CorrelationId}]" +

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -22,7 +22,6 @@ using Hazelcast.Data;
 using Hazelcast.Exceptions;
 using Hazelcast.Messaging;
 using Hazelcast.Networking;
-using Hazelcast.Protocol;
 using Hazelcast.Protocol.BuiltInCodecs;
 using Microsoft.Extensions.Logging;
 
@@ -68,19 +67,6 @@ namespace Hazelcast.Clustering
         private CancellationTokenSource _bgCancellation;
         private CancellationTokenSource _bgTaskCancellation;
         private Task _bgTask;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MemberConnection"/> class.
-        /// </summary>
-        /// <param name="address">The network address.</param>
-        /// <param name="messagingOptions">Messaging options.</param>
-        /// <param name="socketOptions">Socket options.</param>
-        /// <param name="sslOptions">SSL options.</param>
-        /// <param name="correlationIdSequence">A sequence of unique correlation identifiers.</param>
-        /// <param name="loggerFactory">A logger factory.</param>
-        public MemberConnection(NetworkAddress address, MessagingOptions messagingOptions, SocketOptions socketOptions, SslOptions sslOptions, ISequence<long> correlationIdSequence, ILoggerFactory loggerFactory)
-            : this(address, messagingOptions, socketOptions, sslOptions, new Int32Sequence(), correlationIdSequence, loggerFactory)
-        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemberConnection"/> class.
@@ -259,6 +245,8 @@ namespace Hazelcast.Clustering
         /// <returns>A task that will complete when the message has been handled.</returns>
         private void ReceiveMessage(ClientMessageConnection connection, ClientMessage message)
         {
+            message.Sender = MemberId;
+
             if (message.IsEvent)
             {
                 HConsole.WriteLine(this, $"Receive event [{message.CorrelationId}]" +

--- a/src/Hazelcast.Net/Events/EventsOptions.cs
+++ b/src/Hazelcast.Net/Events/EventsOptions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Hazelcast.Events
+{
+    /// <summary>
+    /// Represents the events options.
+    /// </summary>
+    public class EventsOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventsOptions"/> class.
+        /// </summary>
+        public EventsOptions()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventsOptions"/> class.
+        /// </summary>
+        private EventsOptions(EventsOptions other)
+        {
+            SubscriptionCollectDelay = other.SubscriptionCollectDelay;
+            SubscriptionCollectPeriod = other.SubscriptionCollectPeriod;
+            SubscriptionCollectTimeout = other.SubscriptionCollectTimeout;
+        }
+
+        /// <summary>
+        /// Gets or sets the delay before collecting subscriptions starts.
+        /// </summary>
+        public TimeSpan SubscriptionCollectDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Gets or sets the period of the subscription collection.
+        /// </summary>
+        public TimeSpan SubscriptionCollectPeriod { get; set; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Gets or sets the subscription collection timeout, after which a subscription is considered dead and removed.
+        /// </summary>
+        public TimeSpan SubscriptionCollectTimeout { get; set; } = TimeSpan.FromMinutes(4);
+    }
+}

--- a/src/Hazelcast.Net/Events/EventsOptions.cs
+++ b/src/Hazelcast.Net/Events/EventsOptions.cs
@@ -40,12 +40,12 @@ namespace Hazelcast.Events
         /// <summary>
         /// Gets or sets the delay before collecting subscriptions starts.
         /// </summary>
-        public TimeSpan SubscriptionCollectDelay { get; set; } = TimeSpan.FromSeconds(1);
+        public TimeSpan SubscriptionCollectDelay { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// Gets or sets the period of the subscription collection.
         /// </summary>
-        public TimeSpan SubscriptionCollectPeriod { get; set; } = TimeSpan.FromSeconds(1);
+        public TimeSpan SubscriptionCollectPeriod { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// Gets or sets the subscription collection timeout, after which a subscription is considered dead and removed.

--- a/src/Hazelcast.Net/HazelcastOptions.ClusterOptions.cs
+++ b/src/Hazelcast.Net/HazelcastOptions.ClusterOptions.cs
@@ -15,6 +15,7 @@
 using System.Collections.Generic;
 using Hazelcast.Clustering;
 using Hazelcast.Clustering.LoadBalancing;
+using Hazelcast.Events;
 using Hazelcast.Messaging;
 using Hazelcast.Networking;
 
@@ -83,5 +84,10 @@ namespace Hazelcast
         /// Gets the networking options.
         /// </summary>
         public NetworkingOptions Networking { get; } = new NetworkingOptions();
+
+        /// <summary>
+        /// Gets the events options.
+        /// </summary>
+        public EventsOptions Events { get; } = new EventsOptions();
     }
 }

--- a/src/Hazelcast.Net/Messaging/ClientMessage.cs
+++ b/src/Hazelcast.Net/Messaging/ClientMessage.cs
@@ -55,6 +55,11 @@ namespace Hazelcast.Messaging
         }
 
         /// <summary>
+        /// Gets or sets the unique identifier of the member that sent the message, if any.
+        /// </summary>
+        public Guid Sender { get; set; }
+
+        /// <summary>
         /// Whether the operation carried by this message can be retried.
         /// </summary>
         public bool IsRetryable { get; set; }

--- a/src/Hazelcast.Net/Messaging/ClientMessage.cs
+++ b/src/Hazelcast.Net/Messaging/ClientMessage.cs
@@ -55,11 +55,6 @@ namespace Hazelcast.Messaging
         }
 
         /// <summary>
-        /// Gets or sets the unique identifier of the member that sent the message, if any.
-        /// </summary>
-        public Guid Sender { get; set; }
-
-        /// <summary>
         /// Whether the operation carried by this message can be retried.
         /// </summary>
         public bool IsRetryable { get; set; }

--- a/src/Hazelcast.Net/Networking/ClientSocketConnection.cs
+++ b/src/Hazelcast.Net/Networking/ClientSocketConnection.cs
@@ -53,7 +53,9 @@ namespace Hazelcast.Networking
             _socketOptions = options ?? throw new ArgumentNullException(nameof(options));
             _sslOptions = sslOptions ?? throw new ArgumentNullException(nameof(sslOptions));
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-            HConsole.Configure(x => x.Set(this, config => config.SetIndent(16).SetPrefix($"CONN.CLIENT [{id}]")));
+
+            HConsole.Configure(x => x
+                .Set(this, xx => xx.SetIndent(16).SetPrefix($"CONN.CLIENT [{id}]")));
         }
 
         /// <summary>


### PR DESCRIPTION
Add the ability to handled orphaned subscriptions: when a user unsubscribes from events, we try to remove the corresponding listener on each member. If that succeeds then all is well. Otherwise, we still return `true` but we keep the subscription around, and mark it as orphaned. If we receive an event from a member, corresponding to an orphaned subscription, we try again to remove the listener for that member. Eventually, the subscription should be removed.

There is a corresponding test that uses our testing server to verify that it works.

Now, events are triggered by actions... if a listener remains active on a member and we never trigger an action on that member, no event may be triggered and both the listener on the member, and the subscription on the client, will leak.

A next feature (should we create an issue / feature request for it?) would be to periodically scan the subscriptions, and try to remove listeners for orphaned subscriptions, without waiting for an event? And maybe, after a (long enough) while, simply get rid of the subscription?