### PR TITLE
Implement statefull events

### DIFF
--- a/src/Hazelcast.Net.Tests/Remote/ClientListTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientListTest.cs
@@ -14,6 +14,7 @@
 
 using System.Threading.Tasks;
 using Hazelcast.DistributedObjects;
+using Hazelcast.DistributedObjects;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Remote

--- a/src/Hazelcast.Net/Clustering/ObjectLifecycleEventSubscription.cs
+++ b/src/Hazelcast.Net/Clustering/ObjectLifecycleEventSubscription.cs
@@ -36,12 +36,12 @@ namespace Hazelcast.Clustering
                 (message, state) => ClientAddDistributedObjectListenerCodec.DecodeResponse(message).Response,
                 (id, state) => ClientRemoveDistributedObjectListenerCodec.EncodeRequest(id),
                 (message, state) => ClientRemoveDistributedObjectListenerCodec.DecodeResponse(message).Response,
-                (message, state) => ClientAddDistributedObjectListenerCodec.HandleEventAsync(message, HandleInternal, LoggerFactory));
+                (message, state) => ClientAddDistributedObjectListenerCodec.HandleEventAsync(message, HandleCodecEvent, null, LoggerFactory));
         }
 
         internal Func<DistributedObjectLifecycleEventType, DistributedObjectLifecycleEventArgs, ValueTask> Handle { get; set; }
 
-        private ValueTask HandleInternal(string name, string serviceName, string eventTypeName, Guid memberId)
+        private ValueTask HandleCodecEvent(string name, string serviceName, string eventTypeName, Guid memberId, object state)
         {
             if (Handle == null) return default;
 

--- a/src/Hazelcast.Net/Clustering/PartitionLostEventSubscription.cs
+++ b/src/Hazelcast.Net/Clustering/PartitionLostEventSubscription.cs
@@ -38,12 +38,12 @@ namespace Hazelcast.Clustering
                 (message, state) => ClientAddPartitionLostListenerCodec.DecodeResponse(message).Response,
                 (id, state) => ClientRemovePartitionLostListenerCodec.EncodeRequest(id),
                 (message, state) => ClientRemovePartitionLostListenerCodec.DecodeResponse(message).Response,
-                (message, state) => ClientAddPartitionLostListenerCodec.HandleEventAsync(message, HandleInternal, LoggerFactory));
+                (message, state) => ClientAddPartitionLostListenerCodec.HandleEventAsync(message, HandleCodecEvent, null, LoggerFactory));
         }
 
         internal Func<PartitionLostEventArgs, ValueTask> Handle { get; set; }
 
