### PR TITLE
HazelcastClientFactory.StartClientAsync

### DIFF
--- a/doc/dev/doc/building.md
+++ b/doc/dev/doc/building.md
@@ -13,7 +13,7 @@ Although the solution builds in Visual Studio or Rider, a complete build require
 For a complete build, start a Powershell console and build with:
 
 ```powershell
-PS> build/build.ps1 <options> <targets>
+PS> ./hz.ps1 <options> <targets>
 ```
 
 See the build script section below for details and arguments.
@@ -31,18 +31,11 @@ At the moment it is not possible to build the documentation on Linux, as DocFX d
 Powershell must be installed (see [Installing Powershell Core on Linux](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux)
 for instructions).
 
-In order to run tests, Java and Maven are required. For Debian:
+In order to run tests, Java is required. For Debian:
 
 ```sh
 apt-get update
 apt-get install openjdk-11-jre
-apt-get install maven
-```
-
-If Maven gives warnings about "WARNING: An illegal reflective access operation has occurred", you may have to define the following environment variable before building (this is defined automatically in the build script):
-
-```sh
-export MAVEN_OPTS="-Dcom.google.inject.internal.cglib.\$experimental_asm7=true --add-opens java.base/java.lang=ALL-UNNAMED"
 ```
 
 ### Building
@@ -50,14 +43,14 @@ export MAVEN_OPTS="-Dcom.google.inject.internal.cglib.\$experimental_asm7=true -
 From a shell console, build with:
 
 ```sh
-$ pwsh build/build.sh <options> <targets>
+$ ./hz.sh <options> <targets>
 ```
 
 See the build script section below for details and arguments.
 
 ## Build Script
 
-On Linux, `build.sh` is just a proxy to `build.ps1`. The actual build is always performed by `build.ps1`, which is common to Windows and Linux. It accepts the following options:
+On Linux, `hz.sh` is just a proxy to `hz.ps1`. The actual build is always performed by `hz.ps1`, which is common to Windows and Linux. It accepts the following options:
 
 * `-enterprise` test enterprise features
 * `-server <version>` the server version to use for tests
@@ -88,7 +81,7 @@ When no target is specified, the script runs `clean`, `build`, `docsIf` and `tes
 For example, after a complete build, one can rebuild and serve the documentation with:
 
 ```powershell
-PS> build/build.ps1 docs,docsServe
+PS> ./hz.ps1 docs,docsServe
 ```
 
 When the `-enterprise` option is set, in order to test the enterprise features, the `HAZELCAST_ENTERPRISE_KEY` environment variable must contain a valid Hazelcast Enterprise key.

--- a/doc/dev/doc/gettingStarted.md
+++ b/doc/dev/doc/gettingStarted.md
@@ -2,13 +2,12 @@
 
 ## Hazelcast client
 
-The Hazelcast client is the entry point to all interactions with an Hazelcast cluster. A client is created by the static @Hazelcast.HazelcastClientFactory. Before it can be used, it needs to be started via the @Hazelcast.IHazelcastClient.StartAsync* method. After it has been used, it needs to be disposed in order to properly release its resources.
+The Hazelcast client is the entry point to all interactions with an Hazelcast cluster. A client is created by the static @Hazelcast.HazelcastClientFactory. After it has been used, it needs to be disposed in order to properly release its resources.
 
 For example:
 
 ```csharp
-var client = HazelcastClientFactory.CreateClient();
-await client.StartAsync();
+var client = await HazelcastClientFactory.StartClientAsync();
 // ... use the client ...
 await client.DisposeAsync();
 ```
@@ -20,7 +19,7 @@ client. In fact, the above example is equivalent to:
 
 ```csharp
 var options = HazelcastOptions.Build();
-var client = HazelcastClientFactory.CreateClient(options);
+var client = await HazelcastClientFactory.StartClientAsync(options);
 // ...
 ```
 
@@ -84,7 +83,7 @@ The client exposes client-level events.
 For example:
 
 ```csharp
