### PR TITLE
Make more things internal + cleaner

### DIFF
--- a/src/Hazelcast.Net.Examples/Client/CloudClientExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/CloudClientExample.cs
@@ -24,7 +24,6 @@ namespace Hazelcast.Examples.Client
         {
             // create an Hazelcast client and connect to a Cloud server
             var options = HazelcastOptions.Build();
-            options.Networking.Cloud.Enabled = true;
             options.Networking.Cloud.DiscoveryToken = "DISCOVERY_TOKEN_HASH"; // copied from Cloud console
             await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
 

--- a/src/Hazelcast.Net.Examples/Client/CloudClientSslExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/CloudClientSslExample.cs
@@ -25,7 +25,6 @@ namespace Hazelcast.Examples.Client
             // create an Hazelcast client and connect to a Cloud server
             var options = HazelcastOptions.Build();
             var cloud = options.Networking.Cloud;
-            cloud.Enabled = true;
             cloud.DiscoveryToken = "DISCOVERY_TOKEN_HASH"; // copied from Cloud console
 
             var ssl = options.Networking.Ssl;

--- a/src/Hazelcast.Net.Examples/Client/HostedExample.cs
+++ b/src/Hazelcast.Net.Examples/Client/HostedExample.cs
@@ -88,7 +88,7 @@ namespace Hazelcast.Examples.Client
                     // this is how options could be altered
                     services.Configure<HazelcastOptions>(options =>
                     {
-                        options.ClientNamePrefix = "test.client_";
+                        //options.Labels.Add("test");
                     });
 
                     // add a hosted service

--- a/src/Hazelcast.Net.Testing/ClusterRemoteTestBase.cs
+++ b/src/Hazelcast.Net.Testing/ClusterRemoteTestBase.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
+using Hazelcast.Clustering;
 using Hazelcast.Core;
 using NUnit.Framework;
 
@@ -47,7 +48,8 @@ namespace Hazelcast.Testing
         protected override HazelcastOptions CreateHazelcastOptions()
         {
             var options = base.CreateHazelcastOptions();
-            options.ClusterName = RcCluster?.Id ?? options.ClusterName;
+            var clusterOptions = (IClusterOptions) options;
+            clusterOptions.ClusterName = RcCluster?.Id ?? clusterOptions.ClusterName;
             return options;
         }
 

--- a/src/Hazelcast.Net.Tests/Configuration/HazelcastOptionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Configuration/HazelcastOptionsTests.cs
@@ -163,9 +163,8 @@ namespace Hazelcast.Tests.Configuration
             Assert.IsTrue(options.Addresses.Contains("otherhost"));
             Assert.IsFalse(options.ShuffleAddresses);
             Assert.IsFalse(options.SmartRouting);
-            Assert.IsFalse(options.RetryOperations);
+            Assert.IsFalse(options.RedoOperations);
             Assert.AreEqual(1000, options.ConnectionTimeoutMilliseconds);
-            Assert.AreEqual(1001, options.WaitForClientMilliseconds);
             Assert.AreEqual(ReconnectMode.DoNotReconnect, options.ReconnectMode);
             Assert.IsFalse(options.ShuffleAddresses);
 

--- a/src/Hazelcast.Net.Tests/Configuration/HazelcastOptionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Configuration/HazelcastOptionsTests.cs
@@ -124,6 +124,9 @@ namespace Hazelcast.Tests.Configuration
 
             var loadBalancer = options.LoadBalancer.Service;
             Assert.IsInstanceOf<RandomLoadBalancer>(loadBalancer);
+
+            var clusterOptions = (IClusterOptions) options;
+            Assert.AreEqual(1000, clusterOptions.WaitForConnectionMilliseconds);
         }
 
         [Test]
@@ -139,7 +142,9 @@ namespace Hazelcast.Tests.Configuration
         {
             var options = ReadResource(Resources.HazelcastOptions).Messaging;
 
-            Assert.AreEqual(1000, options.MaxFastInvocationCount);
+            // internal, cannot change
+            Assert.AreEqual(5, options.MaxFastInvocationCount);
+
             Assert.AreEqual(1001, options.MinRetryDelayMilliseconds);
             Assert.AreEqual(1003, options.OperationTimeoutMilliseconds);
         }