-        private ValueTask HandleInternal(int partitionId, int lostBackupCount, Guid memberId)
+        private ValueTask HandleCodecEvent(int partitionId, int lostBackupCount, Guid memberId, object state)
         {
             if (Handle == null) return default;
 

--- a/src/Hazelcast.Net/DistributedObjects/CollectionItemEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/CollectionItemEventArgs.cs
@@ -21,7 +21,7 @@ namespace Hazelcast.DistributedObjects
     /// Represents event data for the <see cref="CollectionItemEventTypes"/> events.
     /// </summary>
     /// <typeparam name="T">The topic object type.</typeparam>
-    public sealed class CollectionItemEventArgs<T>
+    public sealed class CollectionItemEventArgs<T> : EventArgsBase
     {
         private readonly Lazy<T> _item;
 
@@ -30,7 +30,9 @@ namespace Hazelcast.DistributedObjects
         /// </summary>
         /// <param name="member">The member.</param>
         /// <param name="item">The item.</param>
-        public CollectionItemEventArgs(MemberInfo member, Lazy<T> item)
+        /// <param name="state">A state object.</param>
+        public CollectionItemEventArgs(MemberInfo member, Lazy<T> item, object state)
+            : base(state)
         {
             Member = member;
             _item = item;

--- a/src/Hazelcast.Net/DistributedObjects/CollectionItemEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/CollectionItemEventHandler.cs
@@ -41,16 +41,17 @@ namespace Hazelcast.DistributedObjects
         public CollectionItemEventTypes EventType { get; }
 
         /// <inheritdoc />
-        public ValueTask HandleAsync(IHCollection<T> sender, MemberInfo member, Lazy<T> item)
-            => _handler(sender, CreateEventArgs(member, item));
+        public ValueTask HandleAsync(IHCollection<T> sender, MemberInfo member, Lazy<T> item, object state)
+            => _handler(sender, CreateEventArgs(member, item, state));
 
         /// <summary>
         /// Creates event arguments.
         /// </summary>
         /// <param name="member">The member.</param>
         /// <param name="item">The item.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>Event arguments.</returns>
-        private static CollectionItemEventArgs<T> CreateEventArgs(MemberInfo member, Lazy<T> item)
-            => new CollectionItemEventArgs<T>(member, item);
+        private static CollectionItemEventArgs<T> CreateEventArgs(MemberInfo member, Lazy<T> item, object state)
+            => new CollectionItemEventArgs<T>(member, item, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryClearedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryClearedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.AllCleared, handler)
         { }
 
-        protected override DictionaryClearedEventArgs CreateEventArgs(MemberInfo member, int numberOfAffectedEntries)
-            => new DictionaryClearedEventArgs(member, numberOfAffectedEntries);
+        protected override DictionaryClearedEventArgs CreateEventArgs(MemberInfo member, int numberOfAffectedEntries, object state)
+            => new DictionaryClearedEventArgs(member, numberOfAffectedEntries, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryAddedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryAddedEventArgs.cs
@@ -21,8 +21,8 @@ namespace Hazelcast.DistributedObjects
     {
         private readonly Lazy<TValue> _value;
 
-        public DictionaryEntryAddedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value)
-            : base(member, key)
+        public DictionaryEntryAddedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, object state)
+            : base(member, key, state)
         {
             _value = value;
         }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryAddedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryAddedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.Added, handler)
         { }
 
-        protected override DictionaryEntryAddedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => new DictionaryEntryAddedEventArgs<TKey, TValue>(member, key, value);
+        protected override DictionaryEntryAddedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => new DictionaryEntryAddedEventArgs<TKey, TValue>(member, key, value, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryEventArgsBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryEventArgsBase.cs
@@ -21,7 +21,7 @@ namespace Hazelcast.DistributedObjects
     /// Represents event data for map entry events.
     /// </summary>
     /// <typeparam name="TKey">The type of the keys.</typeparam>
-    public abstract class DictionaryEntryEventArgsBase<TKey>
+    public abstract class DictionaryEntryEventArgsBase<TKey> : EventArgsBase
     {
         private readonly Lazy<TKey> _key;
 
@@ -30,7 +30,9 @@ namespace Hazelcast.DistributedObjects
         /// </summary>
         /// <param name="member">The member.</param>
         /// <param name="key">The key.</param>
-        protected DictionaryEntryEventArgsBase(MemberInfo member, Lazy<TKey> key)
+        /// <param name="state">A state object.</param>
+        protected DictionaryEntryEventArgsBase(MemberInfo member, Lazy<TKey> key, object state)
+            : base(state)
         {
             Member = member;
             _key = key;

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryEventHandlerBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryEventHandlerBase.cs
@@ -37,9 +37,9 @@ namespace Hazelcast.DistributedObjects
 
         public HDictionaryEventTypes EventType { get; }
 
-        public ValueTask HandleAsync(TSender sender, MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => _handler(sender, CreateEventArgs(member, key, value, oldValue, mergeValue, eventType, numberOfAffectedEntries));
+        public ValueTask HandleAsync(TSender sender, MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => _handler(sender, CreateEventArgs(member, key, value, oldValue, mergeValue, eventType, numberOfAffectedEntries, state));
 
-        protected abstract TArgs CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries);
+        protected abstract TArgs CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryEvictedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryEvictedEventArgs.cs
@@ -21,8 +21,8 @@ namespace Hazelcast.DistributedObjects
     {
         private readonly Lazy<TValue> _oldValue;
 
-        public DictionaryEntryEvictedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> oldValue)
-            : base(member, key)
+        public DictionaryEntryEvictedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> oldValue, object state)
+            : base(member, key, state)
         {
             _oldValue = oldValue;
         }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryEvictedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryEvictedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.Evicted, handler)
         { }
 
-        protected override DictionaryEntryEvictedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => new DictionaryEntryEvictedEventArgs<TKey, TValue>(member, key, oldValue);
+        protected override DictionaryEntryEvictedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => new DictionaryEntryEvictedEventArgs<TKey, TValue>(member, key, oldValue, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryExpiredEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryExpiredEventArgs.cs
@@ -21,8 +21,8 @@ namespace Hazelcast.DistributedObjects
     {
         private readonly Lazy<TValue> _oldValue;
 
-        public DictionaryEntryExpiredEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> oldValue)
-            : base(member, key)
+        public DictionaryEntryExpiredEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> oldValue, object state)
+            : base(member, key, state)
         {
             _oldValue = oldValue;
         }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryExpiredEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryExpiredEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.Expired, handler)
         { }
 
-        protected override DictionaryEntryExpiredEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => new DictionaryEntryExpiredEventArgs<TKey, TValue>(member, key, oldValue);
+        protected override DictionaryEntryExpiredEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => new DictionaryEntryExpiredEventArgs<TKey, TValue>(member, key, oldValue, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryInvalidatedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryInvalidatedEventArgs.cs
@@ -19,8 +19,8 @@ namespace Hazelcast.DistributedObjects
 {
     public sealed class DictionaryEntryInvalidatedEventArgs<TKey, TValue> : DictionaryEntryEventArgsBase<TKey>
     {
-        public DictionaryEntryInvalidatedEventArgs(MemberInfo member, Lazy<TKey> key)
-            : base(member, key)
+        public DictionaryEntryInvalidatedEventArgs(MemberInfo member, Lazy<TKey> key, object state)
+            : base(member, key, state)
         { }
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryInvalidatedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryInvalidatedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.Invalidated, handler)
         { }
 
-        protected override DictionaryEntryInvalidatedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => new DictionaryEntryInvalidatedEventArgs<TKey, TValue>(member, key);
+        protected override DictionaryEntryInvalidatedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => new DictionaryEntryInvalidatedEventArgs<TKey, TValue>(member, key, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryLoadedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryLoadedEventArgs.cs
@@ -22,8 +22,8 @@ namespace Hazelcast.DistributedObjects
         private readonly Lazy<TValue> _value;
         private readonly Lazy<TValue> _oldValue;
 
-        public DictionaryEntryLoadedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue)
-            : base(member, key)
+        public DictionaryEntryLoadedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, object state)
+            : base(member, key, state)
         {
             _value = value;
             _oldValue = oldValue;

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryLoadedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryLoadedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.Loaded, handler)
         { }
 
-        protected override DictionaryEntryLoadedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => new DictionaryEntryLoadedEventArgs<TKey, TValue>(member, key, value, oldValue);
+        protected override DictionaryEntryLoadedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => new DictionaryEntryLoadedEventArgs<TKey, TValue>(member, key, value, oldValue, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryMergedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryMergedEventArgs.cs
@@ -23,8 +23,8 @@ namespace Hazelcast.DistributedObjects
         private readonly Lazy<TValue> _oldValue;
         private readonly Lazy<TValue> _mergeValue;
 
-        public DictionaryEntryMergedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue)
-            : base(member, key)
+        public DictionaryEntryMergedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, object state)
+            : base(member, key, state)
         {
             _value = value;
             _oldValue = oldValue;

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryMergedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryMergedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.Merged, handler)
         { }
 
-        protected override DictionaryEntryMergedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => new DictionaryEntryMergedEventArgs<TKey, TValue>(member, key, value, oldValue, mergeValue);
+        protected override DictionaryEntryMergedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => new DictionaryEntryMergedEventArgs<TKey, TValue>(member, key, value, oldValue, mergeValue, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryRemovedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryRemovedEventArgs.cs
@@ -21,8 +21,8 @@ namespace Hazelcast.DistributedObjects
     {
         private readonly Lazy<TValue> _oldValue;
 
-        public DictionaryEntryRemovedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> oldValue)
-            : base(member, key)
+        public DictionaryEntryRemovedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> oldValue, object state)
+            : base(member, key, state)
         {
             _oldValue = oldValue;
         }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryRemovedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryRemovedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.Removed, handler)
         { }
 
-        protected override DictionaryEntryRemovedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => new DictionaryEntryRemovedEventArgs<TKey, TValue>(member, key, value);
+        protected override DictionaryEntryRemovedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => new DictionaryEntryRemovedEventArgs<TKey, TValue>(member, key, value, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryUpdatedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryUpdatedEventArgs.cs
@@ -22,8 +22,8 @@ namespace Hazelcast.DistributedObjects
         private readonly Lazy<TValue> _oldValue;
         private readonly Lazy<TValue> _value;
 
-        public DictionaryEntryUpdatedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> oldValue, Lazy<TValue> value)
-            : base(member, key)
+        public DictionaryEntryUpdatedEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> oldValue, Lazy<TValue> value, object state)
+            : base(member, key, state)
         {
             _oldValue = oldValue;
             _value = value;

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEntryUpdatedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEntryUpdatedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.Updated, handler)
         { }
 
-        protected override DictionaryEntryUpdatedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries)
-            => new DictionaryEntryUpdatedEventArgs<TKey, TValue>(member, key, oldValue, value);
+        protected override DictionaryEntryUpdatedEventArgs<TKey, TValue> CreateEventArgs(MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state)
+            => new DictionaryEntryUpdatedEventArgs<TKey, TValue>(member, key, oldValue, value, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEventArgsBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEventArgsBase.cs
@@ -26,10 +26,12 @@ namespace Hazelcast.DistributedObjects
         /// </summary>
         /// <param name="member">The member.</param>
         /// <param name="numberOfAffectedEntries">The number of affected entries.</param>
-        protected DictionaryEventArgsBase(MemberInfo member, int numberOfAffectedEntries)
+        /// <param name="state">A state object.</param>
+        protected DictionaryEventArgsBase(MemberInfo member, int numberOfAffectedEntries, object state)
         {
             Member = member;
             NumberOfAffectedEntries = numberOfAffectedEntries;
+            State = state;
         }
 
         /// <summary>
@@ -41,5 +43,10 @@ namespace Hazelcast.DistributedObjects
         /// Gets the number of affected entries.
         /// </summary>
         public int NumberOfAffectedEntries { get; }
+
+        /// <summary>
+        /// Gets the state object.
+        /// </summary>
+        public object State { get; }
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEventHandlerBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEventHandlerBase.cs
@@ -37,9 +37,9 @@ namespace Hazelcast.DistributedObjects
 
         public HDictionaryEventTypes EventType { get; }
 
-        public ValueTask HandleAsync(TSender sender, MemberInfo member, int numberOfAffectedEntries)
-            => _handler(sender, CreateEventArgs(member, numberOfAffectedEntries));
+        public ValueTask HandleAsync(TSender sender, MemberInfo member, int numberOfAffectedEntries, object state)
+            => _handler(sender, CreateEventArgs(member, numberOfAffectedEntries, state));
 
-        protected abstract TArgs CreateEventArgs(MemberInfo member, int numberOfAffectedEntries);
+        protected abstract TArgs CreateEventArgs(MemberInfo member, int numberOfAffectedEntries, object state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEvictedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEvictedEventArgs.cs
@@ -18,8 +18,8 @@ namespace Hazelcast.DistributedObjects
 {
     public sealed class DictionaryEvictedEventArgs : DictionaryEventArgsBase
     {
-        public DictionaryEvictedEventArgs(MemberInfo member, int numberOfAffectedEntries)
-            : base(member, numberOfAffectedEntries)
+        public DictionaryEvictedEventArgs(MemberInfo member, int numberOfAffectedEntries, object state)
+            : base(member, numberOfAffectedEntries, state)
         { }
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DictionaryEvictedEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DictionaryEvictedEventHandler.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.DistributedObjects
             : base(HDictionaryEventTypes.AllEvicted, handler)
         { }
 
-        protected override DictionaryEvictedEventArgs CreateEventArgs(MemberInfo member, int numberOfAffectedEntries)
-            => new DictionaryEvictedEventArgs(member, numberOfAffectedEntries);
+        protected override DictionaryEvictedEventArgs CreateEventArgs(MemberInfo member, int numberOfAffectedEntries, object state)
+            => new DictionaryEvictedEventArgs(member, numberOfAffectedEntries, state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/DistributedObjectBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DistributedObjectBase.cs
@@ -44,6 +44,7 @@ namespace Hazelcast.DistributedObjects
         /// </summary>
         /// <param name="serviceName">the name of the service managing this object.</param>
         /// <param name="name">The unique name of the object.</param>
+        /// <param name="factory">The distributed object factory.</param>
         /// <param name="cluster">A cluster.</param>
         /// <param name="serializationService">A serialization service.</param>
         /// <param name="loggerFactory">A logger factory.</param>
@@ -242,10 +243,12 @@ namespace Hazelcast.DistributedObjects
             /// </summary>
             /// <param name="name">The unique name of the distributed object.</param>
             /// <param name="handlers">The event handlers.</param>
-            public SubscriptionState(string name, TEventHandlers handlers)
+            /// <param name="handlerState">A state object which is passed to handlers.</param>
+            public SubscriptionState(string name, TEventHandlers handlers, object handlerState)
             {
                 Name = name;
                 Handlers = handlers;
+                HandlerState = handlerState;
             }
 
             /// <summary>
@@ -257,6 +260,11 @@ namespace Hazelcast.DistributedObjects
             /// Gets the event handlers.
             /// </summary>
             public TEventHandlers Handlers { get; }
+
+            /// <summary>
+            /// Gets the handler state.
+            /// </summary>
+            public object HandlerState { get; }
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/DistributedObjects/EventArgsBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/EventArgsBase.cs
@@ -1,25 +1,36 @@
 ﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Hazelcast.Data;
-
 namespace Hazelcast.DistributedObjects
 {
-    public sealed class DictionaryClearedEventArgs : DictionaryEventArgsBase
+    /// <summary>
+    /// Provides a base class for all event arguments.
+    /// </summary>
+    public abstract class EventArgsBase
     {
-        public DictionaryClearedEventArgs(MemberInfo member, int numberOfAffectedEntries, object state)
-            : base(member, numberOfAffectedEntries, state)
-        { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventArgsBase"/> class.
+        /// </summary>
+        /// <param name="state">A state object.</param>
+        protected EventArgsBase(object state)
+        {
+            State = state;
+        }
+
+        /// <summary>
+        /// Gets the state object.
+        /// </summary>
+        public object State { get; }
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/ICollectionItemEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/ICollectionItemEventHandler.cs
@@ -35,6 +35,7 @@ namespace Hazelcast.DistributedObjects
         /// <param name="sender">The <see cref="IHCollection{T}"/> that triggered the event.</param>
         /// <param name="member">The member.</param>
         /// <param name="item">The item.</param>
-        ValueTask HandleAsync(IHCollection<T> sender, MemberInfo member, Lazy<T> item);
+        /// <param name="state">A state object.</param>
+        ValueTask HandleAsync(IHCollection<T> sender, MemberInfo member, Lazy<T> item, object state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/IDictionaryEntryEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IDictionaryEntryEventHandler.cs
@@ -37,6 +37,7 @@ namespace Hazelcast.DistributedObjects
         /// <param name="mergeValue">The merged value.</param>
         /// <param name="eventType">The event type.</param>
         /// <param name="numberOfAffectedEntries">The number of affected entries.</param>
-        ValueTask HandleAsync(TSender sender, MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries);
+        /// <param name="state">A state object.</param>
+        ValueTask HandleAsync(TSender sender, MemberInfo member, Lazy<TKey> key, Lazy<TValue> value, Lazy<TValue> oldValue, Lazy<TValue> mergeValue, HDictionaryEventTypes eventType, int numberOfAffectedEntries, object state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/IDictionaryEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IDictionaryEventHandler.cs
@@ -31,6 +31,7 @@ namespace Hazelcast.DistributedObjects
         /// <param name="sender">The sender (map) that triggered the event.</param>
         /// <param name="member">The member.</param>
         /// <param name="numberOfAffectedEntries">The number of affected entries.</param>
-        ValueTask HandleAsync(TSender sender, MemberInfo member, int numberOfAffectedEntries);
+        /// <param name="state">A state object.</param>
+        ValueTask HandleAsync(TSender sender, MemberInfo member, int numberOfAffectedEntries, object state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/IHCollection.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHCollection.cs
@@ -118,8 +118,9 @@ namespace Hazelcast.DistributedObjects
         /// </summary>
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="includeValue">Whether to include values in event arguments.</param>
+        /// <param name="state">A state object that will be passed to handlers.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<CollectionItemEventHandlers<T>> events, bool includeValue = true);
+        Task<Guid> SubscribeAsync(Action<CollectionItemEventHandlers<T>> events, bool includeValue = true, object state = null);
 
         /// <summary>
         /// Unsubscribe from events.

--- a/src/Hazelcast.Net/DistributedObjects/IHDictionary.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHDictionary.Events.cs
@@ -25,8 +25,9 @@ namespace Hazelcast.DistributedObjects
         /// </summary>
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="includeValues">Whether to include values in event arguments.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<DictionaryEventHandlers<TKey, TValue>> events, bool includeValues = true);
+        Task<Guid> SubscribeAsync(Action<DictionaryEventHandlers<TKey, TValue>> events, bool includeValues = true, object state = null);
 
         /// <summary>
         /// Subscribes to events.
@@ -34,8 +35,9 @@ namespace Hazelcast.DistributedObjects
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="key">A key to filter events.</param>
         /// <param name="includeValues">Whether to include values in event arguments.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<DictionaryEventHandlers<TKey, TValue>> events, TKey key, bool includeValues = true);
+        Task<Guid> SubscribeAsync(Action<DictionaryEventHandlers<TKey, TValue>> events, TKey key, bool includeValues = true, object state = null);
 
         /// <summary>
         /// Subscribes to events.
@@ -43,13 +45,14 @@ namespace Hazelcast.DistributedObjects
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="predicate">A predicate to filter events.</param>
         /// <param name="includeValues">Whether to include values in event arguments.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
         /// <remarks>
         /// <para>Note that some methods such as <see cref="RemoveAsync(TKey)"/> may break the
         /// events contract in some situations, such as when the predicate refers to the
         /// entry value. Refer to the documentation for these methods for more details.</para>
         /// </remarks>
-        Task<Guid> SubscribeAsync(Action<DictionaryEventHandlers<TKey, TValue>> events, IPredicate predicate, bool includeValues = true);
+        Task<Guid> SubscribeAsync(Action<DictionaryEventHandlers<TKey, TValue>> events, IPredicate predicate, bool includeValues = true, object state = null);
 
         /// <summary>
         /// Subscribes to events.
@@ -58,13 +61,14 @@ namespace Hazelcast.DistributedObjects
         /// <param name="key">A key to filter events.</param>
         /// <param name="predicate">A predicate to filter events.</param>
         /// <param name="includeValues">Whether to include values in event arguments.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
         /// <remarks>
         /// <para>Note that some methods such as <see cref="RemoveAsync(TKey)"/> may break the
         /// events contract in some situations, such as when the predicate refers to the
         /// entry value. Refer to the documentation for these methods for more details.</para>
         /// </remarks>
-        Task<Guid> SubscribeAsync(Action<DictionaryEventHandlers<TKey, TValue>> events, TKey key, IPredicate predicate, bool includeValues = true);
+        Task<Guid> SubscribeAsync(Action<DictionaryEventHandlers<TKey, TValue>> events, TKey key, IPredicate predicate, bool includeValues = true, object state = null);
 
         /// <summary>
         /// Unsubscribe from events.
@@ -76,7 +80,7 @@ namespace Hazelcast.DistributedObjects
         /// Member side event subscriptions will eventually be removed.
         /// </para>
         /// </remarks>
-        /// <returns><c>true</c> if subscription is removed successfully, <c>false</c> if there is no such subscription</returns>
+        /// <returns><c>true</c> if a subscription with the specified identifier was removed successfully; otherwise, if no subscription was found with the specified identifier, <c>false</c>.</returns>
         ValueTask<bool> UnsubscribeAsync(Guid subscriptionId);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/IHMultiDictionary.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHMultiDictionary.cs
@@ -35,8 +35,9 @@ namespace Hazelcast.DistributedObjects
         /// </summary>
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="includeValues">Whether to include values in event arguments.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<MultiDictionaryEventHandlers<TKey, TValue>> events, bool includeValues = true);
+        Task<Guid> SubscribeAsync(Action<MultiDictionaryEventHandlers<TKey, TValue>> events, bool includeValues = true, object state = null);
 
         /// <summary>
         /// Subscribes to events.
@@ -44,8 +45,9 @@ namespace Hazelcast.DistributedObjects
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="key">A key to filter events.</param>
         /// <param name="includeValues">Whether to include values in event arguments.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<MultiDictionaryEventHandlers<TKey, TValue>> events, TKey key, bool includeValues = true);
+        Task<Guid> SubscribeAsync(Action<MultiDictionaryEventHandlers<TKey, TValue>> events, TKey key, bool includeValues = true, object state = null);
 
         /// <summary>
         /// Unsubscribe from events.

--- a/src/Hazelcast.Net/DistributedObjects/IHReplicatedDictionary.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHReplicatedDictionary.cs
@@ -37,24 +37,27 @@ namespace Hazelcast.DistributedObjects
         /// Subscribes to events.
         /// </summary>
         /// <param name="events">An event handlers collection builder.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<ReplicatedDictionaryEventHandlers<TKey, TValue>> events);
+        Task<Guid> SubscribeAsync(Action<ReplicatedDictionaryEventHandlers<TKey, TValue>> events, object state = null);
 
         /// <summary>
         /// Subscribes to events.
         /// </summary>
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="key">A key to filter events.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<ReplicatedDictionaryEventHandlers<TKey, TValue>> events, TKey key);
+        Task<Guid> SubscribeAsync(Action<ReplicatedDictionaryEventHandlers<TKey, TValue>> events, TKey key, object state = null);
 
         /// <summary>
         /// Subscribes to events.
         /// </summary>
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="predicate">A predicate to filter events.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<ReplicatedDictionaryEventHandlers<TKey, TValue>> events, IPredicate predicate);
+        Task<Guid> SubscribeAsync(Action<ReplicatedDictionaryEventHandlers<TKey, TValue>> events, IPredicate predicate, object state = null);
 
         /// <summary>
         /// Subscribes to events.
@@ -62,8 +65,9 @@ namespace Hazelcast.DistributedObjects
         /// <param name="events">An event handlers collection builder.</param>
         /// <param name="key">A key to filter events.</param>
         /// <param name="predicate">A predicate to filter events.</param>
+        /// <param name="state">A state object.</param>
         /// <returns>The unique identifier of the subscription.</returns>
-        Task<Guid> SubscribeAsync(Action<ReplicatedDictionaryEventHandlers<TKey, TValue>> events, TKey key, IPredicate predicate);
+        Task<Guid> SubscribeAsync(Action<ReplicatedDictionaryEventHandlers<TKey, TValue>> events, TKey key, IPredicate predicate, object state = null);
 
         /// <summary>
         /// Unsubscribe from events.

--- a/src/Hazelcast.Net/DistributedObjects/IHTopic.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHTopic.cs
@@ -36,7 +36,8 @@ namespace Hazelcast.DistributedObjects
     public interface IHTopic<T> : IDistributedObject
     {
         /// <summary>Subscribes to this topic.</summary>
-        Task<Guid> SubscribeAsync(Action<TopicEventHandlers<T>> handle);
+        /// <param name="state">A state object.</param>
+        Task<Guid> SubscribeAsync(Action<TopicEventHandlers<T>> events, object state = null);
 
         /// <summary>Stops receiving messages for the given message listener.</summary>
         /// <remarks>

--- a/src/Hazelcast.Net/DistributedObjects/ITopicEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/ITopicEventHandler.cs
@@ -35,6 +35,7 @@ namespace Hazelcast.DistributedObjects
         /// <param name="member">The member.</param>
         /// <param name="publishTime">The publish time.</param>
         /// <param name="payload">The topic object carried by the message.</param>
-        ValueTask HandleAsync(IHTopic<T> sender, MemberInfo member, long publishTime, T payload);
+        /// <param name="state">A state object.</param>
+        ValueTask HandleAsync(IHTopic<T> sender, MemberInfo member, long publishTime, T payload, object state);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HList.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HList.Events.cs
@@ -35,10 +35,7 @@ namespace Hazelcast.DistributedObjects.Impl
         protected override bool ReadUnsubscribeResponse(ClientMessage unsubscribeResponseMessage, SubscriptionState<CollectionItemEventHandlers<T>> state)
             => ListRemoveListenerCodec.DecodeResponse(unsubscribeResponseMessage).Response;
 
-        protected override ValueTask CodecHandleEventAsync(ClientMessage eventMessage, Func<IData, Guid, int, ValueTask> f, ILoggerFactory loggerFactory)
-            => ListAddListenerCodec.HandleEventAsync(
-                eventMessage, 
-                (itemData, memberId, eventTypeData) => f(itemData, memberId, eventTypeData), 
-                loggerFactory);
+        protected override ValueTask CodecHandleEventAsync(ClientMessage eventMessage, Func<IData, Guid, int, object, ValueTask> handler, object state, ILoggerFactory loggerFactory)
+            => ListAddListenerCodec.HandleEventAsync(eventMessage, handler, state, loggerFactory);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Events.cs
@@ -42,10 +42,7 @@ namespace Hazelcast.DistributedObjects.Impl
             => QueueRemoveListenerCodec.DecodeResponse(unsubscribeResponseMessage).Response;
 
         /// <inheritdoc />
-        protected override ValueTask CodecHandleEventAsync(ClientMessage eventMessage, Func<IData, Guid, int, ValueTask> f, ILoggerFactory loggerFactory)
-            => QueueAddListenerCodec.HandleEventAsync(
-                eventMessage,
-                (itemData, memberId, eventTypeData) => f(itemData, memberId, eventTypeData),
-                LoggerFactory);
+        protected override ValueTask CodecHandleEventAsync(ClientMessage eventMessage, Func<IData, Guid, int, object, ValueTask> handler, object state, ILoggerFactory loggerFactory)
+            => QueueAddListenerCodec.HandleEventAsync(eventMessage, handler, state, LoggerFactory);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HSet.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HSet.Events.cs
@@ -35,10 +35,7 @@ namespace Hazelcast.DistributedObjects.Impl
         protected override bool ReadUnsubscribeResponse(ClientMessage unsubscribeResponseMessage, SubscriptionState<CollectionItemEventHandlers<T>> state)
             => SetRemoveListenerCodec.DecodeResponse(unsubscribeResponseMessage).Response;
 
-        protected override ValueTask CodecHandleEventAsync(ClientMessage eventMessage, Func<IData, Guid, int, ValueTask> f, ILoggerFactory loggerFactory)
-            => SetAddListenerCodec.HandleEventAsync(
-                eventMessage,
-                (itemData, memberId, eventTypeData) => f(itemData, memberId, eventTypeData),
-                loggerFactory);
+        protected override ValueTask CodecHandleEventAsync(ClientMessage eventMessage, Func<IData, Guid, int, object, ValueTask> handler, object state, ILoggerFactory loggerFactory)
+            => SetAddListenerCodec.HandleEventAsync(eventMessage, handler, state, loggerFactory);
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/TopicMessageEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/TopicMessageEventArgs.cs
@@ -34,7 +34,7 @@ namespace Hazelcast.DistributedObjects
     /// Represents event data for the <see cref="TopicEventTypes.Message"/> event.
     /// </summary>
     /// <typeparam name="T">The topic object type.</typeparam>
-    public sealed class TopicMessageEventArgs<T>
+    public sealed class TopicMessageEventArgs<T> : EventArgsBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TopicMessageEventArgs{T}"/> class.
@@ -42,7 +42,9 @@ namespace Hazelcast.DistributedObjects
         /// <param name="member">The member.</param>
         /// <param name="publishTime">The publish time.</param>
         /// <param name="payload">The object.</param>
-        public TopicMessageEventArgs(MemberInfo member, long publishTime, T payload)
+        /// <param name="state">A state object</param>
+        public TopicMessageEventArgs(MemberInfo member, long publishTime, T payload, object state)
+            : base(state)
         {
             Member = member;
             PublishTime = publishTime;

--- a/src/Hazelcast.Net/DistributedObjects/TopicMessageEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/TopicMessageEventHandler.cs
@@ -52,8 +52,8 @@ namespace Hazelcast.DistributedObjects
         public TopicEventTypes EventType => TopicEventTypes.Message;
 
         /// <inheritdoc />
-        public ValueTask HandleAsync(IHTopic<T> sender, MemberInfo member, long publishTime, T payload)
-            => _handler(sender, CreateEventArgs(member, publishTime, payload));
+        public ValueTask HandleAsync(IHTopic<T> sender, MemberInfo member, long publishTime, T payload, object state)
+            => _handler(sender, CreateEventArgs(member, publishTime, payload, state));
 
         /// <summary>
         /// Creates event arguments.
@@ -62,7 +62,7 @@ namespace Hazelcast.DistributedObjects
         /// <param name="publishTime">The publish time.</param>
         /// <param name="payload">The topic object carried by the message.</param>
         /// <returns>Event arguments.</returns>
-        private static TopicMessageEventArgs<T> CreateEventArgs(MemberInfo member, long publishTime, T payload)
-            => new TopicMessageEventArgs<T>(member, publishTime, payload);
+        private static TopicMessageEventArgs<T> CreateEventArgs(MemberInfo member, long publishTime, T payload, object state)
+            => new TopicMessageEventArgs<T>(member, publishTime, payload, state);
     }
 }

--- a/src/Hazelcast.Net/NearCaching/NearCache.cs
+++ b/src/Hazelcast.Net/NearCaching/NearCache.cs
@@ -129,7 +129,7 @@ namespace Hazelcast.NearCaching
                 (message, state) => MapAddNearCacheInvalidationListenerCodec.DecodeResponse(message).Response,
                 (id, state) => MapRemoveEntryListenerCodec.EncodeRequest(((EventState) state).Name, id),
                 (message, state) => MapRemoveEntryListenerCodec.DecodeResponse(message).Response,
-                (message, state) => MapAddNearCacheInvalidationListenerCodec.HandleEventAsync(message, HandleInvalidationEventAsync, HandleBatchInvalidationEventAsync, LoggerFactory),
+                (message, state) => MapAddNearCacheInvalidationListenerCodec.HandleEventAsync(message, HandleCodecSingleEvent, HandleCodecBatchEvent, null, LoggerFactory),
                 new EventState { Name = Name });
 
             await Cluster.Events.InstallSubscriptionAsync(subscription, CancellationToken.None).CAF();
@@ -151,7 +151,7 @@ namespace Hazelcast.NearCaching
         /// <param name="sourceuuids"></param>
         /// <param name="partitionuuids"></param>
         /// <param name="sequences"></param>
-        private ValueTask HandleBatchInvalidationEventAsync(IEnumerable<IData> keys, IEnumerable<Guid> sourceuuids, IEnumerable<Guid> partitionuuids, IEnumerable<long> sequences)
+        private ValueTask HandleCodecBatchEvent(IEnumerable<IData> keys, IEnumerable<Guid> sourceuuids, IEnumerable<Guid> partitionuuids, IEnumerable<long> sequences, object state)
         {
             RepairingHandler.Handle(keys, sourceuuids, partitionuuids, sequences);
             return default;
@@ -164,7 +164,7 @@ namespace Hazelcast.NearCaching
         /// <param name="sourceUuid"></param>
         /// <param name="partitionUuid"></param>
         /// <param name="sequence"></param>
-        private ValueTask HandleInvalidationEventAsync(IData key, Guid sourceUuid, Guid partitionUuid, long sequence)
+        private ValueTask HandleCodecSingleEvent(IData key, Guid sourceUuid, Guid partitionUuid, long sequence, object state)
         {
             RepairingHandler.Handle(key, sourceUuid, partitionUuid, sequence);
             return default;

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientAddDistributedObjectListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientAddDistributedObjectListenerCodec.cs
@@ -143,7 +143,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleDistributedObjectEventAsync handleDistributedObjectEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<string, string, string, Guid, object, ValueTask> handleDistributedObjectEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -154,12 +154,10 @@ namespace Hazelcast.Protocol.Codecs
                 var name = StringCodec.Decode(iterator);
                 var serviceName = StringCodec.Decode(iterator);
                 var eventType = StringCodec.Decode(iterator);
-                return handleDistributedObjectEventAsync(name, serviceName, eventType, source);
+                return handleDistributedObjectEventAsync(name, serviceName, eventType, source, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleDistributedObjectEventAsync(string name, string serviceName, string eventType, Guid source);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientAddPartitionLostListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientAddPartitionLostListenerCodec.cs
@@ -143,7 +143,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandlePartitionLostEventAsync handlePartitionLostEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<int, int, Guid, object, ValueTask> handlePartitionLostEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -153,12 +153,10 @@ namespace Hazelcast.Protocol.Codecs
                 var partitionId =  initialFrame.Bytes.ReadIntL(EventPartitionLostPartitionIdFieldOffset);
                 var lostBackupCount =  initialFrame.Bytes.ReadIntL(EventPartitionLostLostBackupCountFieldOffset);
                 var source =  initialFrame.Bytes.ReadGuidL(EventPartitionLostSourceFieldOffset);
-                return handlePartitionLostEventAsync(partitionId, lostBackupCount, source);
+                return handlePartitionLostEventAsync(partitionId, lostBackupCount, source, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandlePartitionLostEventAsync(int partitionId, int lostBackupCount, Guid source);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientLocalBackupListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientLocalBackupListenerCodec.cs
@@ -130,7 +130,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleBackupEventAsync handleBackupEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<long, object, ValueTask> handleBackupEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -138,12 +138,10 @@ namespace Hazelcast.Protocol.Codecs
             {
                 var initialFrame = iterator.Take();
                 var sourceInvocationCorrelationId =  initialFrame.Bytes.ReadLongL(EventBackupSourceInvocationCorrelationIdFieldOffset);
-                return handleBackupEventAsync(sourceInvocationCorrelationId);
+                return handleBackupEventAsync(sourceInvocationCorrelationId, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleBackupEventAsync(long sourceInvocationCorrelationId);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/ListAddListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ListAddListenerCodec.cs
@@ -156,7 +156,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleItemEventAsync handleItemEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, Guid, int, object, ValueTask> handleItemEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -166,12 +166,10 @@ namespace Hazelcast.Protocol.Codecs
                 var uuid =  initialFrame.Bytes.ReadGuidL(EventItemUuidFieldOffset);
                 var eventType =  initialFrame.Bytes.ReadIntL(EventItemEventTypeFieldOffset);
                 var item = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleItemEventAsync(item, uuid, eventType);
+                return handleItemEventAsync(item, uuid, eventType, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleItemEventAsync(IData item, Guid uuid, int eventType);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/MapAddEntryListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/MapAddEntryListenerCodec.cs
@@ -170,7 +170,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -184,12 +184,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/MapAddEntryListenerToKeyCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/MapAddEntryListenerToKeyCodec.cs
@@ -177,7 +177,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -191,12 +191,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/MapAddEntryListenerToKeyWithPredicateCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/MapAddEntryListenerToKeyWithPredicateCodec.cs
@@ -185,7 +185,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -199,12 +199,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/MapAddEntryListenerWithPredicateCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/MapAddEntryListenerWithPredicateCodec.cs
@@ -178,7 +178,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -192,12 +192,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/MapAddPartitionLostListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/MapAddPartitionLostListenerCodec.cs
@@ -152,7 +152,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleMapPartitionLostEventAsync handleMapPartitionLostEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<int, Guid, object, ValueTask> handleMapPartitionLostEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -161,12 +161,10 @@ namespace Hazelcast.Protocol.Codecs
                 var initialFrame = iterator.Take();
                 var partitionId =  initialFrame.Bytes.ReadIntL(EventMapPartitionLostPartitionIdFieldOffset);
                 var uuid =  initialFrame.Bytes.ReadGuidL(EventMapPartitionLostUuidFieldOffset);
-                return handleMapPartitionLostEventAsync(partitionId, uuid);
+                return handleMapPartitionLostEventAsync(partitionId, uuid, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleMapPartitionLostEventAsync(int partitionId, Guid uuid);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/MultiMapAddEntryListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/MultiMapAddEntryListenerCodec.cs
@@ -161,7 +161,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -175,12 +175,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/MultiMapAddEntryListenerToKeyCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/MultiMapAddEntryListenerToKeyCodec.cs
@@ -169,7 +169,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -183,12 +183,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/QueueAddListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/QueueAddListenerCodec.cs
@@ -156,7 +156,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleItemEventAsync handleItemEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, Guid, int, object, ValueTask> handleItemEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -166,12 +166,10 @@ namespace Hazelcast.Protocol.Codecs
                 var uuid =  initialFrame.Bytes.ReadGuidL(EventItemUuidFieldOffset);
                 var eventType =  initialFrame.Bytes.ReadIntL(EventItemEventTypeFieldOffset);
                 var item = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleItemEventAsync(item, uuid, eventType);
+                return handleItemEventAsync(item, uuid, eventType, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleItemEventAsync(IData item, Guid uuid, int eventType);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddEntryListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddEntryListenerCodec.cs
@@ -153,7 +153,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -167,12 +167,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddEntryListenerToKeyCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddEntryListenerToKeyCodec.cs
@@ -161,7 +161,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -175,12 +175,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.cs
@@ -168,7 +168,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -182,12 +182,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddEntryListenerWithPredicateCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddEntryListenerWithPredicateCodec.cs
@@ -161,7 +161,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -175,12 +175,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddNearCacheEntryListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ReplicatedMapAddNearCacheEntryListenerCodec.cs
@@ -161,7 +161,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleEntryEventAsync handleEntryEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, IData, IData, IData, int, Guid, int, object, ValueTask> handleEntryEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -175,12 +175,10 @@ namespace Hazelcast.Protocol.Codecs
                 var @value = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var oldValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
                 var mergingValue = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                return handleEntryEventAsync(key, @value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleEntryEventAsync(IData key, IData @value, IData oldValue, IData mergingValue, int eventType, Guid uuid, int numberOfAffectedEntries);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/SetAddListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/SetAddListenerCodec.cs
@@ -156,7 +156,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleItemEventAsync handleItemEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, Guid, int, object, ValueTask> handleItemEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -166,12 +166,10 @@ namespace Hazelcast.Protocol.Codecs
                 var uuid =  initialFrame.Bytes.ReadGuidL(EventItemUuidFieldOffset);
                 var eventType =  initialFrame.Bytes.ReadIntL(EventItemEventTypeFieldOffset);
                 var item = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
-                return handleItemEventAsync(item, uuid, eventType);
+                return handleItemEventAsync(item, uuid, eventType, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleItemEventAsync(IData item, Guid uuid, int eventType);
     }
 }

--- a/src/Hazelcast.Net/Protocol/Codecs/TopicAddMessageListenerCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/TopicAddMessageListenerCodec.cs
@@ -149,7 +149,7 @@ namespace Hazelcast.Protocol.Codecs
             return clientMessage;
         }
 #endif
-        public static ValueTask HandleEventAsync(ClientMessage clientMessage, HandleTopicEventAsync handleTopicEventAsync, ILoggerFactory loggerFactory)
+        public static ValueTask HandleEventAsync(ClientMessage clientMessage, Func<IData, long, Guid, object, ValueTask> handleTopicEventAsync, object state, ILoggerFactory loggerFactory)
         {
             using var iterator = clientMessage.GetEnumerator();
             var messageType = clientMessage.MessageType;
@@ -159,12 +159,10 @@ namespace Hazelcast.Protocol.Codecs
                 var publishTime =  initialFrame.Bytes.ReadLongL(EventTopicPublishTimeFieldOffset);
                 var uuid =  initialFrame.Bytes.ReadGuidL(EventTopicUuidFieldOffset);
                 var item = DataCodec.Decode(iterator);
-                return handleTopicEventAsync(item, publishTime, uuid);
+                return handleTopicEventAsync(item, publishTime, uuid, state);
             }
             loggerFactory.CreateLogger(typeof(EventHandler)).LogDebug("Unknown message type received on event handler :" + messageType);
             return default;
         }
-
-        public delegate ValueTask HandleTopicEventAsync(IData item, long publishTime, Guid uuid);
     }
 }


### PR DESCRIPTION
NOTE: this should be reviewed with this [client protocol PR](https://github.com/hazelcast/hazelcast-client-protocol/pull/352)

Makes it possible to pass a state object when subscribing:
```
var state = new MyState();
var id = dictionary.Subscribe(events => events
  .EntryAdded((sender, args) => { ... },
  state);
```

Which becomes available in the `args`:
```
(sender, args) =>
{
  var state = (MyState) args.State;
  // use state...
}
```

This makes it possible to pass data to the handler, when it is declared as a lambda, without having to rely on an implicit capture (closure) which can be expensive in some cases.