-var subscriptionId = await client.SubscribeAsync(handle => handle
+var subscriptionId = await client.SubscribeAsync(events => events
     .ClientStateChanged((sender, args) => {
         Console.WriteLine($"Client state changed to: {args.State}.")
     })
@@ -104,7 +103,7 @@ Each distributed object also exposes events in the same way.
 For example:
 
 ```csharp
-var subscriptionId = await dict.SubscribeAsync(handle => handle
+var subscriptionId = await dict.SubscribeAsync(events => events
     .EntryAdded((sender, args) => {
         // ...
     })

--- a/src/Hazelcast.Net.Examples/Client/ClientLifecycleExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ClientLifecycleExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.Client
         {
             // create an Hazelcast client and connect to a server running on localhost
             var options = HazelcastOptions.Build(args);
-            var hz1 = HazelcastClientFactory.CreateClient(options);
-            await hz1.StartAsync();
+            var hz1 = await HazelcastClientFactory.StartClientAsync(options);
 
             var connected = new SemaphoreSlim(0);
 
@@ -39,8 +38,7 @@ namespace Hazelcast.Examples.Client
                     if (eventArgs.State == ClientLifecycleState.Connected)
                         connected.Release();
                 }));
-            var hz2 = HazelcastClientFactory.CreateClient(options);
-            await hz2.StartAsync();
+            var hz2 = await HazelcastClientFactory.StartClientAsync(options);
 
             // wait for the event
             await connected.WaitAsync();

--- a/src/Hazelcast.Net.Examples/Client/ClientLifecycleExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ClientLifecycleExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.Client
         {
             // create an Hazelcast client and connect to a server running on localhost
             var options = HazelcastOptions.Build(args);
-            var hz1 = await HazelcastClientFactory.StartClientAsync(options);
+            var hz1 = await HazelcastClientFactory.StartNewClientAsync(options);
 
             var connected = new SemaphoreSlim(0);
 
@@ -38,7 +38,7 @@ namespace Hazelcast.Examples.Client
                     if (eventArgs.State == ClientLifecycleState.Connected)
                         connected.Release();
                 }));
-            var hz2 = await HazelcastClientFactory.StartClientAsync(options);
+            var hz2 = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // wait for the event
             await connected.WaitAsync();

--- a/src/Hazelcast.Net.Examples/Client/ClientSslExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ClientSslExample.cs
@@ -37,8 +37,7 @@ namespace Hazelcast.Examples.Client
             //options.Networking.Ssl.CertificateName = "CERTIFICATE CN OR SAN VALUE HERE";
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // use a map
             await using var map = await client.GetDictionaryAsync<string, string>("ssl-example");

--- a/src/Hazelcast.Net.Examples/Client/ClientSslExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ClientSslExample.cs
@@ -37,7 +37,7 @@ namespace Hazelcast.Examples.Client
             //options.Networking.Ssl.CertificateName = "CERTIFICATE CN OR SAN VALUE HERE";
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // use a map
             await using var map = await client.GetDictionaryAsync<string, string>("ssl-example");

--- a/src/Hazelcast.Net.Examples/Client/ClientSslMutualAuthExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ClientSslMutualAuthExample.cs
@@ -34,7 +34,7 @@ namespace Hazelcast.Examples.Client
             options.Networking.Ssl.CertificatePath = "CLIENT_PFX_CERTIFICATE_PATH";
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // use a map
             await using var map = await client.GetDictionaryAsync<string, string>("ssl-example");

--- a/src/Hazelcast.Net.Examples/Client/ClientSslMutualAuthExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ClientSslMutualAuthExample.cs
@@ -34,8 +34,7 @@ namespace Hazelcast.Examples.Client
             options.Networking.Ssl.CertificatePath = "CLIENT_PFX_CERTIFICATE_PATH";
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // use a map
             await using var map = await client.GetDictionaryAsync<string, string>("ssl-example");

--- a/src/Hazelcast.Net.Examples/Client/ClientStatisticsExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ClientStatisticsExample.cs
@@ -39,7 +39,7 @@ namespace Hazelcast.Examples.Client
                 EvictionPolicy = EvictionPolicy.Lru,
                 InMemoryFormat = InMemoryFormat.Binary
             };
-            var hz = await HazelcastClientFactory.StartClientAsync(options);
+            var hz = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get a map
             var map = await hz.GetDictionaryAsync<string, string>("myMap");

--- a/src/Hazelcast.Net.Examples/Client/ClientStatisticsExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ClientStatisticsExample.cs
@@ -39,8 +39,7 @@ namespace Hazelcast.Examples.Client
                 EvictionPolicy = EvictionPolicy.Lru,
                 InMemoryFormat = InMemoryFormat.Binary
             };
-            var hz = HazelcastClientFactory.CreateClient(options);
-            await hz.StartAsync();
+            var hz = await HazelcastClientFactory.StartClientAsync(options);
 
             // get a map
             var map = await hz.GetDictionaryAsync<string, string>("myMap");

--- a/src/Hazelcast.Net.Examples/Client/CloudClientExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/CloudClientExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.Client
             var options = HazelcastOptions.Build();
             options.Networking.Cloud.Enabled = true;
             options.Networking.Cloud.DiscoveryToken = "DISCOVERY_TOKEN_HASH"; // copied from Cloud console
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // use a map
             await using var map = await client.GetDictionaryAsync<string, string>("ssl-example");

--- a/src/Hazelcast.Net.Examples/Client/CloudClientExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/CloudClientExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.Client
             var options = HazelcastOptions.Build();
             options.Networking.Cloud.Enabled = true;
             options.Networking.Cloud.DiscoveryToken = "DISCOVERY_TOKEN_HASH"; // copied from Cloud console
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // use a map
             await using var map = await client.GetDictionaryAsync<string, string>("ssl-example");

--- a/src/Hazelcast.Net.Examples/Client/CloudClientSslExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/CloudClientSslExample.cs
@@ -33,7 +33,7 @@ namespace Hazelcast.Examples.Client
             //ssl.ValidateCertificateChain = false;
             ssl.CertificatePath = "CLIENT_PFX_CERTIFICATE_PATH"; // downloaded from CLoud console
 
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // use a map
             await using var map = await client.GetDictionaryAsync<string, string>("ssl-example");

--- a/src/Hazelcast.Net.Examples/Client/CloudClientSslExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/CloudClientSslExample.cs
@@ -33,8 +33,7 @@ namespace Hazelcast.Examples.Client
             //ssl.ValidateCertificateChain = false;
             ssl.CertificatePath = "CLIENT_PFX_CERTIFICATE_PATH"; // downloaded from CLoud console
 
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // use a map
             await using var map = await client.GetDictionaryAsync<string, string>("ssl-example");

--- a/src/Hazelcast.Net.Examples/Client/ContainerExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ContainerExample.cs
@@ -112,7 +112,7 @@ namespace Hazelcast.Examples.Client
             }
 
             public ValueTask<IHazelcastClient> StartClientAsync()
-                => HazelcastClientFactory.StartClientAsync(_options);
+                => HazelcastClientFactory.StartNewClientAsync(_options);
         }
 
         public class Worker

--- a/src/Hazelcast.Net.Examples/Client/ContainerExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/ContainerExample.cs
@@ -71,15 +71,14 @@ namespace Hazelcast.Examples.Client
                 .Build();
 
             // add hazelcast to services
-            // this adds the options + the client factory
-            // this also wires logging to get a logger from the container
+            // this adds the options, and also wires logging to get a logger from the container
             services.AddHazelcast(configuration);
 
             // add logging to the container, the normal way
             services.AddLogging(builder => builder.AddConfiguration(configuration.GetSection("logging")).AddConsole());
 
-            // add Hazelcast client to the container
-            services.AddTransient(provider => HazelcastClientFactory.CreateClient(provider.GetRequiredService<IOptions<HazelcastOptions>>().Value));
+            // add Hazelcast client custom factory to the container
+            services.AddSingleton<Factory>();
 
             // configure hazelcast (can do it multiple times..)
             services.Configure<HazelcastOptions>(options =>
@@ -87,7 +86,7 @@ namespace Hazelcast.Examples.Client
                 options.Networking.ConnectionTimeoutMilliseconds = 45_000;
             });
 
-            // add the worker
+            // add the worker - which uses the factory to get a client (async)
             services.AddTransient<Worker>();
 
             // create the service provider
@@ -100,14 +99,30 @@ namespace Hazelcast.Examples.Client
             await a.RunAsync();
         }
 
+        public class Factory
+        {
+            // in real-life scenario we may want to cache the client
+            // instead of creating a new one all the time...
+
+            private readonly HazelcastOptions _options;
+
+            public Factory(IOptions<HazelcastOptions> options)
+            {
+                _options = options.Value;
+            }
+
+            public ValueTask<IHazelcastClient> StartClientAsync()
+                => HazelcastClientFactory.StartClientAsync(_options);
+        }
+
         public class Worker
         {
-            private readonly IHazelcastClient _client;
+            private readonly Factory _clientFactory;
             private readonly ILogger<Worker> _logger;
 
-            public Worker(IHazelcastClient client, ILogger<Worker> logger)
+            public Worker(Factory clientFactory, ILogger<Worker> logger)
             {
-                _client = client;
+                _clientFactory = clientFactory;
                 _logger = logger;
             }
 
@@ -117,13 +132,9 @@ namespace Hazelcast.Examples.Client
                 _logger.LogInformation("debug");
                 _logger.LogWarning("debug");
 
-                // this is just an example - practically, connecting the client
-                // would be managed elsewhere - and the class would expect to
-                // receive a connected client - and, that 'elsewhere' would also
-                // dispose the client, etc.
-                await _client.StartAsync();
+                await using var client = await _clientFactory.StartClientAsync();
 
-                await using var map = await _client.GetDictionaryAsync<string, int>("test-map");
+                await using var map = await client.GetDictionaryAsync<string, int>("test-map");
 
                 await map.SetAsync("key", 42);
                 var value = await map.GetAsync("key");
@@ -132,7 +143,7 @@ namespace Hazelcast.Examples.Client
                 Console.WriteLine("It worked.");
 
                 // destroy the map
-                await _client.DestroyAsync(map);
+                await client.DestroyAsync(map);
             }
         }
     }

--- a/src/Hazelcast.Net.Examples/Client/HostedExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/HostedExample.cs
@@ -116,7 +116,7 @@ namespace Hazelcast.Examples.Client
                 _logger.LogInformation("Starting...");
 
                 // open a client
-                var client = await HazelcastClientFactory.StartClientAsync(cancellationToken);
+                var client = await HazelcastClientFactory.StartNewClientAsync(cancellationToken);
 
                 // start the running task
                 _cancel = new CancellationTokenSource();

--- a/src/Hazelcast.Net.Examples/Client/HostedExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/HostedExample.cs
@@ -116,8 +116,7 @@ namespace Hazelcast.Examples.Client
                 _logger.LogInformation("Starting...");
 
                 // open a client
-                var client = HazelcastClientFactory.CreateClient();
-                await client.StartAsync(cancellationToken);
+                var client = await HazelcastClientFactory.StartClientAsync(cancellationToken);
 
                 // start the running task
                 _cancel = new CancellationTokenSource();

--- a/src/Hazelcast.Net.Examples/Client/MemberLifecycleExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/MemberLifecycleExample.cs
@@ -36,7 +36,7 @@ namespace Hazelcast.Examples.Client
             });
 
             // create an Hazelcast client and connect to a server running on localhost
-            var hz = await HazelcastClientFactory.StartClientAsync(options);
+            var hz = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // wait for the event
             await memberAdded.WaitAsync();

--- a/src/Hazelcast.Net.Examples/Client/MemberLifecycleExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/MemberLifecycleExample.cs
@@ -36,8 +36,7 @@ namespace Hazelcast.Examples.Client
             });
 
             // create an Hazelcast client and connect to a server running on localhost
-            var hz = HazelcastClientFactory.CreateClient(options);
-            await hz.StartAsync();
+            var hz = await HazelcastClientFactory.StartClientAsync(options);
 
             // wait for the event
             await memberAdded.WaitAsync();

--- a/src/Hazelcast.Net.Examples/Client/SimpleExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/SimpleExample.cs
@@ -71,7 +71,7 @@ namespace Hazelcast.Examples.Client
 
             // create a logger, a client factory and a client
             var logger = loggerFactory.CreateLogger<Worker>();
-            await using var client = await HazelcastClientFactory.StartClientAsync(options); // disposed when method exits
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options); // disposed when method exits
 
             // create the worker, and run
             var worker = new Worker(client, logger);

--- a/src/Hazelcast.Net.Examples/Client/SimpleExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/SimpleExample.cs
@@ -71,7 +71,7 @@ namespace Hazelcast.Examples.Client
 
             // create a logger, a client factory and a client
             var logger = loggerFactory.CreateLogger<Worker>();
-            await using var client = HazelcastClientFactory.CreateClient(options); // disposed when method exits
+            await using var client = await HazelcastClientFactory.StartClientAsync(options); // disposed when method exits
 
             // create the worker, and run
             var worker = new Worker(client, logger);
@@ -94,12 +94,6 @@ namespace Hazelcast.Examples.Client
                 _logger.LogDebug("debug");
                 _logger.LogInformation("debug");
                 _logger.LogWarning("debug");
-
-                // this is just an example - practically, connecting the client
-                // would be managed elsewhere - and the class would expect to
-                // receive a connected client - and, that 'elsewhere' would also
-                // dispose the client, etc.
-                await _client.StartAsync();
 
                 await using var map = await _client.GetDictionaryAsync<string, int>("test-map");
 

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryAsyncExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryAsyncExample.cs
@@ -27,7 +27,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("simple-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryAsyncExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryAsyncExample.cs
@@ -27,8 +27,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("simple-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryCustomSerializerExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryCustomSerializerExample.cs
@@ -36,8 +36,7 @@ namespace Hazelcast.Examples.DistributedObjects
             });
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var mapCustomers = await client.GetDictionaryAsync<string, Person>("persons");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryCustomSerializerExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryCustomSerializerExample.cs
@@ -36,7 +36,7 @@ namespace Hazelcast.Examples.DistributedObjects
             });
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var mapCustomers = await client.GetDictionaryAsync<string, Person>("persons");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryEntryProcessorExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryEntryProcessorExample.cs
@@ -32,8 +32,7 @@ namespace Hazelcast.Examples.DistributedObjects
                 new EntryProcessorDataSerializableFactory());
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<int, string>("entry-processor-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryEntryProcessorExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryEntryProcessorExample.cs
@@ -32,7 +32,7 @@ namespace Hazelcast.Examples.DistributedObjects
                 new EntryProcessorDataSerializableFactory());
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<int, string>("entry-processor-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryEventsExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryEventsExample.cs
@@ -27,7 +27,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("listener-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryEventsExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryEventsExample.cs
@@ -27,8 +27,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("listener-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryIdentifiedDataSerializableExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryIdentifiedDataSerializableExample.cs
@@ -32,8 +32,7 @@ namespace Hazelcast.Examples.DistributedObjects
                 new ExampleDataSerializableFactory());
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<int, Employee>("identified-data-serializable-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryIdentifiedDataSerializableExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryIdentifiedDataSerializableExample.cs
@@ -32,7 +32,7 @@ namespace Hazelcast.Examples.DistributedObjects
                 new ExampleDataSerializableFactory());
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<int, Employee>("identified-data-serializable-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryJsonExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryJsonExample.cs
@@ -27,8 +27,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, HazelcastJsonValue>("json-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryJsonExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryJsonExample.cs
@@ -27,7 +27,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, HazelcastJsonValue>("json-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryLockExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryLockExample.cs
@@ -46,7 +46,7 @@ namespace Hazelcast.Examples.DistributedObjects
             using var used = options.Logging.LoggerFactory;
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("map-lock-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryLockExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryLockExample.cs
@@ -46,8 +46,7 @@ namespace Hazelcast.Examples.DistributedObjects
             using var used = options.Logging.LoggerFactory;
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("map-lock-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryNearCacheExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryNearCacheExample.cs
@@ -38,8 +38,7 @@ namespace Hazelcast.Examples.DistributedObjects
             };
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("nearcache-map-1");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryNearCacheExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryNearCacheExample.cs
@@ -38,7 +38,7 @@ namespace Hazelcast.Examples.DistributedObjects
             };
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("nearcache-map-1");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryPartitionPredicateExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryPartitionPredicateExample.cs
@@ -27,7 +27,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<int, int>("predicate-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryPartitionPredicateExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryPartitionPredicateExample.cs
@@ -27,8 +27,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<int, int>("predicate-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryPortableExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryPortableExample.cs
@@ -39,8 +39,7 @@ namespace Hazelcast.Examples.DistributedObjects
             */
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var hz = HazelcastClientFactory.CreateClient(options);
-            await hz.StartAsync();
+            await using var hz = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await hz.GetDictionaryAsync<int, Customer>("portable-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryPortableExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionaryPortableExample.cs
@@ -39,7 +39,7 @@ namespace Hazelcast.Examples.DistributedObjects
             */
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var hz = await HazelcastClientFactory.StartClientAsync(options);
+            await using var hz = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await hz.GetDictionaryAsync<int, Customer>("portable-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionarySimpleExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionarySimpleExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("simple-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/DictionarySimpleExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/DictionarySimpleExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetDictionaryAsync<string, string>("simple-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/ListEventsExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/ListEventsExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get a distributed list from the cluster
             await using var list = await client.GetListAsync<string>("collection-listener-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/ListEventsExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/ListEventsExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get a distributed list from the cluster
             await using var list = await client.GetListAsync<string>("collection-listener-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/ListExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/ListExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var list = await client.GetListAsync<string>("list-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/ListExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/ListExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var list = await client.GetListAsync<string>("list-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/MultiDictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/MultiDictionaryExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetMultiDictionaryAsync<string, string>("multimap-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/MultiDictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/MultiDictionaryExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetMultiDictionaryAsync<string, string>("multimap-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/QueueExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/QueueExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed queue from the cluster
             await using var queue = await client.GetQueueAsync<string>("queue-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/QueueExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/QueueExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed queue from the cluster
             await using var queue = await client.GetQueueAsync<string>("queue-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/ReplicatedDictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/ReplicatedDictionaryExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetReplicatedDictionaryAsync<string, string>("replicatedMap-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/ReplicatedDictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/ReplicatedDictionaryExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed map from the cluster
             await using var map = await client.GetReplicatedDictionaryAsync<string, string>("replicatedMap-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/RingBufferExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/RingBufferExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed ring buffer from the cluster
             await using var ringBuffer = await client.GetRingBufferAsync<string>("ringbuffer-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/RingBufferExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/RingBufferExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed ring buffer from the cluster
             await using var ringBuffer = await client.GetRingBufferAsync<string>("ringbuffer-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/SetExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/SetExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get the distributed set from the cluster
             await using var set = await client.GetSetAsync<string>("set-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/SetExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/SetExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get the distributed set from the cluster
             await using var set = await client.GetSetAsync<string>("set-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/TopicExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/TopicExample.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // get distributed topic from cluster
             await using var topic = await client.GetTopicAsync<string>("topic-example");

--- a/src/Hazelcast.Net.Examples/DistributedObjects/TopicExample.cs
+++ b/src/Hazelcast.Net.Examples/DistributedObjects/TopicExample.cs
@@ -26,8 +26,7 @@ namespace Hazelcast.Examples.DistributedObjects
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // get distributed topic from cluster
             await using var topic = await client.GetTopicAsync<string>("topic-example");

--- a/src/Hazelcast.Net.Examples/Transactions/BenchmarkExample.cs
+++ b/src/Hazelcast.Net.Examples/Transactions/BenchmarkExample.cs
@@ -28,7 +28,7 @@ namespace Hazelcast.Examples.Transactions
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             var map1 = await client.GetDictionaryAsync<int, string>("test1");
             var map2 = await client.GetDictionaryAsync<int, string>("test2");

--- a/src/Hazelcast.Net.Examples/Transactions/BenchmarkExample.cs
+++ b/src/Hazelcast.Net.Examples/Transactions/BenchmarkExample.cs
@@ -28,8 +28,7 @@ namespace Hazelcast.Examples.Transactions
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             var map1 = await client.GetDictionaryAsync<int, string>("test1");
             var map2 = await client.GetDictionaryAsync<int, string>("test2");

--- a/src/Hazelcast.Net.Examples/Transactions/SimpleExample.cs
+++ b/src/Hazelcast.Net.Examples/Transactions/SimpleExample.cs
@@ -27,7 +27,7 @@ namespace Hazelcast.Examples.Transactions
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // begin a transaction
             await using (var transactionContext = await client.BeginTransactionAsync(

--- a/src/Hazelcast.Net.Examples/Transactions/SimpleExample.cs
+++ b/src/Hazelcast.Net.Examples/Transactions/SimpleExample.cs
@@ -27,8 +27,7 @@ namespace Hazelcast.Examples.Transactions
             var options = BuildExampleOptions(args);
 
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // begin a transaction
             await using (var transactionContext = await client.BeginTransactionAsync(

--- a/src/Hazelcast.Net.Examples/WebSite/CustomSerializerExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/CustomSerializerExample.cs
@@ -60,8 +60,7 @@ namespace Hazelcast.Examples.WebSite
                 SerializedType = typeof(CustomSerializableType),
                 Creator = () => new CustomSerializer()
             });
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             //CustomSerializer will serialize/deserialize CustomSerializable objects
         }

--- a/src/Hazelcast.Net.Examples/WebSite/CustomSerializerExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/CustomSerializerExample.cs
@@ -60,7 +60,7 @@ namespace Hazelcast.Examples.WebSite
                 SerializedType = typeof(CustomSerializableType),
                 Creator = () => new CustomSerializer()
             });
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             //CustomSerializer will serialize/deserialize CustomSerializable objects
         }

--- a/src/Hazelcast.Net.Examples/WebSite/DictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/DictionaryExample.cs
@@ -22,7 +22,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(BuildExampleOptions(args));
 
             // get distributed map from cluster
             await using var map = await client.GetDictionaryAsync<string, string>("my-distributed-map");

--- a/src/Hazelcast.Net.Examples/WebSite/DictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/DictionaryExample.cs
@@ -22,8 +22,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(BuildExampleOptions(args));
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
 
             // get distributed map from cluster
             await using var map = await client.GetDictionaryAsync<string, string>("my-distributed-map");

--- a/src/Hazelcast.Net.Examples/WebSite/EntryProcessorExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/EntryProcessorExample.cs
@@ -58,8 +58,7 @@ namespace Hazelcast.Examples.WebSite
                 EntryProcessorDataSerializableFactory.FactoryId,
                 new EntryProcessorDataSerializableFactory());
 
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // Get the Distributed Map from Cluster.
             await using var map = await client.GetDictionaryAsync<string, string>("my-distributed-map");

--- a/src/Hazelcast.Net.Examples/WebSite/EntryProcessorExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/EntryProcessorExample.cs
@@ -58,7 +58,7 @@ namespace Hazelcast.Examples.WebSite
                 EntryProcessorDataSerializableFactory.FactoryId,
                 new EntryProcessorDataSerializableFactory());
 
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // Get the Distributed Map from Cluster.
             await using var map = await client.GetDictionaryAsync<string, string>("my-distributed-map");

--- a/src/Hazelcast.Net.Examples/WebSite/GlobalSerializerExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/GlobalSerializerExample.cs
@@ -54,7 +54,7 @@ namespace Hazelcast.Examples.WebSite
             {
                 Creator = () => new GlobalSerializer()
             };
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             //GlobalSerializer will serialize/deserialize all non-builtin types
         }

--- a/src/Hazelcast.Net.Examples/WebSite/GlobalSerializerExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/GlobalSerializerExample.cs
@@ -54,8 +54,7 @@ namespace Hazelcast.Examples.WebSite
             {
                 Creator = () => new GlobalSerializer()
             };
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             //GlobalSerializer will serialize/deserialize all non-builtin types
         }

--- a/src/Hazelcast.Net.Examples/WebSite/IdentifiedDataSerializableExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/IdentifiedDataSerializableExample.cs
@@ -60,7 +60,7 @@ namespace Hazelcast.Examples.WebSite
             // create an Hazelcast client and connect to a server running on localhost
             var options = BuildExampleOptions(args);
             options.Serialization.AddDataSerializableFactory(SampleDataSerializableFactory.FactoryId, new SampleDataSerializableFactory());
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
         }
     }
 }

--- a/src/Hazelcast.Net.Examples/WebSite/IdentifiedDataSerializableExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/IdentifiedDataSerializableExample.cs
@@ -60,8 +60,7 @@ namespace Hazelcast.Examples.WebSite
             // create an Hazelcast client and connect to a server running on localhost
             var options = BuildExampleOptions(args);
             options.Serialization.AddDataSerializableFactory(SampleDataSerializableFactory.FactoryId, new SampleDataSerializableFactory());
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
         }
     }
 }

--- a/src/Hazelcast.Net.Examples/WebSite/ListExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/ListExample.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(BuildExampleOptions(args));
 
             // Get the Distributed List from Cluster.
             await using var list = await client.GetListAsync<string>("my-distributed-list");

--- a/src/Hazelcast.Net.Examples/WebSite/ListExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/ListExample.cs
@@ -23,8 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(BuildExampleOptions(args));
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
 
             // Get the Distributed List from Cluster.
             await using var list = await client.GetListAsync<string>("my-distributed-list");

--- a/src/Hazelcast.Net.Examples/WebSite/MultiDictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/MultiDictionaryExample.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(BuildExampleOptions(args));
 
             // Get the Distributed MultiMap from Cluster.
             await using var multiMap = await client.GetMultiDictionaryAsync<string, string>("my-distributed-multimap");

--- a/src/Hazelcast.Net.Examples/WebSite/MultiDictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/MultiDictionaryExample.cs
@@ -23,8 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(BuildExampleOptions(args));
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
 
             // Get the Distributed MultiMap from Cluster.
             await using var multiMap = await client.GetMultiDictionaryAsync<string, string>("my-distributed-multimap");

--- a/src/Hazelcast.Net.Examples/WebSite/PortableSerializableExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/PortableSerializableExample.cs
@@ -64,8 +64,7 @@ namespace Hazelcast.Examples.WebSite
             // create an Hazelcast client and connect to a server running on localhost
             var options = BuildExampleOptions(args);
             options.Serialization.AddPortableFactory(SamplePortableFactory.FactoryId, new SamplePortableFactory());
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
         }
     }
 }

--- a/src/Hazelcast.Net.Examples/WebSite/PortableSerializableExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/PortableSerializableExample.cs
@@ -64,7 +64,7 @@ namespace Hazelcast.Examples.WebSite
             // create an Hazelcast client and connect to a server running on localhost
             var options = BuildExampleOptions(args);
             options.Serialization.AddPortableFactory(SamplePortableFactory.FactoryId, new SamplePortableFactory());
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
         }
     }
 }

--- a/src/Hazelcast.Net.Examples/WebSite/QueryExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/QueryExample.cs
@@ -79,7 +79,7 @@ namespace Hazelcast.Examples.WebSite
             // create an Hazelcast client and connect to a server running on localhost
             var options = BuildExampleOptions(args);
             options.Serialization.AddPortableFactory(PortableFactory.FactoryId, new PortableFactory());
-            await using var client = await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
             // Get a Distributed Map called "users"
             await using var users = await client.GetDictionaryAsync<string, User>("users");

--- a/src/Hazelcast.Net.Examples/WebSite/QueryExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/QueryExample.cs
@@ -79,8 +79,7 @@ namespace Hazelcast.Examples.WebSite
             // create an Hazelcast client and connect to a server running on localhost
             var options = BuildExampleOptions(args);
             options.Serialization.AddPortableFactory(PortableFactory.FactoryId, new PortableFactory());
-            await using var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(options);
 
             // Get a Distributed Map called "users"
             await using var users = await client.GetDictionaryAsync<string, User>("users");

--- a/src/Hazelcast.Net.Examples/WebSite/QueueExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/QueueExample.cs
@@ -23,8 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(BuildExampleOptions(args));
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
 
             // Get a Blocking Queue called "my-distributed-queue"
             var queue = await client.GetQueueAsync<string>("my-distributed-queue");

--- a/src/Hazelcast.Net.Examples/WebSite/QueueExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/QueueExample.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(BuildExampleOptions(args));
 
             // Get a Blocking Queue called "my-distributed-queue"
             var queue = await client.GetQueueAsync<string>("my-distributed-queue");

--- a/src/Hazelcast.Net.Examples/WebSite/ReplicatedDictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/ReplicatedDictionaryExample.cs
@@ -23,8 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(BuildExampleOptions(args));
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
 
             // Get a Replicated Map called "my-replicated-map"
             await using var map = await client.GetReplicatedDictionaryAsync<string, string>("my-replicated-map");

--- a/src/Hazelcast.Net.Examples/WebSite/ReplicatedDictionaryExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/ReplicatedDictionaryExample.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(BuildExampleOptions(args));
 
             // Get a Replicated Map called "my-replicated-map"
             await using var map = await client.GetReplicatedDictionaryAsync<string, string>("my-replicated-map");

--- a/src/Hazelcast.Net.Examples/WebSite/RingBufferExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/RingBufferExample.cs
@@ -23,8 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(BuildExampleOptions(args));
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
 
             await using var rb = await client.GetRingBufferAsync<long>("rb");
 

--- a/src/Hazelcast.Net.Examples/WebSite/RingBufferExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/RingBufferExample.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(BuildExampleOptions(args));
 
             await using var rb = await client.GetRingBufferAsync<long>("rb");
 

--- a/src/Hazelcast.Net.Examples/WebSite/SetExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/SetExample.cs
@@ -23,8 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(BuildExampleOptions(args));
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
 
             // Get the Distributed Set from Cluster.
             await using var set = await client.GetSetAsync<string>("my-distributed-set");

--- a/src/Hazelcast.Net.Examples/WebSite/SetExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/SetExample.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(BuildExampleOptions(args));
 
             // Get the Distributed Set from Cluster.
             await using var set = await client.GetSetAsync<string>("my-distributed-set");

--- a/src/Hazelcast.Net.Examples/WebSite/TopicExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/TopicExample.cs
@@ -29,7 +29,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(BuildExampleOptions(args));
 
             // get distributed topic from cluster
             await using var topic = await client.GetTopicAsync<string>("my-distributed-topic");

--- a/src/Hazelcast.Net.Examples/WebSite/TopicExample.cs
+++ b/src/Hazelcast.Net.Examples/WebSite/TopicExample.cs
@@ -29,8 +29,7 @@ namespace Hazelcast.Examples.WebSite
         public static async Task Run(string[] args)
         {
             // create an Hazelcast client and connect to a server running on localhost
-            await using var client = HazelcastClientFactory.CreateClient(BuildExampleOptions(args));
-            await client.StartAsync();
+            await using var client = await HazelcastClientFactory.StartClientAsync(BuildExampleOptions(args));
 
             // get distributed topic from cluster
             await using var topic = await client.GetTopicAsync<string>("my-distributed-topic");

--- a/src/Hazelcast.Net.Testing/RemoteTestBase.cs
+++ b/src/Hazelcast.Net.Testing/RemoteTestBase.cs
@@ -70,8 +70,7 @@ namespace Hazelcast.Testing
         {
             Logger.LogInformation("Create new client");
 
-            var client = HazelcastClientFactory.CreateClient(CreateHazelcastOptions());
-            await client.StartAsync(CreateAndStartClientTimeout).CAF();
+            var client = await HazelcastClientFactory.StartClientAsync(CreateHazelcastOptions(), CreateAndStartClientTimeout).CAF();
             return client;
         }
 
@@ -85,8 +84,7 @@ namespace Hazelcast.Testing
 
             var options = CreateHazelcastOptions();
             configure(options);
-            var client = HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync(CreateAndStartClientTimeout).CAF();
+            var client = await HazelcastClientFactory.StartClientAsync(options, CreateAndStartClientTimeout).CAF();
             return client;
         }
 

--- a/src/Hazelcast.Net.Testing/RemoteTestBase.cs
+++ b/src/Hazelcast.Net.Testing/RemoteTestBase.cs
@@ -70,7 +70,7 @@ namespace Hazelcast.Testing
         {
             Logger.LogInformation("Create new client");
 
-            var client = await HazelcastClientFactory.StartClientAsync(CreateHazelcastOptions(), CreateAndStartClientTimeout).CAF();
+            var client = await HazelcastClientFactory.StartNewClientAsync(CreateHazelcastOptions(), CreateAndStartClientTimeout).CAF();
             return client;
         }
 
@@ -84,7 +84,7 @@ namespace Hazelcast.Testing
 
             var options = CreateHazelcastOptions();
             configure(options);
-            var client = await HazelcastClientFactory.StartClientAsync(options, CreateAndStartClientTimeout).CAF();
+            var client = await HazelcastClientFactory.StartNewClientAsync(options, CreateAndStartClientTimeout).CAF();
             return client;
         }
 

--- a/src/Hazelcast.Net.Tests/Clustering/OrphanSubscriptionTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/OrphanSubscriptionTests.cs
@@ -101,7 +101,7 @@ namespace Hazelcast.Tests.Clustering
                 options.Networking.Addresses.Add("127.0.0.1:11002");
                 options.Events.SubscriptionCollectDelay = TimeSpan.FromSeconds(4); // don't go too fast
             });
-            await using var client = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = (HazelcastClient) await HazelcastClientFactory.StartNewClientAsync(options);
 
             HConsole.WriteLine(this, "Get dictionary");
 

--- a/src/Hazelcast.Net.Tests/Clustering/OrphanSubscriptionTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/OrphanSubscriptionTests.cs
@@ -101,8 +101,7 @@ namespace Hazelcast.Tests.Clustering
                 options.Networking.Addresses.Add("127.0.0.1:11002");
                 options.Events.SubscriptionCollectDelay = TimeSpan.FromSeconds(4); // don't go too fast
             });
-            await using var client = (HazelcastClient)HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync().CAF();
+            await using var client = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
 
             HConsole.WriteLine(this, "Get dictionary");
 

--- a/src/Hazelcast.Net.Tests/HazelcastClientFactoryTests.cs
+++ b/src/Hazelcast.Net.Tests/HazelcastClientFactoryTests.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Threading.Tasks;
+using Hazelcast.Testing;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests
@@ -21,26 +23,13 @@ namespace Hazelcast.Tests
     public class HazelcastClientFactoryTests
     {
         [Test]
-        public void CreateClient()
+        public async Task Exceptions()
         {
-            var client = HazelcastClientFactory.CreateClient();
-            Assert.That(client, Is.Not.Null);
-
-            client = HazelcastClientFactory.CreateClient(options =>
-            {
-                options.ClientName = "clientName";
-            });
-            Assert.That(client, Is.Not.Null);
-
-            client = HazelcastClientFactory.CreateClient(new HazelcastOptions());
-            Assert.That(client, Is.Not.Null);
-        }
-
-        [Test]
-        public void Exceptions()
-        {
-            Assert.Throws<ArgumentNullException>(() => HazelcastClientFactory.CreateClient((HazelcastOptions) null));
-            Assert.Throws<ArgumentNullException>(() => HazelcastClientFactory.CreateClient((Action<HazelcastOptions>)null));
+            await AssertEx.ThrowsAsync<ArgumentNullException>(async () 
+                => await HazelcastClientFactory.StartClientAsync((HazelcastOptions) null));
+            
+            await AssertEx.ThrowsAsync<ArgumentNullException>(async () => 
+                await HazelcastClientFactory.StartClientAsync((Action<HazelcastOptions>) null));
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/HazelcastClientFactoryTests.cs
+++ b/src/Hazelcast.Net.Tests/HazelcastClientFactoryTests.cs
@@ -26,10 +26,10 @@ namespace Hazelcast.Tests
         public async Task Exceptions()
         {
             await AssertEx.ThrowsAsync<ArgumentNullException>(async () 
-                => await HazelcastClientFactory.StartClientAsync((HazelcastOptions) null));
+                => await HazelcastClientFactory.StartNewClientAsync((HazelcastOptions) null));
             
             await AssertEx.ThrowsAsync<ArgumentNullException>(async () => 
-                await HazelcastClientFactory.StartClientAsync((Action<HazelcastOptions>) null));
+                await HazelcastClientFactory.StartNewClientAsync((Action<HazelcastOptions>) null));
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslMutualAuthTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslMutualAuthTests.cs
@@ -27,7 +27,7 @@ namespace Hazelcast.Tests.Networking
         [Test]
         public async Task TestSSLEnabled_mutualAuthRequired_Server1KnowsClient1()
         {
-            await using var client = await Setup(Resources.Cluster_MA_Required,
+            await using var client = await StartClientAsync(Resources.Cluster_MA_Required,
                 true,
                 true,
                 null,
@@ -35,14 +35,14 @@ namespace Hazelcast.Tests.Networking
                 null,
                 Resources.Cert_Client1,
                 Password);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLEnabled_mutualAuthRequired_Server1KnowsClient1_clientDoesNotProvideCerts()
         {
-            await using var client = await Setup(Resources.Cluster_MA_Required,
+            await AssertEx.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await using var client = await StartClientAsync(Resources.Cluster_MA_Required,
                 true,
                 true,
                 null,
@@ -51,30 +51,30 @@ namespace Hazelcast.Tests.Networking
                 null,
                 null,
                 true);
-
-            Assert.ThrowsAsync<InvalidOperationException>(() => client.StartAsync());
+            });
         }
 
         [Test]
         public async Task TestSSLEnabled_mutualAuthRequired_Server1NotKnowsClient2()
         {
-            await using var client = await Setup(Resources.Cluster_MA_Required,
-                true,
-                true,
-                null,
-                null,
-                null,
-                Resources.Cert_Client2,
-                Password,
-                true);
-
-            Assert.ThrowsAsync<InvalidOperationException>(() => client.StartAsync());
+            await AssertEx.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await using var client = await StartClientAsync(Resources.Cluster_MA_Required,
+                    true,
+                    true,
+                    null,
+                    null,
+                    null,
+                    Resources.Cert_Client2,
+                    Password,
+                    true);
+            });
         }
 
         [Test]
         public async Task TestSSLEnabled_mutualAuthOptional_Server1KnowsClient1()
         {
-            await using var client = await Setup(Resources.Cluster_MA_Optional,
+            await using var client = await StartClientAsync(Resources.Cluster_MA_Optional,
                 true,
                 true,
                 null,
@@ -82,14 +82,12 @@ namespace Hazelcast.Tests.Networking
                 null,
                 Resources.Cert_Client1,
                 Password);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLEnabled_mutualAuthOptional_Server1KnowsClient1_clientDoesNotProvideCerts()
         {
-            await using var client = await Setup(Resources.Cluster_MA_Optional,
+            await using var client = await StartClientAsync(Resources.Cluster_MA_Optional,
                 true,
                 true,
                 null,
@@ -97,30 +95,29 @@ namespace Hazelcast.Tests.Networking
                 null,
                 null,
                 null);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLEnabled_mutualAuthOptional_Server1NotKnowsClient2()
         {
-            await using var client = await Setup(Resources.Cluster_MA_Optional,
-                true,
-                true,
-                null,
-                null,
-                null,
-                Resources.Cert_Client2,
-                Password,
-                true);
-
-            Assert.ThrowsAsync<InvalidOperationException>(() => client.StartAsync());
+            await AssertEx.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await using var client = await StartClientAsync(Resources.Cluster_MA_Optional,
+                    true,
+                    true,
+                    null,
+                    null,
+                    null,
+                    Resources.Cert_Client2,
+                    Password,
+                    true);
+            });
         }
 
         [Test]
         public async Task TestSSLEnabled_mutualAuthDisabled_Client1()
         {
-            await using var client = await Setup(Resources.Cluster_Ssl_Signed,
+            await using var client = await StartClientAsync(Resources.Cluster_Ssl_Signed,
                 true,
                 true,
                 null,
@@ -128,8 +125,6 @@ namespace Hazelcast.Tests.Networking
                 null,
                 Resources.Cert_Client1,
                 Password);
-
-            await client.StartAsync(); // succeeds
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
@@ -121,7 +121,7 @@ namespace Hazelcast.Tests.Networking
                 if (certPassword != null) sslOptions.CertificatePassword = certPassword;
             }
 
-            return await HazelcastClientFactory.StartClientAsync(options);
+            return await HazelcastClientFactory.StartNewClientAsync(options);
         }
 
         private static string CreateTmpFile(byte[] cert)

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
@@ -87,7 +87,7 @@ namespace Hazelcast.Tests.Networking
             }
         }
 
-        protected async Task<IHazelcastClient> Setup(string serverXml, bool enableSsl, bool? validateCertificateChain,
+        protected async ValueTask<IHazelcastClient> StartClientAsync(string serverXml, bool enableSsl, bool? validateCertificateChain,
             bool? validateCertificateName, bool? checkCertificateRevocation, string certSubjectName, byte[] clientCertificate,
             string certPassword, bool failFast = false)
         {
@@ -121,7 +121,7 @@ namespace Hazelcast.Tests.Networking
                 if (certPassword != null) sslOptions.CertificatePassword = certPassword;
             }
 
-            return HazelcastClientFactory.CreateClient(options);
+            return await HazelcastClientFactory.StartClientAsync(options);
         }
 
         private static string CreateTmpFile(byte[] cert)

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslTests.cs
@@ -14,7 +14,9 @@
 
 using System;
 using System.Threading.Tasks;
+using Hazelcast.Testing;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace Hazelcast.Tests.Networking
 {
@@ -25,7 +27,7 @@ namespace Hazelcast.Tests.Networking
         [Test]
         public async Task Test_NoSSL()
         {
-            await using var client = await Setup(Hazelcast.Testing.Remote.Resources.hazelcast,
+            await using var client = await StartClientAsync(Hazelcast.Testing.Remote.Resources.hazelcast,
                 false,
                 true,
                 true,
@@ -33,14 +35,12 @@ namespace Hazelcast.Tests.Networking
                 ValidCertNameSigned,
                 null,
                 null);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLEnabled_validateName_validName()
         {
-            await using var client = await Setup(Resources.Cluster_Ssl_Signed,
+            await using var client = await StartClientAsync(Resources.Cluster_Ssl_Signed,
                 true,
                 true,
                 true,
@@ -48,30 +48,29 @@ namespace Hazelcast.Tests.Networking
                 ValidCertNameSigned,
                 null,
                 null);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLEnabled_validateName_invalidName()
         {
-            await using var client = await Setup(Resources.Cluster_Ssl_Signed,
-                true,
-                true,
-                true,
-                null,
-                "Invalid Cert Name",
-                null,
-                null,
-                true);
-
-            Assert.ThrowsAsync<InvalidOperationException>(() => client.StartAsync());
+            await AssertEx.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await using var client = await StartClientAsync(Resources.Cluster_Ssl_Signed,
+                    true,
+                    true,
+                    true,
+                    null,
+                    "Invalid Cert Name",
+                    null,
+                    null,
+                    true);
+            });
         }
 
         [Test]
         public async Task TestSSLEnabled_validateChain_DoNotValidateName_invalidName()
         {
-            await using var client = await Setup(Resources.Cluster_Ssl_Signed,
+            await using var client = await StartClientAsync(Resources.Cluster_Ssl_Signed,
                 true,
                 true,
                 false,
@@ -79,14 +78,12 @@ namespace Hazelcast.Tests.Networking
                 "Invalid Cert Name",
                 null,
                 null);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLEnabled_DoNotValidateChain_DoNotValidateName_invalidName()
         {
-            await using var client = await Setup(Resources.Cluster_Ssl_Signed,
+            await using var client = await StartClientAsync(Resources.Cluster_Ssl_Signed,
                 true,
                 false,
                 false,
@@ -94,14 +91,12 @@ namespace Hazelcast.Tests.Networking
                 "Invalid Cert Name",
                 null,
                 null);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLDisabled()
         {
-            await using var client = await Setup(Resources.Cluster_Default,
+            await using var client = await StartClientAsync(Resources.Cluster_Default,
                 false,
                 null,
                 null,
@@ -109,30 +104,29 @@ namespace Hazelcast.Tests.Networking
                 null,
                 null,
                 null);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLEnabled_self_signed_remote_cert()
         {
-            await using var client = await Setup(Resources.Cluster_Ssl,
-                true,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                true);
-
-            Assert.ThrowsAsync<InvalidOperationException>(() => client.StartAsync());
+            await AssertEx.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await using var client = await StartClientAsync(Resources.Cluster_Ssl,
+                    true,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    true);
+            });
         }
 
         [Test]
         public async Task TestSSLEnabled_signed_remote_cert()
         {
-            await using var client = await Setup(Resources.Cluster_Ssl_Signed,
+            await using var client = await StartClientAsync(Resources.Cluster_Ssl_Signed,
                 true,
                 null,
                 null,
@@ -140,14 +134,12 @@ namespace Hazelcast.Tests.Networking
                 null,
                 null,
                 null);
-
-            await client.StartAsync(); // succeeds
         }
 
         [Test]
         public async Task TestSSLEnabled_validateChain_validateName_validName()
         {
-            await using var client = await Setup(Resources.Cluster_Ssl_Signed,
+            await using var client = await StartClientAsync(Resources.Cluster_Ssl_Signed,
                 true,
                 null,
                 true,
@@ -155,8 +147,6 @@ namespace Hazelcast.Tests.Networking
                 ValidCertNameSigned,
                 null,
                 null);
-
-            await client.StartAsync(); // succeeds
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/Networking/NetworkingTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/NetworkingTests.cs
@@ -223,7 +223,7 @@ namespace Hazelcast.Tests.Networking
             {
                 options.Networking.Addresses.Add("127.0.0.1:11001");
             });
-            await using var client = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = (HazelcastClient) await HazelcastClientFactory.StartNewClientAsync(options);
 
             HConsole.WriteLine(this, "Send message");
             var message = ClientPingServerCodec.EncodeRequest();
@@ -272,7 +272,7 @@ namespace Hazelcast.Tests.Networking
             {
                 options.Networking.Addresses.Add("127.0.0.1:11001");
             });
-            await using var client = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = (HazelcastClient) await HazelcastClientFactory.StartNewClientAsync(options);
 
             HConsole.WriteLine(this, "Send message");
             var message = ClientPingServerCodec.EncodeRequest();
@@ -313,7 +313,7 @@ namespace Hazelcast.Tests.Networking
             {
                 options.Networking.Addresses.Add("127.0.0.1:11001");
             });
-            await using var client = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
+            await using var client = (HazelcastClient) await HazelcastClientFactory.StartNewClientAsync(options);
 
             HConsole.WriteLine(this, "Send message");
             var message = ClientPingServerCodec.EncodeRequest();
@@ -352,7 +352,7 @@ namespace Hazelcast.Tests.Networking
             });
 
             HConsole.WriteLine(this, "Start client 1");
-            await using var client1 = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
+            await using var client1 = (HazelcastClient) await HazelcastClientFactory.StartNewClientAsync(options);
 
             HConsole.WriteLine(this, "Send message 1 to client 1");
             var message = CreateMessage("ping");
@@ -361,7 +361,7 @@ namespace Hazelcast.Tests.Networking
             HConsole.WriteLine(this, "Got response: " + GetText(response));
 
             HConsole.WriteLine(this, "Start client 2");
-            await using var client2 = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
+            await using var client2 = (HazelcastClient) await HazelcastClientFactory.StartNewClientAsync(options);
 
             HConsole.WriteLine(this, "Send message 1 to client 2");
             message = CreateMessage("a");
@@ -406,7 +406,7 @@ namespace Hazelcast.Tests.Networking
             });
 
             HConsole.WriteLine(this, "Start client 1");
-            await using var client1 = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
+            await using var client1 = (HazelcastClient) await HazelcastClientFactory.StartNewClientAsync(options);
 
             HConsole.WriteLine(this, "Send message 1 to client 1");
             var message = CreateMessage("ping");

--- a/src/Hazelcast.Net.Tests/Networking/NetworkingTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/NetworkingTests.cs
@@ -223,8 +223,7 @@ namespace Hazelcast.Tests.Networking
             {
                 options.Networking.Addresses.Add("127.0.0.1:11001");
             });
-            await using var client = (HazelcastClient) HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync().CAF();
+            await using var client = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
 
             HConsole.WriteLine(this, "Send message");
             var message = ClientPingServerCodec.EncodeRequest();
@@ -273,8 +272,7 @@ namespace Hazelcast.Tests.Networking
             {
                 options.Networking.Addresses.Add("127.0.0.1:11001");
             });
-            await using var client = (HazelcastClient) HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync().CAF();
+            await using var client = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
 
             HConsole.WriteLine(this, "Send message");
             var message = ClientPingServerCodec.EncodeRequest();
@@ -315,8 +313,7 @@ namespace Hazelcast.Tests.Networking
             {
                 options.Networking.Addresses.Add("127.0.0.1:11001");
             });
-            await using var client = (HazelcastClient) HazelcastClientFactory.CreateClient(options);
-            await client.StartAsync().CAF();
+            await using var client = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
 
             HConsole.WriteLine(this, "Send message");
             var message = ClientPingServerCodec.EncodeRequest();
@@ -355,8 +352,7 @@ namespace Hazelcast.Tests.Networking
             });
 
             HConsole.WriteLine(this, "Start client 1");
-            await using var client1 = (HazelcastClient)HazelcastClientFactory.CreateClient(options);
-            await client1.StartAsync().CAF();
+            await using var client1 = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
 
             HConsole.WriteLine(this, "Send message 1 to client 1");
             var message = CreateMessage("ping");
@@ -365,8 +361,7 @@ namespace Hazelcast.Tests.Networking
             HConsole.WriteLine(this, "Got response: " + GetText(response));
 
             HConsole.WriteLine(this, "Start client 2");
-            await using var client2 = (HazelcastClient)HazelcastClientFactory.CreateClient(options);
-            await client2.StartAsync().CAF();
+            await using var client2 = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
 
             HConsole.WriteLine(this, "Send message 1 to client 2");
             message = CreateMessage("a");
@@ -411,8 +406,7 @@ namespace Hazelcast.Tests.Networking
             });
 
             HConsole.WriteLine(this, "Start client 1");
-            await using var client1 = (HazelcastClient) HazelcastClientFactory.CreateClient(options);
-            await client1.StartAsync().CAF();
+            await using var client1 = (HazelcastClient) await HazelcastClientFactory.StartClientAsync(options);
 
             HConsole.WriteLine(this, "Send message 1 to client 1");
             var message = CreateMessage("ping");

--- a/src/Hazelcast.Net/Clustering/Authenticator.cs
+++ b/src/Hazelcast.Net/Clustering/Authenticator.cs
@@ -40,8 +40,7 @@ namespace Hazelcast.Clustering
         public Authenticator(AuthenticationOptions options)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            HConsole.Configure(x => x
-                .Set(this, xx => xx.SetIndent(4).SetPrefix("AUTH")));
+            HConsole.Configure(x => x.Set(this, config => config.SetIndent(4).SetPrefix("AUTH")));
         }
 
         /// <inheritdoc />

--- a/src/Hazelcast.Net/Clustering/Cluster.cs
+++ b/src/Hazelcast.Net/Clustering/Cluster.cs
@@ -77,8 +77,7 @@ namespace Hazelcast.Clustering
             _heartbeat = new Heartbeat(_clusterState, Members, Messaging, options.Heartbeat, loggerFactory);
             _heartbeat.Start();
 
-            HConsole.Configure(x => x
-                .Set(this, xx => xx.SetIndent(2).SetPrefix("CLUSTER")));
+            HConsole.Configure(x => x.Set(this, config => config.SetIndent(2).SetPrefix("CLUSTER")));
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
+++ b/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.Core;

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -94,8 +94,7 @@ namespace Hazelcast.Clustering
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = loggerFactory.CreateLogger<MemberConnection>();
 
-            HConsole.Configure(x => x
-                .Set(this, xx => xx.SetIndent(4).SetPrefix("CLIENT")));
+            HConsole.Configure(x => x.Set(this, config => config.SetIndent(4).SetPrefix("CLIENT")));
         }
 
         /// <summary>
@@ -209,9 +208,7 @@ namespace Hazelcast.Clustering
 
             _socketConnection = new ClientSocketConnection(_connectionIdSequence.GetNext(), Address.IPEndPoint, _socketOptions, _sslOptions, _loggerFactory) { OnShutdown = SocketShutdown };
             _messageConnection = new ClientMessageConnection(_socketConnection, _loggerFactory) { OnReceiveMessage = ReceiveMessage };
-
-            HConsole.Configure(x => x
-                .Set(_messageConnection, xx => xx.SetIndent(12).SetPrefix($"MSG.CLIENT [{_socketConnection.Id}]")));
+            HConsole.Configure(x => x.Set(_messageConnection, config => config.SetIndent(12).SetPrefix($"MSG.CLIENT [{_socketConnection.Id}]")));
 
             try
             {

--- a/src/Hazelcast.Net/HazelcastClient.cs
+++ b/src/Hazelcast.Net/HazelcastClient.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using Hazelcast.Clustering;
 using Hazelcast.Core;
 using Hazelcast.DistributedObjects;
+using Hazelcast.Exceptions;
 using Hazelcast.NearCaching;
 using Hazelcast.Serialization;
 using Microsoft.Extensions.Logging;
@@ -95,7 +96,15 @@ namespace Hazelcast
         /// </summary>
         public ISerializationService SerializationService { get; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Starts the client by connecting to the remote cluster.
+        /// </summary>
+        /// <param name="timeout">A timeout.</param>
+        /// <returns>A task that will complete when the client is connected.</returns>
+        /// <exception cref="TaskTimeoutException">Failed to connect within the specified timeout.</exception>
+        /// <remarks>
+        /// <para>If the timeout is omitted, then the timeout configured in the options is used.</para>
+        /// </remarks>
         public
 #if !HZ_OPTIMIZE_ASYNC
         async
@@ -117,7 +126,11 @@ namespace Hazelcast
 #endif
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Starts the client by connecting to the remote cluster.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that will complete when the client is connected.</returns>
         public
 #if !HZ_OPTIMIZE_ASYNC
         async

--- a/src/Hazelcast.Net/HazelcastClientFactory.cs
+++ b/src/Hazelcast.Net/HazelcastClientFactory.cs
@@ -44,8 +44,8 @@ namespace Hazelcast
         /// <remarks>
         /// <para>Options are built via HazelcastOptions.Build method.</para>
         /// </remarks>
-        public static ValueTask<IHazelcastClient> StartClientAsync(CancellationToken cancellationToken)
-            => StartClientAsync(HazelcastOptions.Build(), cancellationToken);
+        public static ValueTask<IHazelcastClient> StartNewClientAsync(CancellationToken cancellationToken)
+            => StartNewClientAsync(HazelcastOptions.Build(), cancellationToken);
 
         /// <summary>
         /// Starts a new <see cref="IHazelcastClient"/> instance with the automatic options.
@@ -57,8 +57,8 @@ namespace Hazelcast
         /// <para>Options are built via HazelcastOptions.Build method.</para>
         /// <para>If the timeout is omitted, then the timeout configured in the options is used.</para>
         /// </remarks>
-        public static ValueTask<IHazelcastClient> StartClientAsync(TimeSpan timeout = default)
-            => StartClientAsync(HazelcastOptions.Build(), timeout);
+        public static ValueTask<IHazelcastClient> StartNewClientAsync(TimeSpan timeout = default)
+            => StartNewClientAsync(HazelcastOptions.Build(), timeout);
 
         /// <summary>
         /// Starts a new <see cref="IHazelcastClient"/> instance with configured options.
@@ -70,8 +70,8 @@ namespace Hazelcast
         /// <para>Options are built via the <see cref="HazelcastOptions.Build(string[], IEnumerable{KeyValuePair{string, string}}, string, string, string, Action{IConfiguration, HazelcastOptions})"/>
         /// method and passed to the <paramref name="configure"/> method, where they can be refined and adjusted, before being used to create the client.</para>
         /// </remarks>
-        public static ValueTask<IHazelcastClient> StartClientAsync(Action<HazelcastOptions> configure, CancellationToken cancellationToken)
-            => StartClientAsync(GetOptions(configure ?? throw new ArgumentNullException(nameof(configure))), cancellationToken);
+        public static ValueTask<IHazelcastClient> StartNewClientAsync(Action<HazelcastOptions> configure, CancellationToken cancellationToken)
+            => StartNewClientAsync(GetOptions(configure ?? throw new ArgumentNullException(nameof(configure))), cancellationToken);
 
         /// <summary>
         /// Starts a new <see cref="IHazelcastClient"/> instance with configured options.
@@ -85,8 +85,8 @@ namespace Hazelcast
         /// method and passed to the <paramref name="configure"/> method, where they can be refined and adjusted, before being used to create the client.</para>
         /// <para>If the timeout is omitted, then the timeout configured in the options is used.</para>
         /// </remarks>
-        public static ValueTask <IHazelcastClient> StartClientAsync(Action<HazelcastOptions> configure, TimeSpan timeout = default)
-            => StartClientAsync(GetOptions(configure ?? throw new ArgumentNullException(nameof(configure))), timeout);
+        public static ValueTask <IHazelcastClient> StartNewClientAsync(Action<HazelcastOptions> configure, TimeSpan timeout = default)
+            => StartNewClientAsync(GetOptions(configure ?? throw new ArgumentNullException(nameof(configure))), timeout);
 
         /// <summary>
         /// Starts a new <see cref="IHazelcastClient"/> instance with options.
@@ -94,7 +94,7 @@ namespace Hazelcast
         /// <param name="options">Options.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A new <see cref="IHazelcastClient"/> instance.</returns>
-        public static async ValueTask<IHazelcastClient> StartClientAsync(HazelcastOptions options, CancellationToken cancellationToken)
+        public static async ValueTask<IHazelcastClient> StartNewClientAsync(HazelcastOptions options, CancellationToken cancellationToken)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
@@ -113,7 +113,7 @@ namespace Hazelcast
         /// <remarks>
         /// <para>If the timeout is omitted, then the timeout configured in the options is used.</para>
         /// </remarks>
-        public static async ValueTask<IHazelcastClient> StartClientAsync(HazelcastOptions options, TimeSpan timeout = default)
+        public static async ValueTask<IHazelcastClient> StartNewClientAsync(HazelcastOptions options, TimeSpan timeout = default)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 

--- a/src/Hazelcast.Net/HazelcastClientFactory.cs
+++ b/src/Hazelcast.Net/HazelcastClientFactory.cs
@@ -14,9 +14,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Hazelcast.Aggregating;
 using Hazelcast.Clustering;
 using Hazelcast.Core;
+using Hazelcast.Exceptions;
 using Hazelcast.Partitioning.Strategies;
 using Hazelcast.Predicates;
 using Hazelcast.Projections;
@@ -34,26 +37,90 @@ namespace Hazelcast
     public static class HazelcastClientFactory
     {
         /// <summary>
-        /// Creates an <see cref="IHazelcastClient"/> instance with the automatic options.
+        /// Starts a new <see cref="IHazelcastClient"/> instance with the automatic options.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A new <see cref="IHazelcastClient"/> instance.</returns>
         /// <remarks>
-        /// <para>Options are built via <see cref="HazelcastOptions.Build(string[], System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string,string}}, string, string, string, System.Action{Microsoft.Extensions.Configuration.IConfiguration,Hazelcast.HazelcastOptions}(Microsoft.Extensions.Configuration.IConfiguration,Hazelcast.HazelcastOptions))"/> method.</para>
+        /// <para>Options are built via HazelcastOptions.Build method.</para>
         /// </remarks>
-        public static IHazelcastClient CreateClient()
-            => CreateClient(HazelcastOptions.Build());
+        public static ValueTask<IHazelcastClient> StartClientAsync(CancellationToken cancellationToken)
+            => StartClientAsync(HazelcastOptions.Build(), cancellationToken);
 
         /// <summary>
-        /// Creates an <see cref="IHazelcastClient"/> instance with configured options.
+        /// Starts a new <see cref="IHazelcastClient"/> instance with the automatic options.
+        /// </summary>
+        /// <param name="timeout">A timeout.</param>
+        /// <returns>A new <see cref="IHazelcastClient"/> instance.</returns>
+        /// <exception cref="TaskTimeoutException">Failed to connect within the specified timeout.</exception>
+        /// <remarks>
+        /// <para>Options are built via HazelcastOptions.Build method.</para>
+        /// <para>If the timeout is omitted, then the timeout configured in the options is used.</para>
+        /// </remarks>
+        public static ValueTask<IHazelcastClient> StartClientAsync(TimeSpan timeout = default)
+            => StartClientAsync(HazelcastOptions.Build(), timeout);
+
+        /// <summary>
+        /// Starts a new <see cref="IHazelcastClient"/> instance with configured options.
         /// </summary>
         /// <param name="configure">A <see cref="HazelcastOptions"/> configuration delegate.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A new <see cref="IHazelcastClient"/> instance.</returns>
         /// <remarks>
         /// <para>Options are built via the <see cref="HazelcastOptions.Build(string[], IEnumerable{KeyValuePair{string, string}}, string, string, string, Action{IConfiguration, HazelcastOptions})"/>
         /// method and passed to the <paramref name="configure"/> method, where they can be refined and adjusted, before being used to create the client.</para>
         /// </remarks>
-        public static IHazelcastClient CreateClient(Action<HazelcastOptions> configure)
-            => CreateClient(GetOptions(configure ?? throw new ArgumentNullException(nameof(configure))));
+        public static ValueTask<IHazelcastClient> StartClientAsync(Action<HazelcastOptions> configure, CancellationToken cancellationToken)
+            => StartClientAsync(GetOptions(configure ?? throw new ArgumentNullException(nameof(configure))), cancellationToken);
+
+        /// <summary>
+        /// Starts a new <see cref="IHazelcastClient"/> instance with configured options.
+        /// </summary>
+        /// <param name="configure">A <see cref="HazelcastOptions"/> configuration delegate.</param>
+        /// <param name="timeout">A timeout.</param>
+        /// <returns>A new <see cref="IHazelcastClient"/> instance.</returns>
+        /// <exception cref="TaskTimeoutException">Failed to connect within the specified timeout.</exception>
+        /// <remarks>
+        /// <para>Options are built via the <see cref="HazelcastOptions.Build(string[], IEnumerable{KeyValuePair{string, string}}, string, string, string, Action{IConfiguration, HazelcastOptions})"/>
+        /// method and passed to the <paramref name="configure"/> method, where they can be refined and adjusted, before being used to create the client.</para>
+        /// <para>If the timeout is omitted, then the timeout configured in the options is used.</para>
+        /// </remarks>
+        public static ValueTask <IHazelcastClient> StartClientAsync(Action<HazelcastOptions> configure, TimeSpan timeout = default)
+            => StartClientAsync(GetOptions(configure ?? throw new ArgumentNullException(nameof(configure))), timeout);
+
+        /// <summary>
+        /// Starts a new <see cref="IHazelcastClient"/> instance with options.
+        /// </summary>
+        /// <param name="options">Options.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A new <see cref="IHazelcastClient"/> instance.</returns>
+        public static async ValueTask<IHazelcastClient> StartClientAsync(HazelcastOptions options, CancellationToken cancellationToken)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            var client = CreateClient(options);
+            await client.StartAsync(cancellationToken).CAF();
+            return client;
+        }
+
+        /// <summary>
+        /// Starts a new <see cref="IHazelcastClient"/> instance with options.
+        /// </summary>
+        /// <param name="options">Options.</param>
+        /// <param name="timeout">A timeout.</param>
+        /// <returns>A new <see cref="IHazelcastClient"/> instance.</returns>
+        /// <exception cref="TaskTimeoutException">Failed to connect within the specified timeout.</exception>
+        /// <remarks>
+        /// <para>If the timeout is omitted, then the timeout configured in the options is used.</para>
+        /// </remarks>
+        public static async ValueTask<IHazelcastClient> StartClientAsync(HazelcastOptions options, TimeSpan timeout = default)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            var client = CreateClient(options);
+            await client.StartAsync(timeout).CAF();
+            return client;
+        }
 
         private static HazelcastOptions GetOptions(Action<HazelcastOptions> configure)
         {
@@ -62,12 +129,7 @@ namespace Hazelcast
             return options;
         }
 
-        /// <summary>
-        /// Creates an <see cref="IHazelcastClient"/> instance with options.
-        /// </summary>
-        /// <param name="options">Options.</param>
-        /// <returns>A new <see cref="IHazelcastClient"/> instance.</returns>
-        public static IHazelcastClient CreateClient(HazelcastOptions options)
+        private static HazelcastClient CreateClient(HazelcastOptions options)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
@@ -98,6 +160,7 @@ namespace Hazelcast
 
             var cluster = new Cluster(options, serializationService, loggerFactory);
             var client = new HazelcastClient(options, cluster, serializationService, loggerFactory);
+
             return client;
         }
     }

--- a/src/Hazelcast.Net/IHazelcastClient.cs
+++ b/src/Hazelcast.Net/IHazelcastClient.cs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.DistributedObjects;
-using Hazelcast.Exceptions;
 using Hazelcast.Transactions;
 
 namespace Hazelcast
@@ -26,24 +24,6 @@ namespace Hazelcast
     /// </summary>
     public interface IHazelcastClient : IAsyncDisposable
     {
-        /// <summary>
-        /// Starts the client by connecting to the remote cluster.
-        /// </summary>
-        /// <param name="timeout">A timeout.</param>
-        /// <returns>A task that will complete when the client is connected.</returns>
-        /// <exception cref="TaskTimeoutException">Failed to connect within the specified timeout.</exception>
-        /// <remarks>
-        /// <para>If the timeout is omitted, then the timeout configured in the options is used.</para>
-        /// </remarks>
-        Task StartAsync(TimeSpan timeout = default);
-
-        /// <summary>
-        /// Starts the client by connecting to the remote cluster.
-        /// </summary>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that will complete when the client is connected.</returns>
-        Task StartAsync(CancellationToken cancellationToken);
-
         /// <summary>
         /// Whether the client is active.
         /// </summary>


### PR DESCRIPTION
This refactors how we get and start a client. Previously, we'd get the client from the factory *then* start it. Now, the factory creates *and* starts a client all at once.