@@ -185,7 +190,9 @@ namespace Hazelcast.Tests.Configuration
             var cloudOptions = options.Cloud;
             Assert.IsTrue(cloudOptions.Enabled);
             Assert.AreEqual("token", cloudOptions.DiscoveryToken);
-            Assert.AreEqual(new Uri("http://cloud"), cloudOptions.UrlBase);
+
+            // constant
+            Assert.AreEqual(new Uri("https://coordinator.hazelcast.cloud/"), cloudOptions.UrlBase);
 
             var socketOptions = options.Socket;
             Assert.AreEqual(1000, socketOptions.BufferSizeKiB);

--- a/src/Hazelcast.Net.Tests/Networking/AddressProviderTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/AddressProviderTests.cs
@@ -80,7 +80,7 @@ namespace Hazelcast.Tests.Networking
 
             options.Cloud.DiscoveryToken = null;
             Assert.That(options.Cloud.Enabled, Is.False);
-            Assert.Throws<ArgumentException>(() => _ = new AddressProvider(options, loggerFactory));
+
             options.Cloud.DiscoveryToken = "*****";
             Assert.That(options.Cloud.Enabled, Is.True);
 

--- a/src/Hazelcast.Net.Tests/Networking/AddressProviderTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/AddressProviderTests.cs
@@ -78,11 +78,11 @@ namespace Hazelcast.Tests.Networking
 
             options.Addresses.Clear();
 
-            options.Cloud.Enabled = true;
-
             options.Cloud.DiscoveryToken = null;
+            Assert.That(options.Cloud.Enabled, Is.False);
             Assert.Throws<ArgumentException>(() => _ = new AddressProvider(options, loggerFactory));
             options.Cloud.DiscoveryToken = "*****";
+            Assert.That(options.Cloud.Enabled, Is.True);
 
             options.Cloud.UrlBase = null;
             Assert.Throws<ArgumentNullException>(() => _ = new AddressProvider(options, loggerFactory));

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
@@ -15,10 +15,12 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Hazelcast.Clustering;
 using Hazelcast.Core;
 using Hazelcast.Testing;
 using Hazelcast.Testing.Remote;
 using NUnit.Framework;
