### PR TITLE
Cleanup after reviews

### DIFF
--- a/src/Hazelcast.Net.Tests/Clustering/LoadBalancingTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/LoadBalancingTests.cs
@@ -32,7 +32,12 @@ namespace Hazelcast.Tests.Clustering
             for (var i = 0; i < 4; i++)
                 Assert.That(lb.GetMember(), Is.EqualTo(memberId));
 
-            Assert.Throws<InvalidOperationException>(() => lb.NotifyMembers(new[] { Guid.NewGuid() }));
+            // no effect
+            lb.NotifyMembers(new[] { Guid.NewGuid() });
+
+            Assert.That(lb.Count, Is.EqualTo(1));
+            for (var i = 0; i < 4; i++)
+                Assert.That(lb.GetMember(), Is.EqualTo(memberId));
 
             lb = new StaticLoadBalancer(new Dictionary<string, string>
             {

--- a/src/Hazelcast.Net.Tests/Remote/ClientTxnListTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientTxnListTest.cs
@@ -31,7 +31,7 @@ namespace Hazelcast.Tests.Remote
 
             await using var context = await Client.BeginTransactionAsync();
 
-            var txList = await context.GetTransactionalAsync(list);
+            var txList = await context.GetListAsync<string>(list.Name);
             Assert.IsTrue(await txList.AddAsync("item2"));
             Assert.AreEqual(2, await txList.CountAsync());
             Assert.AreEqual(1, await list.CountAsync());

--- a/src/Hazelcast.Net.Tests/Remote/ClientTxnMultiMapTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientTxnMultiMapTest.cs
@@ -33,7 +33,7 @@ namespace Hazelcast.Tests.Remote
                 var key = i + "key";
                 await multiDictionary.PutAsync(key, "value");
                 await using var context = await Client.BeginTransactionAsync();
-                var txMultiDictionary = await context.GetTransactionalAsync(multiDictionary);
+                var txMultiDictionary = await context.GetMultiMapAsync<string, string>(multiDictionary.Name);
                 Assert.IsFalse(await txMultiDictionary.PutAsync(key, "value"));
                 Assert.IsTrue(await txMultiDictionary.PutAsync(key, "value1"));
                 Assert.IsTrue(await txMultiDictionary.PutAsync(key, "value2"));
@@ -51,7 +51,7 @@ namespace Hazelcast.Tests.Remote
             await multiDictionary.PutAsync(key, "value");
             var context = await Client.BeginTransactionAsync();
 
-            var txMultiDictionary = await context.GetTransactionalAsync(multiDictionary);
+            var txMultiDictionary = await context.GetMultiMapAsync<string, string>(multiDictionary.Name);
 
             Assert.IsFalse(await txMultiDictionary.PutAsync(key, "value"));
             Assert.IsTrue(await txMultiDictionary.PutAsync(key, "value1"));
@@ -74,7 +74,7 @@ namespace Hazelcast.Tests.Remote
             await multiDictionary.PutAsync(key, value);
             var context = await Client.BeginTransactionAsync();
 
-            var txMultiDictionary = await context.GetTransactionalAsync(multiDictionary);
+            var txMultiDictionary = await context.GetMultiMapAsync<string, string>(multiDictionary.Name);
             await txMultiDictionary.RemoveAsync(key, value);
             await context.CommitAsync();
 
@@ -95,7 +95,7 @@ namespace Hazelcast.Tests.Remote
 
             var context = await Client.BeginTransactionAsync();
 
-            var txMultiDictionary = await context.GetTransactionalAsync(multiDictionary);
+            var txMultiDictionary = await context.GetMultiMapAsync<string, string>(multiDictionary.Name);
             await txMultiDictionary.RemoveAsync(key);
             await context.CommitAsync();
 
@@ -113,7 +113,7 @@ namespace Hazelcast.Tests.Remote
 
             var context = await Client.BeginTransactionAsync();
 
-            var txMultiDictionary = await context.GetTransactionalAsync(multiDictionary);
+            var txMultiDictionary = await context.GetMultiMapAsync<string, string>(multiDictionary.Name);
 
             await txMultiDictionary.PutAsync(key, "newValue");
             await txMultiDictionary.PutAsync("newKey", value);
@@ -133,7 +133,7 @@ namespace Hazelcast.Tests.Remote
             await multiDictionary.PutAsync(key, value);
 
             var context = await Client.BeginTransactionAsync();
-            var txMultiDictionary = await context.GetTransactionalAsync(multiDictionary);
+            var txMultiDictionary = await context.GetMultiMapAsync<string, string>(multiDictionary.Name);
 
             await txMultiDictionary.PutAsync(key, "newValue");
 

--- a/src/Hazelcast.Net.Tests/Remote/ClientTxnSetTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientTxnSetTest.cs
@@ -31,7 +31,7 @@ namespace Hazelcast.Tests.Remote
 
             await using var context = await Client.BeginTransactionAsync();
 
-            var txSet = await context.GetTransactionalAsync(set);
+            var txSet = await context.GetSetAsync<string>(set.Name);
             Assert.IsTrue(await txSet.AddAsync("item2"));
             Assert.AreEqual(2, await txSet.CountAsync());
             Assert.AreEqual(1, await set.CountAsync());

--- a/src/Hazelcast.Net.Tests/Remote/TransactionTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/TransactionTests.cs
@@ -31,7 +31,7 @@ namespace Hazelcast.Tests.Remote
 
             await using (var tx = await Client.BeginTransactionAsync())
             {
-                var txList = await tx.GetTransactionalAsync(list);
+                var txList = await tx.GetListAsync<string>(list.Name);
 
                 Assert.IsTrue(await txList.AddAsync("item2"));
                 Assert.AreEqual(2, await txList.CountAsync());
@@ -59,7 +59,7 @@ namespace Hazelcast.Tests.Remote
 
             await using (var tx = await Client.BeginTransactionAsync())
             {
-                var txList = await tx.GetTransactionalAsync(list);
+                var txList = await tx.GetListAsync<string>(list.Name);
 
                 Assert.IsTrue(await txList.AddAsync("item2"));
                 Assert.AreEqual(2, await txList.CountAsync());
@@ -87,7 +87,7 @@ namespace Hazelcast.Tests.Remote
 
             await using (var tx = await Client.BeginTransactionAsync())
             {
-                var txList = await tx.GetTransactionalAsync(list);
+                var txList = await tx.GetListAsync<string>(list.Name);
 
                 Assert.IsTrue(await txList.AddAsync("item2"));
                 Assert.AreEqual(2, await txList.CountAsync());
@@ -116,7 +116,7 @@ namespace Hazelcast.Tests.Remote
 
             await using (var tx = await Client.BeginTransactionAsync())
             {
-                var txList = await tx.GetTransactionalAsync(list);
+                var txList = await tx.GetListAsync<string>(list.Name);
 
                 Assert.IsTrue(await txList.AddAsync("item2"));
                 Assert.AreEqual(2, await txList.CountAsync());

--- a/src/Hazelcast.Net/Clustering/DistributedEventExceptionEventArgs.cs
+++ b/src/Hazelcast.Net/Clustering/DistributedEventExceptionEventArgs.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ namespace Hazelcast.Clustering
     /// <summary>
     /// Represents the event data corresponding to an exception thrown while handling a distributed event.
     /// </summary>
-    public class DistributedEventExceptionEventArgs : EventArgs
+    internal class DistributedEventExceptionEventArgs : EventArgs
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DistributedEventExceptionEventArgs"/> class.

--- a/src/Hazelcast.Net/Clustering/IClusterOptions.cs
+++ b/src/Hazelcast.Net/Clustering/IClusterOptions.cs
@@ -62,6 +62,15 @@ namespace Hazelcast.Clustering
         /// Gets the service factory for <see cref="ILoadBalancer"/>.
         /// </summary>
         /// <returns>The service factory for <see cref="ILoadBalancer"/>.</returns>
+        /// <remarks>
+        /// <para>Load balancing determines how the Hazelcast client selects the member to
+        /// talk to, when it could talk to any member. By default it uses a round-robin
+        /// mechanism (see <see cref="RoundRobinLoadBalancer"/>), but it can also be random
+        /// (see <see cref="RandomLoadBalancer"/>) or static (see <see cref="StaticLoadBalancer"/>)
+        /// or any type that implements <see cref="ILoadBalancer"/>. In the configuration file,
+        /// the short names <c>roundrobin</c>, <c>random</c> and <c>static</c> can be used
+        /// in place of the full type name.</para>
+        /// </remarks>
         SingletonServiceFactory<ILoadBalancer> LoadBalancer { get; }
 
         /// <summary>

--- a/src/Hazelcast.Net/Clustering/LoadBalancing/StaticLoadBalancer.cs
+++ b/src/Hazelcast.Net/Clustering/LoadBalancing/StaticLoadBalancer.cs
@@ -55,6 +55,6 @@ namespace Hazelcast.Clustering.LoadBalancing
 
         /// <inheritdoc />
         public override void NotifyMembers(IEnumerable<Guid> memberIds)
-            => throw new InvalidOperationException("Static load balancer cannot be notified of new members.");
+        { }
     }
 }

--- a/src/Hazelcast.Net/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/Hazelcast.Net/Configuration/ConfigurationBuilderExtensions.cs
@@ -24,6 +24,14 @@ namespace Hazelcast.Configuration
     /// </summary>
     public static class ConfigurationBuilderExtensions
     {
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads Hazelcast configuration value from a file.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="filePath">The path to the file.</param>
+        /// <param name="fileName">The name of the file.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        /// <returns></returns>
         public static IConfigurationBuilder AddHazelcastFile(this IConfigurationBuilder configurationBuilder, string filePath, string fileName, string environmentName)
         {
             if (configurationBuilder == null) throw new ArgumentNullException(nameof(configurationBuilder));
@@ -69,7 +77,7 @@ namespace Hazelcast.Configuration
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         /// <remarks>
-        /// <para>Adds support for hazelcast.x.y arguments that do not respect the standard hazelcast:x:y pattern.</para>
+        /// <para>Adds support for `hazelcast.x.y` arguments that do not respect the standard `hazelcast:x:y` pattern.</para>
         /// <para>Does not add default support for command line arguments.</para>
         /// </remarks>
         public static IConfigurationBuilder AddHazelcastCommandLine(this IConfigurationBuilder configurationBuilder, string[] args)

--- a/src/Hazelcast.Net/DistributedObjects/CollectionItemEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/CollectionItemEventArgs.cs
@@ -39,7 +39,7 @@ namespace Hazelcast.DistributedObjects
         }
 
         /// <summary>
-        /// Gets the member.
+        /// Gets the member that fired the event.
         /// </summary>
         public MemberInfo Member { get; }
 

--- a/src/Hazelcast.Net/HazelcastOptions.ClusterOptions.cs
+++ b/src/Hazelcast.Net/HazelcastOptions.ClusterOptions.cs
@@ -66,7 +66,7 @@ namespace Hazelcast
         /// <inheritdoc />
         [BinderIgnore]
         public SingletonServiceFactory<ILoadBalancer> LoadBalancer { get; }
-            = new SingletonServiceFactory<ILoadBalancer> { Creator = () => new RandomLoadBalancer() };
+            = new SingletonServiceFactory<ILoadBalancer> { Creator = () => new RoundRobinLoadBalancer() };
 
         [BinderName("loadBalancer")]
         [BinderIgnore(false)]
@@ -89,6 +89,9 @@ namespace Hazelcast
                         break;
                     case "ROUNDROBIN":
                         LoadBalancer.Creator = () => new RoundRobinLoadBalancer();
+                        break;
+                    case "STATIC":
+                        LoadBalancer.Creator = () => new StaticLoadBalancer(value.Args);
                         break;
                     default:
                         LoadBalancer.Creator = () => ServiceFactory.CreateInstance<ILoadBalancer>(value.TypeName, value.Args);

--- a/src/Hazelcast.Net/Projections/IProjection.cs
+++ b/src/Hazelcast.Net/Projections/IProjection.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Hazelcast.Serialization;
-
 namespace Hazelcast.Projections
 {
     /// <summary>
@@ -24,6 +22,6 @@ namespace Hazelcast.Projections
     /// n-to-n projections.</para>
     /// <para>Projections must have a server-side counterpart.</para>
     /// </remarks>
-    public interface IProjection : IIdentifiedDataSerializable
+    public interface IProjection
     { }
 }

--- a/src/Hazelcast.Net/Projections/SingleAttributeProjection.cs
+++ b/src/Hazelcast.Net/Projections/SingleAttributeProjection.cs
@@ -21,7 +21,7 @@ namespace Hazelcast.Projections
     /// <summary>
     /// Represents a simple attribute projection.
     /// </summary>
-    public class SingleAttributeProjection : IProjection
+    public class SingleAttributeProjection : IProjection, IIdentifiedDataSerializable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleAttributeProjection"/> class/.

--- a/src/Hazelcast.Net/Security/KerberosCredentialsFactory.cs
+++ b/src/Hazelcast.Net/Security/KerberosCredentialsFactory.cs
@@ -22,7 +22,7 @@ namespace Hazelcast.Security
     /// <summary>
     /// Implements a Kerberos <see cref="ICredentialsFactory"/>.
     /// </summary>
-    public sealed class KerberosCredentialsFactory : IResettableCredentialsFactory
+    internal sealed class KerberosCredentialsFactory : IResettableCredentialsFactory
     {
         private static IKerberosTokenProvider _tokenProvider;
         private readonly string _spn;

--- a/src/Hazelcast.Net/Security/TokenCredentialsFactory.cs
+++ b/src/Hazelcast.Net/Security/TokenCredentialsFactory.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Security
     /// <summary>
     /// Provides an implementation of <see cref="ICredentialsFactory"/> that returns a static token <see cref="ICredentials"/>.
     /// </summary>
-    public class TokenCredentialsFactory : StaticCredentialsFactory
+    internal class TokenCredentialsFactory : StaticCredentialsFactory
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenCredentialsFactory"/>.

--- a/src/Hazelcast.Net/Security/UsernamePasswordCredentialsFactory.cs
+++ b/src/Hazelcast.Net/Security/UsernamePasswordCredentialsFactory.cs
@@ -20,7 +20,7 @@ namespace Hazelcast.Security
     /// <summary>
     /// Provides an implementation of <see cref="ICredentialsFactory"/> that returns a static username+password <see cref="ICredentials"/>.
     /// </summary>
-    public class UsernamePasswordCredentialsFactory : StaticCredentialsFactory
+    internal class UsernamePasswordCredentialsFactory : StaticCredentialsFactory
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UsernamePasswordCredentialsFactory"/> class.

--- a/src/Hazelcast.Net/Transactions/ITransactionContext.cs
+++ b/src/Hazelcast.Net/Transactions/ITransactionContext.cs
@@ -29,11 +29,6 @@ namespace Hazelcast.Transactions
         Guid TransactionId { get; }
 
         /// <summary>
-        /// Gets the state of the transaction.
-        /// </summary>
-        TransactionState State { get; }
-
-        /// <summary>
         /// Commits the transaction.
         /// </summary>
         Task CommitAsync();
@@ -64,14 +59,6 @@ namespace Hazelcast.Transactions
         Task<IHTxList<TItem>> GetListAsync<TItem>(string name);
 
         /// <summary>
-        /// Gets a <see cref="IHTxList{TItem}"/> transactional distributed object.
-        /// </summary>
-        /// <typeparam name="TItem">The type of the items.</typeparam>
-        /// <param name="source">The original, non-transactional list.</param>
-        /// <returns>The transactional list that was retrieved or created.</returns>
-        Task<IHTxList<TItem>> GetTransactionalAsync<TItem>(IHList<TItem> source);
-
-        /// <summary>
         /// Gets a <see cref="IHTxSet{TItem}"/> transactional distributed object.
         /// </summary>
         /// <typeparam name="TItem">The type of the items.</typeparam>
@@ -80,28 +67,12 @@ namespace Hazelcast.Transactions
         Task<IHTxSet<TItem>> GetSetAsync<TItem>(string name);
 
         /// <summary>
-        /// Gets a <see cref="IHTxSet{TItem}"/> transactional distributed object.
-        /// </summary>
-        /// <typeparam name="TItem">The type of the items.</typeparam>
-        /// <param name="source">The original, non-transactional set.</param>
-        /// <returns>The transactional set that was retrieved or created.</returns>
-        Task<IHTxSet<TItem>> GetTransactionalAsync<TItem>(IHSet<TItem> source);
-
-        /// <summary>
         /// Gets a <see cref="IHTxQueue{TItem}"/> transactional distributed object.
         /// </summary>
         /// <typeparam name="TItem">The type of the items.</typeparam>
         /// <param name="name">The unique name of the v.</param>
         /// <returns>The transactional queue that was retrieved or created.</returns>
         Task<IHTxQueue<TItem>> GetQueueAsync<TItem>(string name);
-
-        /// <summary>
-        /// Gets a <see cref="IHTxQueue{TItem}"/> transactional distributed object.
-        /// </summary>
-        /// <typeparam name="TItem">The type of the items.</typeparam>
-        /// <param name="source">The original, non-transactional queue.</param>
-        /// <returns>The transactional queue that was retrieved or created.</returns>
-        Task<IHTxQueue<TItem>> GetTransactionalAsync<TItem>(IHQueue<TItem> source);
 
         /// <summary>
         /// Gets a <see cref="IHTxMultiMap{TKey,TValue}"/> transactional distributed object.
@@ -113,15 +84,6 @@ namespace Hazelcast.Transactions
         Task<IHTxMultiMap<TKey, TValue>> GetMultiMapAsync<TKey, TValue>(string name);
 
         /// <summary>
-        /// Gets a <see cref="IHTxMultiMap{TKey,TValue}"/> transactional distributed object.
-        /// </summary>
-        /// <typeparam name="TKey">The type of the keys.</typeparam>
-        /// <typeparam name="TValue">The type of the values.</typeparam>
-        /// <param name="source">The original, non-transactional map.</param>
-        /// <returns>The transactional map that was retrieved or created.</returns>
-        Task<IHTxMultiMap<TKey, TValue>> GetTransactionalAsync<TKey, TValue>(IHMultiMap<TKey, TValue> source);
-
-        /// <summary>
         /// Gets a <see cref="IHTxMap{TKey,TValue}"/> transactional distributed object.
         /// </summary>
         /// <typeparam name="TKey">The type of the keys.</typeparam>
@@ -129,14 +91,5 @@ namespace Hazelcast.Transactions
         /// <param name="name">The unique name of the v.</param>
         /// <returns>The transactional map that was retrieved or created.</returns>
         Task<IHTxMap<TKey, TValue>> GetMapAsync<TKey, TValue>(string name);
-
-        /// <summary>
-        /// Gets a <see cref="IHTxMap{TKey,TValue}"/> transactional distributed object.
-        /// </summary>
-        /// <typeparam name="TKey">The type of the keys.</typeparam>
-        /// <typeparam name="TValue">The type of the values.</typeparam>
-        /// <param name="source">The original, non-transactional map.</param>
-        /// <returns>The transactional map that was retrieved or created.</returns>
-        Task<IHTxMap<TKey, TValue>> GetTransactionalAsync<TKey, TValue>(IHMap<TKey, TValue> source);
     }
 }

--- a/src/Hazelcast.Net/Transactions/TransactionContext.cs
+++ b/src/Hazelcast.Net/Transactions/TransactionContext.cs
@@ -61,7 +61,9 @@ namespace Hazelcast.Transactions
         /// <inheritdoc />
         public Guid TransactionId { get; private set; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the state of the transaction.
+        /// </summary>
         public TransactionState State { get; private set; }
 
         /// <summary>
@@ -231,20 +233,12 @@ namespace Hazelcast.Transactions
         // Objects
 
         /// <inheritdoc />
-        public Task<IHTxList<TItem>> GetTransactionalAsync<TItem>(IHList<TItem> source)
-            => GetListAsync<TItem>(source.Name);
-
-        /// <inheritdoc />
         public Task<IHTxList<TItem>> GetListAsync<TItem>(string name)
         {
             return _distributedObjectFactory.GetOrCreateAsync<IHTxList<TItem>, HTxList<TItem>>(ServiceNames.List, name, true,
                 (n, factory, cluster, serializationService, loggerFactory)
                     => new HTxList<TItem>(name, factory, cluster, _connection, TransactionId, serializationService, loggerFactory));
         }
-
-        /// <inheritdoc />
-        public Task<IHTxSet<TItem>> GetTransactionalAsync<TItem>(IHSet<TItem> source)
-            => GetSetAsync<TItem>(source.Name);
 
         /// <inheritdoc />
         public Task<IHTxSet<TItem>> GetSetAsync<TItem>(string name)
@@ -254,9 +248,7 @@ namespace Hazelcast.Transactions
                     => new HTxSet<TItem>(name, factory, cluster, _connection, TransactionId, serializationService, loggerFactory));
         }
 
-        public Task<IHTxQueue<TItem>> GetTransactionalAsync<TItem>(IHQueue<TItem> source)
-            => GetQueueAsync<TItem>(source.Name);
-
+        /// <inheritdoc />
         public Task<IHTxQueue<TItem>> GetQueueAsync<TItem>(string name)
         {
             return _distributedObjectFactory.GetOrCreateAsync<IHTxQueue<TItem>, HTxQueue<TItem>>(ServiceNames.Queue, name, true,
@@ -264,9 +256,7 @@ namespace Hazelcast.Transactions
                     => new HTxQueue<TItem>(name, factory, cluster, _connection, TransactionId, serializationService, loggerFactory));
         }
 
-        public Task<IHTxMultiMap<TKey, TValue>> GetTransactionalAsync<TKey, TValue>(IHMultiMap<TKey, TValue> source)
-            => GetMultiMapAsync<TKey, TValue>(source.Name);
-
+        /// <inheritdoc />
         public Task<IHTxMultiMap<TKey, TValue>> GetMultiMapAsync<TKey, TValue>(string name)
         {
             return _distributedObjectFactory.GetOrCreateAsync<IHTxMultiMap<TKey, TValue>, HTxMultiMap<TKey, TValue>>(ServiceNames.MultiMap, name, true,
@@ -274,9 +264,7 @@ namespace Hazelcast.Transactions
                     => new HTxMultiMap<TKey, TValue>(name, factory, cluster, _connection, TransactionId, serializationService, loggerFactory));
         }
 
-        public Task<IHTxMap<TKey, TValue>> GetTransactionalAsync<TKey, TValue>(IHMap<TKey, TValue> source)
-            => GetMapAsync<TKey, TValue>(source.Name);
-
+        /// <inheritdoc />
         public Task<IHTxMap<TKey, TValue>> GetMapAsync<TKey, TValue>(string name)
         {
             return _distributedObjectFactory.GetOrCreateAsync<IHTxMap<TKey, TValue>, HTxMap<TKey, TValue>>(ServiceNames.Map, name, true,

--- a/src/Hazelcast.Net/Transactions/TransactionState.cs
+++ b/src/Hazelcast.Net/Transactions/TransactionState.cs
@@ -14,7 +14,7 @@
 
 namespace Hazelcast.Transactions
 {
-    public enum TransactionState
+    internal enum TransactionState
     {
         None = 0, // default
         Active,


### PR DESCRIPTION

(merge after #336)

HazelcastOptions#LoadBalancingOptions - default is RoundRobin
Hazelcast Security - make all credentials factory internals, they can be configured via shortcuts in the configuration file, or extension methods in the code
ITransactionContext#State - internal
TransactionState - internal
ITransactionContext - get rid of GetTransactionalAsync methods
StaticLoadBalancer - throws on NotifyMembers - fixed
ConfigurationBuilderExtensions - document AddHazelcastFile
There is a rendered X in this page. I suppose this should be the :x:y text instead. https://hazelcast.github.io/hazelcast-csharp-client/dev/api/Hazelcast.Configuration.ConfigurationBuilderExtensions.AddHazelcastCommandLine.html#Hazelcast_Configuration_ConfigurationBuilderExtensions_AddHazelcastCommandLine_Microsoft_Extensions_Configuration_IConfigurationBuilder_System_String___
CollectionItemEventTypes - When does the server sends Nothing event (event type with 0 value)? - never, removed
MapEventTypes - Same comment as above for Nothing type.
CollectionItemEventArgs#Member we can improve the documentation a little bit by saying that this the member that fired the event.
IProjection - I guess this does not have to implement IIdentifiedDataSerializable - only specific projects may have to