+using Cluster = Hazelcast.Testing.Remote.Cluster;
 
 namespace Hazelcast.Tests.Networking
 {
@@ -98,7 +100,7 @@ namespace Hazelcast.Tests.Networking
             options.Networking.Addresses.Clear();
             //options.Networking.Addresses.Add("localhost:5701");
             options.Networking.Addresses.Add("127.0.0.1:5701");
-            options.ClusterName = RcCluster.Id;
+            ((IClusterOptions) options).ClusterName = RcCluster.Id;
             options.LoggerFactory.Creator = () => LoggerFactory;
 
             var sslOptions = options.Networking.Ssl;

--- a/src/Hazelcast.Net.Tests/Resources/Options/HazelcastOptions.json
+++ b/src/Hazelcast.Net.Tests/Resources/Options/HazelcastOptions.json
@@ -7,6 +7,11 @@
     // name of the cluster
     "clusterName": "cluster",
 
+    // how long to pause before looking for clients again, when trying to
+    // set the client that handles cluster view events, and no client is
+    // available
+    "waitForClientMilliseconds": 1001,
+
     // client labels
     "labels": [
       "label_1",
@@ -78,19 +83,14 @@
       // whether to use smart routing
       "smartRouting": false,
 
-      // whether to retry non-readonly operations
-      "retryOperations": false,
+      // whether to redo non-readonly operations
+      "redoOperations": false,
 
       // ?
       "connectionTimeoutMilliseconds": 1000,
 
       // how to reconnect in case the client is disconnected from the cluster
       "reconnectMode": "doNotReconnect",
-
-      // how long to pause before looking for clients again, when trying to
-      // set the client that handles cluster view events, and no client is
-      // available
-      "waitForClientMilliseconds": 1001,
 
       "ssl": {
         "enabled": true,

--- a/src/Hazelcast.Net/Clustering/ClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterEvents.cs
@@ -554,15 +554,7 @@ namespace Hazelcast.Clustering
             // cancelled, when the cluster goes down (and never up again)
             while (!cancellationToken.IsCancellationRequested)
             {
-                connection ??= _clusterMembers.GetRandomConnection(false);
-
-                if (connection == null)
-                {
-                    // no clients => wait for clients
-                    // TODO: consider IRetryStrategy?
-                    await Task.Delay(_clusterState.Options.Networking.WaitForClientMilliseconds, cancellationToken).CAF();
-                    continue;
-                }
+                connection ??= await _clusterMembers.WaitRandomConnection(cancellationToken).CAF();
 
                 // try to subscribe, relying on the default invocation timeout,
                 // so this is not going to last forever - we know it will end

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -186,7 +186,7 @@ namespace Hazelcast.Clustering
 
                 // no clients => wait for clients
                 // this *may* throw
-                await Task.Delay(_clusterState.Options.Networking.WaitForClientMilliseconds, cancellationToken).CAF();
+                await Task.Delay(_clusterState.Options.WaitForConnectionMilliseconds, cancellationToken).CAF();
             }
 
             // this *will* throw

--- a/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
@@ -250,7 +250,7 @@ namespace Hazelcast.Clustering
                     // if it's retryable, and can be retried (no timeout etc), retry
                     // note that CanRetryAsync may wait (depending on the retry strategy)
                     // and may throw if canceled while waiting - and then the exception is rethrown
-                    if (invocation.IsRetryable(exception, _clusterState.Options.Networking.RetryOperations) &&
+                    if (invocation.IsRetryable(exception, _clusterState.Options.Networking.RedoOperations) &&
                         await invocation.CanRetryAsync(() => _clusterState.GetNextCorrelationId()).CAF())
                     {
                         HConsole.WriteLine(this, "Retrying...");

--- a/src/Hazelcast.Net/Clustering/IClusterOptions.cs
+++ b/src/Hazelcast.Net/Clustering/IClusterOptions.cs
@@ -27,19 +27,31 @@ namespace Hazelcast.Clustering
     internal interface IClusterOptions
     {
         /// <summary>
-        /// Gets the cluster name.
+        /// Gets or sets the cluster name.
         /// </summary>
-        string ClusterName { get; }
+        string ClusterName { get; set; }
 
         /// <summary>
-        /// Gets the client name.
+        /// Gets or sets the client name.
         /// </summary>
-        string ClientName { get; }
+        string ClientName { get; set; }
 
         /// <summary>
-        /// Gets the client name prefix.
+        /// Gets or sets the client name prefix.
         /// </summary>
-        string ClientNamePrefix { get; }
+        string ClientNamePrefix { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delay to pause for when looking for a client
+        /// to handle cluster view events and no client is available.
+        /// </summary>
+        /// <remarks>
+        /// <para>In some situations the cluster needs a connection: to subscribe to cluster-level
+        /// events (members view, partitions view), to begin a transaction... It then invokes
+        /// <see cref="ClusterMembers.WaitRandomConnection"/> which will try to return an available
+        /// connection, else will wait for <see cref="WaitForConnectionMilliseconds"/> before retrying.</para>
+        /// </remarks>
+        int WaitForConnectionMilliseconds { get; set; }
 
         /// <summary>
         /// Gets the client labels.

--- a/src/Hazelcast.Net/Data/CollectionItemEventTypes.cs
+++ b/src/Hazelcast.Net/Data/CollectionItemEventTypes.cs
@@ -23,14 +23,9 @@ namespace Hazelcast.Data
     public enum CollectionItemEventTypes
     {
         /// <summary>
-        /// Nothing (default value).
-        /// </summary>
-        Nothing = 0,
-
-        /// <summary>
         /// The item was added.
         /// </summary>
-        Added = 1,
+        Added = 1, // zero is for default, make sure we start at 1
 
         /// <summary>
         /// The item was removed.

--- a/src/Hazelcast.Net/Data/MapEventTypes.cs
+++ b/src/Hazelcast.Net/Data/MapEventTypes.cs
@@ -23,14 +23,9 @@ namespace Hazelcast.Data
     public enum MapEventTypes
     {
         /// <summary>
-        /// Nothing (default value).
-        /// </summary>
-        Nothing = 0,
-
-        /// <summary>
         /// The entry was added.
         /// </summary>
-        Added = 1,
+        Added = 1, // zero is for default, make sure we start at 1
 
         /// <summary>
         /// The entry was removed.

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HCollectionBase.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HCollectionBase.Events.cs
@@ -52,8 +52,8 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var sstate = ToSafeState<SubscriptionState<CollectionItemEventHandlers<T>>>(state);
 
+            if (eventTypeData == 0) return;
             var eventType = (CollectionItemEventTypes) eventTypeData;
-            if (eventType == CollectionItemEventTypes.Nothing) return;
 
             var member = Cluster.Members.GetMember(memberId);
             var item = LazyArg<T>(itemData);

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Events.cs
@@ -34,7 +34,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var handlers = new MapEventHandlers<TKey, TValue>();
             events(handlers);
 
-            var flags = MapEventTypes.Nothing;
+            var flags = default (MapEventTypes);
             foreach (var handler in handlers)
                 flags |= handler.EventType;
 
@@ -106,8 +106,8 @@ namespace Hazelcast.DistributedObjects.Impl
 
         private async ValueTask HandleEntryEvent(IData keyData, IData valueData, IData oldValueData, IData mergingValueData, int eventTypeData, Guid memberId, int numberOfAffectedEntries, object state)
         {
+            if (eventTypeData == 0) return;
             var eventType = (MapEventTypes) eventTypeData;
-            if (eventType == MapEventTypes.Nothing) return;
 
             var member = Cluster.Members.GetMember(memberId);
             var key = LazyArg<TKey>(keyData);

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMultiMap.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMultiMap.cs
@@ -102,8 +102,8 @@ namespace Hazelcast.DistributedObjects.Impl
 
         private async ValueTask HandleEntryEventAsync(IData keyData, IData valueData, IData oldValueData, IData mergingValueData, int eventTypeData, Guid memberId, int numberOfAffectedEntries, object state)
         {
+            if (eventTypeData == 0) return;
             var eventType = (MapEventTypes) eventTypeData;
-            if (eventType == MapEventTypes.Nothing) return;
 
             var member = Cluster.Members.GetMember(memberId);
             var key = LazyArg<TKey>(keyData);

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HReplicatedMap.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HReplicatedMap.cs
@@ -222,8 +222,8 @@ namespace Hazelcast.DistributedObjects.Impl
 
         private async ValueTask HandleEntryEventAsync(IData keyData, IData valueData, IData oldValueData, IData mergingValueData, int eventTypeData, Guid memberId, int numberOfAffectedEntries, object state)
         {
+            if (eventTypeData == 0) return;
             var eventType = (MapEventTypes) eventTypeData;
-            if (eventType == MapEventTypes.Nothing) return;
 
             var member = Cluster.Members.GetMember(memberId);
             var key = LazyArg<TKey>(keyData);

--- a/src/Hazelcast.Net/Events/ConnectionLifecycleEventArgs.cs
+++ b/src/Hazelcast.Net/Events/ConnectionLifecycleEventArgs.cs
@@ -17,7 +17,7 @@ namespace Hazelcast.Events
     /// <summary>
     /// Represents event data for connection lifecycle events.
     /// </summary>
-    public class ConnectionLifecycleEventArgs
+    internal class ConnectionLifecycleEventArgs
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionLifecycleEventArgs"/> class.

--- a/src/Hazelcast.Net/Events/ConnectionLifecycleEventType.cs
+++ b/src/Hazelcast.Net/Events/ConnectionLifecycleEventType.cs
@@ -20,14 +20,9 @@ namespace Hazelcast.Events
     internal enum ConnectionLifecycleEventType
     {
         /// <summary>
-        /// Nothing (default).
-        /// </summary>
-        Nothing = 0,
-
-        /// <summary>
         /// A connection was added.
         /// </summary>
-        Added,
+        Added = 1, // zero is for default, make sure we start at 1
 
         /// <summary>
         /// A connection was removed.

--- a/src/Hazelcast.Net/Events/DistributedObjectLifecycleEventType.cs
+++ b/src/Hazelcast.Net/Events/DistributedObjectLifecycleEventType.cs
@@ -20,14 +20,9 @@ namespace Hazelcast.Events
     public enum DistributedObjectLifecycleEventType
     {
         /// <summary>
-        /// Nothing (default)
-        /// </summary>
-        Nothing = 0,
-
-        /// <summary>
         /// The object was created.
         /// </summary>
-        Created,
+        Created = 1, // zero is for default, make sure we start at 1
 
         /// <summary>
         /// The object was destroyed.

--- a/src/Hazelcast.Net/HazelcastClientEventHandlers.cs
+++ b/src/Hazelcast.Net/HazelcastClientEventHandlers.cs
@@ -165,7 +165,7 @@ namespace Hazelcast
         /// </summary>
         /// <param name="handler">The handler.</param>
         /// <returns>The handlers.</returns>
-        public HazelcastClientEventHandlers ConnectionAdded(Action<IHazelcastClient, ConnectionLifecycleEventArgs> handler)
+        internal HazelcastClientEventHandlers ConnectionAdded(Action<IHazelcastClient, ConnectionLifecycleEventArgs> handler)
         {
             Add(new ConnectionLifecycleEventHandler(ConnectionLifecycleEventType.Added, handler.AsAsync()));
             return this;
@@ -176,7 +176,7 @@ namespace Hazelcast
         /// </summary>
         /// <param name="handler">The handler.</param>
         /// <returns>The handlers.</returns>
-        public HazelcastClientEventHandlers ConnectionAdded(Func<IHazelcastClient, ConnectionLifecycleEventArgs, ValueTask> handler)
+        internal HazelcastClientEventHandlers ConnectionAdded(Func<IHazelcastClient, ConnectionLifecycleEventArgs, ValueTask> handler)
         {
             Add(new ConnectionLifecycleEventHandler(ConnectionLifecycleEventType.Added, handler));
             return this;
@@ -187,7 +187,7 @@ namespace Hazelcast
         /// </summary>
         /// <param name="handler">The handler.</param>
         /// <returns>The handlers.</returns>
-        public HazelcastClientEventHandlers ConnectionRemoved(Action<IHazelcastClient, ConnectionLifecycleEventArgs> handler)
+        internal HazelcastClientEventHandlers ConnectionRemoved(Action<IHazelcastClient, ConnectionLifecycleEventArgs> handler)
         {
             Add(new ConnectionLifecycleEventHandler(ConnectionLifecycleEventType.Removed, handler.AsAsync()));
             return this;
@@ -198,7 +198,7 @@ namespace Hazelcast
         /// </summary>
         /// <param name="handler">The handler.</param>
         /// <returns>The handlers.</returns>
-        public HazelcastClientEventHandlers ConnectionRemoved(Func<IHazelcastClient, ConnectionLifecycleEventArgs, ValueTask> handler)
+        internal  HazelcastClientEventHandlers ConnectionRemoved(Func<IHazelcastClient, ConnectionLifecycleEventArgs, ValueTask> handler)
         {
             Add(new ConnectionLifecycleEventHandler(ConnectionLifecycleEventType.Removed, handler));
             return this;

--- a/src/Hazelcast.Net/HazelcastClientEventHandlers.cs
+++ b/src/Hazelcast.Net/HazelcastClientEventHandlers.cs
@@ -198,7 +198,7 @@ namespace Hazelcast
         /// </summary>
         /// <param name="handler">The handler.</param>
         /// <returns>The handlers.</returns>
-        internal  HazelcastClientEventHandlers ConnectionRemoved(Func<IHazelcastClient, ConnectionLifecycleEventArgs, ValueTask> handler)
+        internal HazelcastClientEventHandlers ConnectionRemoved(Func<IHazelcastClient, ConnectionLifecycleEventArgs, ValueTask> handler)
         {
             Add(new ConnectionLifecycleEventHandler(ConnectionLifecycleEventType.Removed, handler));
             return this;

--- a/src/Hazelcast.Net/HazelcastOptions.Build.cs
+++ b/src/Hazelcast.Net/HazelcastOptions.Build.cs
@@ -26,7 +26,7 @@ namespace Hazelcast
         /// Gets the Hazelcast configuration section name, which is <c>"hazelcast"</c>.
         /// </summary>
         /// <returns>The Hazelcast configuration section name, which is <c>"hazelcast"</c>.</returns>
-        public const string Hazelcast = "hazelcast";
+        internal const string Hazelcast = "hazelcast";
 
         /// <summary>
         /// Builds Hazelcast options.

--- a/src/Hazelcast.Net/HazelcastOptions.ClusterOptions.cs
+++ b/src/Hazelcast.Net/HazelcastOptions.ClusterOptions.cs
@@ -27,66 +27,43 @@ namespace Hazelcast
 {
     public partial class HazelcastOptions : IClusterOptions // ClusterName, Subscribers
     {
+        private string _clientNamePrefix;
+
         /// <summary>
         /// Gets the default cluster name, which is <c>"dev"</c>.
         /// </summary>
         /// <returns>The default cluster name, which is <c>"dev"</c>.</returns>
-        public const string DefaultClusterName = "dev";
+        internal const string DefaultClusterName = "dev";
 
         /// <summary>
         /// Gets the default client name prefix, which is <c>"hz.client_"</c>.
         /// </summary>
         /// <returns>The default client name prefix, which is <c>"hz.client_"</c>.</returns>
-        public const string DefaultClientNamePrefix = "hz.client_";
+        internal const string DefaultClientNamePrefix = "hz.client_";
 
-        /// <summary>
-        /// Gets or sets the cluster name.
-        /// </summary>
-        /// <returns>The cluster name.</returns>
+        /// <inheritdoc />
         public string ClusterName { get; set; } = DefaultClusterName;
 
-        /// <summary>
-        /// Gets or sets the client name.
-        /// </summary>
-        /// <returns>The client name.</returns>
-        /// <remarks>
-        /// <para>When <c>null</c>, the client name is derived from <see cref="ClientNamePrefix"/>.</para>
-        /// </remarks>
+        /// <inheritdoc />
         public string ClientName { get; set; } // null by default
 
-        /// <summary>
-        /// Gets or sets the client name prefix.
-        /// </summary>
-        /// <returns>The client name prefix.</returns>
-        public string ClientNamePrefix
+        /// <inheritdoc />
+        string IClusterOptions.ClientNamePrefix
         {
             get => string.IsNullOrWhiteSpace(_clientNamePrefix) ? DefaultClientNamePrefix : _clientNamePrefix;
             set => _clientNamePrefix = value;
         }
 
-        /// <summary>
-        /// Gets the client labels.
-        /// </summary>
-        /// <returns>The client labels.</returns>
+        /// <inheritdoc />
+        int IClusterOptions.WaitForConnectionMilliseconds { get; set; } = 1_000;
+
+        /// <inheritdoc />
         public ISet<string> Labels { get; } = new HashSet<string>();
 
-        /// <summary>
-        /// Gets the authentication options.
-        /// </summary>
-        /// <returns>The authentication options.</returns>
+        /// <inheritdoc />
         public AuthenticationOptions Authentication { get; } = new AuthenticationOptions();
 
-        /// <summary>
-        /// Gets the service factory for <see cref="ILoadBalancer"/>.
-        /// </summary>
-        /// <returns>The service factory for <see cref="ILoadBalancer"/>.</returns>
-        /// <remarks>
-        /// <para>A service factory is initialized with a creator function, that creates an
-        /// instance of the service. For instance:
-        /// <code>
-        /// options.LoadBalancer.Creator = () => new RandomLoadBalancer();
-        /// </code></para>
-        /// </remarks>
+        /// <inheritdoc />
         [BinderIgnore]
         public SingletonServiceFactory<ILoadBalancer> LoadBalancer { get; }
             = new SingletonServiceFactory<ILoadBalancer> { Creator = () => new RandomLoadBalancer() };
@@ -120,28 +97,16 @@ namespace Hazelcast
             }
         }
 
-        /// <summary>
-        /// Gets the heartbeat options.
-        /// </summary>
-        /// <returns>The heartbeat options.</returns>
+        /// <inheritdoc />
         public HeartbeatOptions Heartbeat { get; } = new HeartbeatOptions();
 
-        /// <summary>
-        /// Gets the messaging options.
-        /// </summary>
-        /// <returns>The messaging options.</returns>
+        /// <inheritdoc />
         public MessagingOptions Messaging { get; } = new MessagingOptions();
 
-        /// <summary>
-        /// Gets the networking options.
-        /// </summary>
-        /// <returns>The networking options.</returns>
+        /// <inheritdoc />
         public NetworkingOptions Networking { get; } = new NetworkingOptions();
 
-        /// <summary>
-        /// Gets the events options.
-        /// </summary>
-        /// <returns>The events options.</returns>
+        /// <inheritdoc />
         public EventsOptions Events { get; } = new EventsOptions();
     }
 }

--- a/src/Hazelcast.Net/HazelcastOptions.cs
+++ b/src/Hazelcast.Net/HazelcastOptions.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using Hazelcast.Clustering;
 using Hazelcast.Configuration.Binding;
 using Hazelcast.Core;
 
@@ -24,8 +25,6 @@ namespace Hazelcast
     /// </summary>
     public sealed partial class HazelcastOptions
     {
-        private string _clientNamePrefix;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="HazelcastOptions"/> class.
         /// </summary>
@@ -46,6 +45,8 @@ namespace Hazelcast
             Subscribers = new List<IHazelcastClientEventSubscriber>(other.Subscribers);
             Labels = new HashSet<string>(other.Labels);
             LoggerFactory = other.LoggerFactory.Clone();
+
+            ((IClusterOptions) this).ClientNamePrefix = ((IClusterOptions) other).ClientNamePrefix;
 
             Core = other.Core.Clone();
             Heartbeat = other.Heartbeat.Clone();

--- a/src/Hazelcast.Net/Messaging/MessagingOptions.cs
+++ b/src/Hazelcast.Net/Messaging/MessagingOptions.cs
@@ -38,7 +38,7 @@ namespace Hazelcast.Messaging
         /// <summary>
         /// Gets or sets the max fast invocation count.
         /// </summary>
-        public int MaxFastInvocationCount { get; set; } = 5;
+        internal int MaxFastInvocationCount { get; set; } = 5;
 
         /// <summary>
         /// Gets or sets the min retry delay.

--- a/src/Hazelcast.Net/NearCaching/NearCacheOptions.cs
+++ b/src/Hazelcast.Net/NearCaching/NearCacheOptions.cs
@@ -51,7 +51,7 @@ namespace Hazelcast.NearCaching
         /// <summary>
         /// Gets or sets the eviction percentage.
         /// </summary>
-        public int EvictionPercentage { get; set; } = 20;
+        internal int EvictionPercentage { get; set; } = 20;
 
         /// <summary>
         /// Gets or sets the in-memory format.
@@ -69,7 +69,7 @@ namespace Hazelcast.NearCaching
         /// <summary>
         /// Gets or sets the period of the cleanup.
         /// </summary>
-        public int CleanupPeriodSeconds { get; set; } = 5;
+        internal int CleanupPeriodSeconds { get; set; } = 5;
 
         /// <summary>
         /// Gets or sets the maximum size of the cache before entries get evicted.

--- a/src/Hazelcast.Net/NetStandard/HashCode.cs
+++ b/src/Hazelcast.Net/NetStandard/HashCode.cs
@@ -72,7 +72,7 @@ namespace System
     // https://github.com/Cyan4973/xxHash
 
     [ExcludeFromCodeCoverage] // not covering MS code
-    public struct HashCode
+    internal struct HashCode
     {
         private static readonly uint s_seed = GenerateGlobalSeed();
 

--- a/src/Hazelcast.Net/Networking/CloudOptions.cs
+++ b/src/Hazelcast.Net/Networking/CloudOptions.cs
@@ -32,7 +32,6 @@ namespace Hazelcast.Networking
         /// </summary>
         private CloudOptions(CloudOptions other)
         {
-            Enabled = other.Enabled;
             DiscoveryToken = other.DiscoveryToken;
             UrlBase = other.UrlBase;
         }
@@ -40,7 +39,7 @@ namespace Hazelcast.Networking
         /// <summary>
         /// Whether Hazelcast Cloud is enabled.
         /// </summary>
-        public bool Enabled { get; set; }
+        public bool Enabled => !string.IsNullOrWhiteSpace(DiscoveryToken);
 
         /// <summary>
         /// Gets or sets the discovery token of the cluster.
@@ -50,7 +49,7 @@ namespace Hazelcast.Networking
         /// <summary>
         /// Gets or sets the cloud url base.
         /// </summary>
-        public Uri UrlBase { get; set; } = new Uri("https://coordinator.hazelcast.cloud");
+        internal Uri UrlBase { get; set; } = new Uri("https://coordinator.hazelcast.cloud");
 
         /// <summary>
         /// Clones the options.

--- a/src/Hazelcast.Net/Networking/CloudOptions.cs
+++ b/src/Hazelcast.Net/Networking/CloudOptions.cs
@@ -39,7 +39,7 @@ namespace Hazelcast.Networking
         /// <summary>
         /// Whether Hazelcast Cloud is enabled.
         /// </summary>
-        public bool Enabled => !string.IsNullOrWhiteSpace(DiscoveryToken);
+        internal bool Enabled => !string.IsNullOrWhiteSpace(DiscoveryToken);
 
         /// <summary>
         /// Gets or sets the discovery token of the cluster.

--- a/src/Hazelcast.Net/Networking/NetworkingOptions.cs
+++ b/src/Hazelcast.Net/Networking/NetworkingOptions.cs
@@ -36,9 +36,8 @@ namespace Hazelcast.Networking
             Addresses = new List<string>(other.Addresses);
             ShuffleAddresses = other.ShuffleAddresses;
             SmartRouting = other.SmartRouting;
-            RetryOperations = other.RetryOperations;
+            RedoOperations = other.RedoOperations;
             ConnectionTimeoutMilliseconds = other.ConnectionTimeoutMilliseconds;
-            WaitForClientMilliseconds = other.WaitForClientMilliseconds;
             ReconnectMode = other.ReconnectMode;
 
             Ssl = other.Ssl.Clone();
@@ -95,7 +94,7 @@ namespace Hazelcast.Networking
         /// undesirable effects. Also note that the redo can perform on any member.</para>
         /// </remarks>
 
-        public bool RetryOperations { get; set; } = true;
+        public bool RedoOperations { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the connection timeout.
@@ -111,12 +110,6 @@ namespace Hazelcast.Networking
         /// Gets or sets the reconnection mode in case the client is disconnected.
         /// </summary>
         public ReconnectMode ReconnectMode { get; set; } = ReconnectMode.DoNotReconnect;
-
-        /// <summary>
-        /// Gets or sets the delay to pause for when looking for a client
-        /// to handle cluster view events and no client is available.
-        /// </summary>
-        public int WaitForClientMilliseconds { get; set; } = 1_000;
 
         /// <summary>
         /// Gets the SSL options.

--- a/src/Hazelcast.Net/Networking/SocketOptions.cs
+++ b/src/Hazelcast.Net/Networking/SocketOptions.cs
@@ -38,10 +38,11 @@ namespace Hazelcast.Networking
         }
 
         /// <summary>
-        /// The buffer size.
+        /// The send and receive buffers size.
         /// </summary>
         /// <remarks>
-        /// <para>The buffer size is expressed in Kibibytes, ie units of 1024 bytes.</para>
+        /// <para>The buffer size is expressed in Kibibytes, ie units of 1024 bytes. This
+        /// sets the size of both the send and receive buffers.</para>
         /// </remarks>
         public int BufferSizeKiB { get; set; } = 128;
 


### PR DESCRIPTION
ConnectionAdded/Removed events - internal 
HazelcastOptions#DefaultClientNamePrefix - internal
HazelcastOptions#Hazelcast - internal
HazelcastOptions#Messaging#MaxFastInvocationCount - internal
NearCacheOptions#CleanupPeriodSeconds and EvictionPercentage - internal
CloudOptions#UrlBase - internal
SocketOptions#BufferSizeKiB - documented
NetworkingOptions#RetryOnTargetDisconnected - renamed RedoOperations
NetworkingOptions#WaitForClientMilliseconds - documented + renamed + moved to cluster options
HazelcastOptions#ClientNamePrefix - internal
CloudOptions#Enabled - automatically enable if there is a token
ConnectionLifecycleEventArgs - internal
DistributedObjectLifecycleEventType - "Nothing" enumeration value removed
MemberLifecycleEventType - "Nothing" enumeration value removed
HashCode - internal