### PR TITLE
Refactoring following reviews (3)

### DIFF
--- a/src/Hazelcast.Net.Benchmarks/Hazelcast.Net.Benchmarks.csproj
+++ b/src/Hazelcast.Net.Benchmarks/Hazelcast.Net.Benchmarks.csproj
@@ -5,6 +5,9 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Hazelcast.Benchmarks</RootNamespace>
     <AssemblyName>hb</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hazelcast.Net.Benchmarks/ReadWriteUtf8.cs
+++ b/src/Hazelcast.Net.Benchmarks/ReadWriteUtf8.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Hazelcast.Core;
+
+namespace Hazelcast.Benchmarks
+{
+    public class ReadWriteUtf8
+    {
+        private readonly byte[] _bytes = new byte[256];
+
+        // what about four chars?
+
+        [Benchmark]
+        public void BuiltinWriteUtf8()
+        {
+            var position = 0;
+
+            _bytes.WriteUtf8Char(ref position, Utf8Char.OneByte);
+            _bytes.WriteUtf8Char(ref position, Utf8Char.TwoBytes);
+            _bytes.WriteUtf8Char(ref position, Utf8Char.ThreeBytes);
+
+            if (position != 6) throw new Exception("position");
+        }
+
+        [Benchmark]
+        public void EncodingWriteUtf8()
+        {
+            var position = 0;
+
+            // that version yields
+            //
+            // |            Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+            // |------------------ |---------:|---------:|---------:|-------:|------:|------:|----------:|
+            // |  BuiltinWriteUtf8 | 12.80 ns | 0.272 ns | 0.255 ns |      - |     - |     - |         - |
+            // | EncodingWriteUtf8 | 32.69 ns | 0.419 ns | 0.392 ns | 0.0076 |     - |     - |      32 B |
+
+            //var chars = new[] { Utf8Char.OneByte, Utf8Char.TwoBytes, Utf8Char.ThreeBytes };
+            //position += Encoding.UTF8.GetBytes(chars, 0, chars.Length, _bytes, 0);
+
+            // that version yields
+            //
+            // |            Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+            // |------------------ |---------:|---------:|---------:|-------:|------:|------:|----------:|
+            // |  BuiltinWriteUtf8 | 12.62 ns | 0.236 ns | 0.375 ns |      - |     - |     - |         - |
+            // | EncodingWriteUtf8 | 71.60 ns | 0.877 ns | 0.820 ns | 0.0229 |     - |     - |      96 B |
+
+            //position += Encoding.UTF8.GetBytes(new []{ Utf8Char.OneByte }, 0, 1, _bytes, 0);
+            //position += Encoding.UTF8.GetBytes(new[] { Utf8Char.TwoBytes }, 0, 1, _bytes, 0);
+            //position += Encoding.UTF8.GetBytes(new[] { Utf8Char.ThreeBytes }, 0, 1, _bytes, 0);
+
+            if (position != 6) throw new Exception("position");
+        }
+
+        public static class Utf8Char
+        {
+            // http://www.i18nguy.com/unicode/supplementary-test.html
+
+            // '\u0078' ('x') LATIN SMALL LETTER X (U+0078) 78
+            public const char OneByte = '\u0078';
+
+            // '\u00E3' ('ã') LATIN SMALL LETTER A WITH TILDE (U+00E3) c3a3
+            public const char TwoBytes = '\u00e3';
+
+            // '\u08DF' ARABIC SMALL HIGH WORD WAQFA (U+08DF) e0a39f
+            public const char ThreeBytes = '\u08df';
+
+            // there are no '4 bytes' chars in C#, surrogate pairs are 2 chars
+            // '\u2070e' CJK UNIFIED IDEOGRAPH-2070E f0a09c8e
+            public const char FourBytesH = '\uf0a0';
+            public const char FourBytesL = '\u8c8e';
+        }
+    }
+}

--- a/src/Hazelcast.Net.Testing/Utf8Char.cs
+++ b/src/Hazelcast.Net.Testing/Utf8Char.cs
@@ -15,7 +15,15 @@
 
         // there are no '4 bytes' chars in C#, surrogate pairs are 2 chars
         // '\u2070e' CJK UNIFIED IDEOGRAPH-2070E f0a09c8e
-        public const char FourBytesH = '\uf0a0';
-        public const char FourBytesL = '\u8c8e';
+        public const char FourBytesH = (char) 0xd83d;
+        public const char FourBytesL = (char) 0xde01;
+
+        // can only be expressed as a string
+        // '\u1f601' GRINNING FACE WITH SMILING EYES f09f9881
+        public const string FourBytes = "😁"; // "\u1f601" - d83d + de01
+
+        // can only be expressed as a string
+        // '\u2070e' CJK UNIFIED IDEOGRAPH-2070E f0a09c8e
+        //public const string FourBytes = "𠜎"; // "\u2070e" - d841 + df0e
     }
 }

--- a/src/Hazelcast.Net.Tests/Serialization/StringSerializationTest.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/StringSerializationTest.cs
@@ -137,8 +137,10 @@ namespace Hazelcast.Tests.Serialization
         [Test]
         public void TestStringSurrogateCharEncode()
         {
-            var str = new string(new[] { Utf8Char.FourBytesH, Utf8Char.FourBytesL });
-            Assert.Throws<SerializationException>(() => _serializationService.ToData(str));
+            var data = _serializationService.ToData(Utf8Char.FourBytes);
+            var s = _serializationService.ToObject<string>(data);
+
+            Assert.That(s, Is.EqualTo(Utf8Char.FourBytes));
         }
 
         [Test]

--- a/src/Hazelcast.Net/Core/BytesExtensions.Protocol.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.Protocol.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace Hazelcast.Core
 {
-    public static partial class BytesExtensions // Protocol
+    internal static partial class BytesExtensions // Protocol
     {
         // use little endian where it makes sense
         // for some types (byte, bool...) it just does not make sense

--- a/src/Hazelcast.Net/Core/BytesExtensions.ReadFromByteArray.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.ReadFromByteArray.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace Hazelcast.Core
 {
@@ -263,12 +264,16 @@ namespace Hazelcast.Core
                 var b = bytes[position];
                 var x = b >> 4;
 
+                // 1 byte, 7 bits, represented as 0vvvvvvv
+                //                                ^^^^
                 if (x >= 0 && x <= 7)
                 {
                     position += 1;
                     return (char)b;
                 }
 
+                // 2 bytes, 11 bits, represented as 110vvvvv 10vvvvvv
+                //                                  ^^^^
                 if (x == 12 || x == 13)
                 {
                     if (bytes.Length < position + 2 * SizeOfByte)
@@ -280,6 +285,8 @@ namespace Hazelcast.Core
                     return (char)(first | second);
                 }
 
+                // 3 bytes, 16 bits, represented as 1110vvvv 10vvvvvv 10vvvvvv
+                //                                  ^^^^
                 if (x == 14)
                 {
                     if (bytes.Length < position + 3 * SizeOfByte)
@@ -296,6 +303,69 @@ namespace Hazelcast.Core
             }
         }
 
+        public static string ReadUtf8String(this byte[] bytes, ref int position, int length)
+        {
+            var buffer = ArrayPool<char>.Shared.Rent(length);
+            try
+            {
+                bytes.ReadUtf8Chars(ref position, buffer, length);
+                return new string(buffer, 0, length);
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
+        }
+
+        public static void ReadUtf8Chars(this byte[] bytes, ref int position, char[] buffer, int length)
+        {
+            if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+
+            if (position < 0 || bytes.Length < position + SizeOfByte)
+                throw new ArgumentOutOfRangeException(nameof(position));
+
+            if (length > buffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            var i = 0;
+
+            while (i < length)
+            {
+                var b = bytes[position];
+                var x = b >> 4;
+
+                if (x <= 14)
+                {
+                    buffer[i++] = ReadUtf8Char(bytes, ref position);
+                }
+                else
+                {
+                    // surrogate pair
+
+                    // 4 bytes, 21 bits, represented as 11110vvv 10vvvvvv 10vvvvvv 10vvvvvv
+                    //                                  0xf0     0x80     0x80     0x80
+                    //                                      0x0f     0x3f     0x3f     0x3f
+
+                    if (bytes.Length < position + 4 * SizeOfByte)
+                        throw new ArgumentOutOfRangeException(nameof(position));
+
+                    var first = (b & 0x07) << 18;
+                    var second = (bytes[position + 1] & 0x3f) << 12;
+                    var third = (bytes[position + 2] & 0x3f) << 6;
+                    var fourth = bytes[position + 3] & 0x3f;
+                    position += 4;
+
+                    var v = first | second | third | fourth; // real unicode value
+
+                    // which we need to split on two chars
+                    v -= 0x10000;
+                    buffer[i++] = (char)(0xd800 + ((v & 0xffc00) >> 10)); // high 10 bits
+                    if (i == length)
+                        throw new ArgumentOutOfRangeException(nameof(length));
+                    buffer[i++] = (char)(0xdc00 + (v & 0x3ff)); // low 10 bits
+                }
+            }
+        }
 
 
         /// <summary>

--- a/src/Hazelcast.Net/Core/BytesExtensions.ReadFromByteArray.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.ReadFromByteArray.cs
@@ -305,6 +305,8 @@ namespace Hazelcast.Core
 
         public static string ReadUtf8String(this byte[] bytes, ref int position, int length)
         {
+            if (length == 0) return "";
+
             var buffer = ArrayPool<char>.Shared.Rent(length);
             try
             {
@@ -320,6 +322,8 @@ namespace Hazelcast.Core
         public static void ReadUtf8Chars(this byte[] bytes, ref int position, char[] buffer, int length)
         {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+
+            if (length == 0) return;
 
             if (position < 0 || bytes.Length < position + SizeOfByte)
                 throw new ArgumentOutOfRangeException(nameof(position));

--- a/src/Hazelcast.Net/Core/BytesExtensions.ReadFromByteArray.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.ReadFromByteArray.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace Hazelcast.Core
 {
-    public static partial class BytesExtensions // Read from byte[]
+    internal static partial class BytesExtensions // Read from byte[]
     {
         /// <summary>
         /// Reads a <see cref="byte"/> value from an array of bytes.

--- a/src/Hazelcast.Net/Core/BytesExtensions.ReadFromReadOnlySequence.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.ReadFromReadOnlySequence.cs
@@ -18,7 +18,7 @@ using Hazelcast.Exceptions;
 
 namespace Hazelcast.Core
 {
-    public static partial class BytesExtensions // Read from ReadOnlySequence
+    internal static partial class BytesExtensions // Read from ReadOnlySequence
     {
         /// <summary>
         /// Reads an <see cref="ushort"/> value from a sequence of bytes, and slices the sequence accordingly.

--- a/src/Hazelcast.Net/Core/BytesExtensions.ReadFromReadOnlySpan.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.ReadFromReadOnlySpan.cs
@@ -17,7 +17,7 @@ using Hazelcast.Exceptions;
 
 namespace Hazelcast.Core
 {
-    public static partial class BytesExtensions // Read from ReadOnlySpan
+    internal static partial class BytesExtensions // Read from ReadOnlySpan
     {
         /// <summary>
         /// Reads a <see cref="short"/> value from a span of bytes.

--- a/src/Hazelcast.Net/Core/BytesExtensions.WriteToByteArray.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.WriteToByteArray.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Hazelcast.Core
 {
@@ -322,6 +324,7 @@ namespace Hazelcast.Core
         /// <param name="value">The value to write.</param>
         /// <remarks>
         /// <para>The position is incremented with the number of bytes written.</para>
+        /// <para>Surrogate pairs (chars that encode on 4 bytes) are not supported.</para>
         /// </remarks>
         public static void WriteUtf8Char(this byte[] bytes, ref int position, char value)
         {
@@ -330,6 +333,12 @@ namespace Hazelcast.Core
             if (position < 0)
                 throw new ArgumentOutOfRangeException(nameof(position));
 
+            WriteUtf8CharInternal(bytes, ref position, value);
+        }
+
+        private static void WriteUtf8CharInternal(byte[] bytes, ref int position, char value)
+        {
+            // 1 byte, 7 bits, represented as 0vvvvvvv
             if (value <= 0x007f)
             {
                 if (bytes.Length < position + SizeOfByte)
@@ -340,27 +349,104 @@ namespace Hazelcast.Core
                 return;
             }
 
+            // 2 bytes, 11 bits, represented as 110vvvvv 10vvvvvv
+            //                                  0xc0     0x80
+            //                                      0x1f     0x3f
             if (value <= 0x07ff)
             {
                 if (bytes.Length < position + 2 * SizeOfByte)
                     throw new ArgumentOutOfRangeException(nameof(position));
 
-                bytes[position] = (byte)(0xc0 | value >> 6 & 0x1f);
-                bytes[position + 1] = (byte)(0x80 | value & 0x3f);
+                bytes[position] = (byte)(0xc0 | ((value >> 6) & 0x1f));
+                bytes[position + 1] = (byte)(0x80 | (value & 0x3f));
                 position += 2;
                 return;
             }
 
-            if (bytes.Length < position + 3 * SizeOfByte)
+            // 3 bytes, 16 bits, represented as 1110vvvv 10vvvvvv 10vvvvvv
+            //                                  0xe0     0x80     0x80
+            //                                      0x0f     0x3f     0x3f
+            if (value <= 0xd7ff)
+            {
+                if (bytes.Length < position + 3 * SizeOfByte)
+                    throw new ArgumentOutOfRangeException(nameof(position));
+
+                bytes[position] = (byte)(0xe0 | ((value >> 12) & 0x0f));
+                bytes[position + 1] = (byte)(0x80 | ((value >> 6) & 0x3f));
+                bytes[position + 2] = (byte)(0x80 | (value & 0x3f));
+                position += 3;
+                return;
+            }
+
+            // high-surrogate (4 bytes) = not supported
+            throw new InvalidOperationException("Cannot write surrogate pairs.");
+        }
+
+        /// <summary>
+        /// Writes a <see cref="string"/> value to an array of bytes, encoded on 1, 2, 3 or 4 bytes.
+        /// </summary>
+        /// <param name="bytes">The array of bytes to write to.</param>
+        /// <param name="position">The position in the array where the value should be written.</param>
+        /// <param name="value">The value to write.</param>
+        /// <remarks>
+        /// <para>The position is incremented with the number of bytes written.</para>
+        /// </remarks>
+        public static void WriteUtf8Chars(this byte[] bytes, ref int position, string value)
+            => bytes.WriteUtf8String(ref position, value.ToCharArray());
+
+        /// <summary>
+        /// Writes <see cref="char"/> values to an array of bytes, encoded on 1, 2, 3 or 4 bytes.
+        /// </summary>
+        /// <param name="bytes">The array of bytes to write to.</param>
+        /// <param name="position">The position in the array where the value should be written.</param>
+        /// <param name="values">The values to write.</param>
+        /// <remarks>
+        /// <para>The position is incremented with the number of bytes written.</para>
+        /// </remarks>
+        public static void WriteUtf8String(this byte[] bytes, ref int position, char[] values)
+        {
+            if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+
+            if (position < 0)
                 throw new ArgumentOutOfRangeException(nameof(position));
 
-            if (value > 0xd7ff)
-                throw new InvalidOperationException("Cannot write surrogate pairs.");
+            for (var i = 0; i < values.Length; i++)
+            {
+                var value = values[i];
+                if (value <= 0xd7ff)
+                {
+                    WriteUtf8CharInternal(bytes, ref position, value);
+                }
+                else
+                {
+                    // surrogate pair
 
-            bytes[position] = (byte)(0xe0 | value >> 12 & 0x0f);
-            bytes[position + 1] = (byte)(0x80 | value >> 6 & 0x3f);
-            bytes[position + 2] = (byte)(0x80 | value & 0x3f);
-            position += 3;
+                    // 4 bytes, 21 bits, represented as 11110vvv 10vvvvvv 10vvvvvv 10vvvvvv
+                    //                                  0xf0     0x80     0x80     0x80
+                    //                                      0x0f     0x3f     0x3f     0x3f
+
+                    if (bytes.Length < position + 4 * SizeOfByte)
+                        throw new ArgumentOutOfRangeException(nameof(position));
+
+                    if (i == values.Length - 1)
+                        throw new InvalidOperationException("Incomplete surrogate pair.");
+
+                    // get the real unicode value as an int
+                    var v = (value - 0xd800) * 0x400 + (values[++i] - 0xdc00) + 0x10000;
+
+                    // note:
+                    //internal const char HIGH_SURROGATE_START = '\ud800';
+                    //internal const char HIGH_SURROGATE_END = '\udbff';
+                    //internal const char LOW_SURROGATE_START = '\udc00';
+                    //internal const char LOW_SURROGATE_END = '\udfff';
+
+                    bytes[position] = (byte)(0xf0 | ((v >> 18) & 0x07));
+                    bytes[position + 1] = (byte)(0x80 | ((v >> 12) & 0x3f));
+                    bytes[position + 2] = (byte)(0x80 | ((v >> 6) & 0x3f));
+                    bytes[position + 3] = (byte)(0x80 | (v & 0x3f));
+                    position += 4;
+                }
+            }
         }
 
 

--- a/src/Hazelcast.Net/Core/BytesExtensions.WriteToByteArray.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.WriteToByteArray.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace Hazelcast.Core
 {
-    public static partial class BytesExtensions // Write to byte[]
+    internal static partial class BytesExtensions // Write to byte[]
     {
         /// <summary>
         /// Writes a <see cref="byte"/> value to an array of bytes.

--- a/src/Hazelcast.Net/Core/BytesExtensions.cs
+++ b/src/Hazelcast.Net/Core/BytesExtensions.cs
@@ -22,7 +22,7 @@ namespace Hazelcast.Core
     /// <summary>
     /// Provides extension methods to byte buffers.
     /// </summary>
-    public static partial class BytesExtensions
+    internal static partial class BytesExtensions
     {
         /// <summary>
         /// Gets the size of a <see cref="byte"/> value in arrays or sequences of bytes.

--- a/src/Hazelcast.Net/Data/BitmapIndexOptions.cs
+++ b/src/Hazelcast.Net/Data/BitmapIndexOptions.cs
@@ -14,10 +14,20 @@
 
 namespace Hazelcast.Data
 {
+    /// <summary>
+    /// Configures indexing options for <see cref="IndexType.Bitmap"/> indexes.
+    /// </summary>
     public class BitmapIndexOptions
     {
+        /// <summary>
+        /// Gets or sets the unique key.
+        /// </summary>
         public string UniqueKey { get; set; } = Predicates.Predicate.KeyConst;
 
+        /// <summary>
+        /// Gets or sets the <see cref="UniqueKeyTransformation"/> which will be
+        /// applied to the <see cref="UniqueKey"/> value.
+        /// </summary>
         public UniqueKeyTransformation UniqueKeyTransformation { get; set; } = UniqueKeyTransformation.Object;
     }
 }

--- a/src/Hazelcast.Net/Data/EndpointQualifier.cs
+++ b/src/Hazelcast.Net/Data/EndpointQualifier.cs
@@ -17,7 +17,7 @@ using Hazelcast.Serialization;
 
 namespace Hazelcast.Data
 {
-    public class EndpointQualifier : IIdentifiedDataSerializable, IEquatable<EndpointQualifier>
+    internal class EndpointQualifier : IIdentifiedDataSerializable, IEquatable<EndpointQualifier>
     {
         public EndpointQualifier(ProtocolType type, string identifier)
         {

--- a/src/Hazelcast.Net/Data/IndexOptions.cs
+++ b/src/Hazelcast.Net/Data/IndexOptions.cs
@@ -90,7 +90,7 @@ namespace Hazelcast.Data
             return this;
         }
 
-        public static void ValidateAttribute(IndexOptions options, string attributeName)
+        internal static void ValidateAttribute(IndexOptions options, string attributeName)
         {
             if (attributeName == null)
                 throw new ArgumentNullException(nameof(attributeName), $"Attribute name cannot be null: {options}");

--- a/src/Hazelcast.Net/Data/IndexOptions.cs
+++ b/src/Hazelcast.Net/Data/IndexOptions.cs
@@ -22,14 +22,14 @@ namespace Hazelcast.Data
     /// Configuration of an index.
     /// </summary>
     /// <remarks>
-    /// Hazelcast support two types of indexes: sorted index and hash index.
-    /// Sorted indexes could be used with equality and range predicates and have logarithmic search time.
-    /// Hash indexes could be used with equality predicates and have constant search time assuming the hash
-    /// function of the indexed field disperses the elements properly.
-    /// <p>
-    /// Index could be created on one or more attributes.
+    /// <para>Hazelcast support three types of indexes: sorted, hash and bitmap indexes. They can be
+    /// created on one or more attributes, specified by their name.</para>
+    /// <para>Sorted indexes can be used with equality and range predicates and have logarithmic
+    /// search time.</para>
+    /// <para>Hash indexes can be used with equality predicates and have constant search time assuming
+    /// the hash function of the indexed field disperses the elements properly.</para>
+    /// <para>Bitmap indexes (to be completed).</para>
     /// </remarks>
-    /// <seealso cref="IndexType"/>
     public class IndexOptions
     {
         public static readonly IndexType DefaultType = IndexType.Sorted;
@@ -49,26 +49,29 @@ namespace Hazelcast.Data
         }
 
         /// <summary>
-        /// Name of the index.
+        /// Gets or sets the name of the index.
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
-        /// Type of the index.
+        /// Gets or sets the type of the index.
         /// </summary>
         public IndexType Type { get; set; } = DefaultType;
 
         /// <summary>
-        /// Indexed attributes.
+        /// Gets the indexed attributes.
         /// </summary>
         public IList<string> Attributes { get; } = new List<string>();
 
+        /// <summary>
+        /// Gets or sets the bitmap index options.
+        /// </summary>
         public BitmapIndexOptions BitmapIndexOptions{ get; set; } = new BitmapIndexOptions();
 
         /// <summary>
-        /// Adds an index attribute with the given.
+        /// Adds an indexed attribute.
         /// </summary>
-        /// <param name="attribute">Attribute name.</param>
+        /// <param name="attribute">The name of the attribute.</param>
         /// <returns>This instance for chaining.</returns>
         public IndexOptions AddAttribute(string attribute)
         {
@@ -77,6 +80,11 @@ namespace Hazelcast.Data
             return this;
         }
 
+        /// <summary>
+        /// Adds indexed attributes.
+        /// </summary>
+        /// <param name="attributes">The names of the attributes.</param>
+        /// <returns>This instance for chaining.</returns>
         public IndexOptions AddAttributes(params string[] attributes)
         {
             foreach (var attribute in attributes)
@@ -104,6 +112,7 @@ namespace Hazelcast.Data
                 throw new ArgumentException($"Attribute name cannot end with dot: {attributeName}", nameof(attributeName));
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"IndexConfig[Name={Name}, IndexType= {Type}, Attributes={string.Join(",", Attributes)}]";

--- a/src/Hazelcast.Net/Data/IndexType.cs
+++ b/src/Hazelcast.Net/Data/IndexType.cs
@@ -19,6 +19,8 @@ namespace Hazelcast.Data
     /// </summary>
     public enum IndexType
     {
+        // values MUST match IndexType.java
+
         /// <summary>
         /// Sorted index. Can be used with equality and range predicates.
         /// </summary>
@@ -27,6 +29,11 @@ namespace Hazelcast.Data
         /// <summary>
         /// Hash index. Can be used with equality predicates.
         /// </summary>
-        Hashed = 1
+        Hashed = 1,
+
+        /// <summary>
+        /// Bitmap index. Can be used with equality predicates.
+        /// </summary>
+        Bitmap = 2
     }
 }

--- a/src/Hazelcast.Net/Data/MemberInfo.cs
+++ b/src/Hazelcast.Net/Data/MemberInfo.cs
@@ -104,7 +104,7 @@ namespace Hazelcast.Data
         /// <summary>
         /// Gets the address map.
         /// </summary>
-        public IDictionary<EndpointQualifier, NetworkAddress> AddressMap { get; }
+        internal IDictionary<EndpointQualifier, NetworkAddress> AddressMap { get; }
 
         /// <inheritdoc />
         public override bool Equals(object obj)

--- a/src/Hazelcast.Net/Data/ProtocolType.cs
+++ b/src/Hazelcast.Net/Data/ProtocolType.cs
@@ -1,13 +1,13 @@
 ﻿namespace Hazelcast.Data
 {
-    public enum ProtocolType
+    internal enum ProtocolType
     {
-        // order must match ProtocolType.java
+        // values MUST match ProtocolType.java
 
         Member = 0,
-        Client,
-        Wan,
-        Rest,
-        MemCache
+        Client = 1,
+        Wan = 2,
+        Rest = 3,
+        MemCache = 4
     }
 }

--- a/src/Hazelcast.Net/Data/UniqueKeyTransformation.cs
+++ b/src/Hazelcast.Net/Data/UniqueKeyTransformation.cs
@@ -14,29 +14,32 @@
 
 namespace Hazelcast.Data
 {
+    /// <summary>
+    /// Defines transformations which can be applied to <see cref="BitmapIndexOptions.UniqueKey"/> values.
+    /// </summary>
     public enum UniqueKeyTransformation
     {
 #pragma warning disable CA1720 // Identifier contains type name - well, yes
 
-        /**
-         * Extracted unique key value is interpreted as an object value.
-         * Non-negative unique ID is assigned to every distinct object value.
-         */
+        /// <summary>
+        /// The unique key value is interpreted as an object value.
+        /// Non-negative unique ID is assigned to every distinct object value.
+        /// </summary>
         Object = 0,
 
-        /**
-         * Extracted unique key value is interpreted as a whole integer value of
-         * byte, short, int or long type. The extracted value is upcasted to
-         * long (if necessary) and unique non-negative ID is assigned to every
-         * distinct value.
-         */
+        /// <summary>
+        /// The unique key value is interpreted as a whole integer value of
+        /// byte, short, int or long type. The extracted value is upcasted to
+        /// long (if necessary) and unique non-negative ID is assigned to every
+        /// distinct value.
+        /// </summary>
         Long = 1,
 
-        /**
-         * Extracted unique key value is interpreted as a whole integer value of
-         * byte, short, int or long type. The extracted value is upcasted to
-         * long (if necessary) and the resulting value is used directly as an ID.
-         */
+        /// <summary>
+        /// The unique key value is interpreted as a whole integer value of
+        /// byte, short, int or long type. The extracted value is upcasted to
+        /// long (if necessary) and the resulting value is used directly as an ID.
+        /// </summary>
         Raw = 2
 
 #pragma warning restore CA1720

--- a/src/Hazelcast.Net/NearCaching/EvictionPolicy.cs
+++ b/src/Hazelcast.Net/NearCaching/EvictionPolicy.cs
@@ -32,6 +32,11 @@ namespace Hazelcast.NearCaching
         /// <summary>
         /// Evict least-frequently used entries first.
         /// </summary>
-        Lfu
+        Lfu,
+
+        /// <summary>
+        /// Evict random entries.
+        /// </summary>
+        Random
     }
 }

--- a/src/Hazelcast.Net/NearCaching/LfuComparer.cs
+++ b/src/Hazelcast.Net/NearCaching/LfuComparer.cs
@@ -40,4 +40,19 @@ namespace Hazelcast.NearCaching
             return cx.CompareTo(cy);
         }
     }
+
+    /// <summary>
+    /// Compares <see cref="NearCacheEntry"/> randomly.
+    /// </summary>
+    internal class RandomComparer : IComparer<NearCacheEntry>
+    {
+        /// <inheritdoc />
+        public int Compare(NearCacheEntry x, NearCacheEntry y)
+        {
+            if (x == null) throw new ArgumentNullException(nameof(x));
+            if (y == null) throw new ArgumentNullException(nameof(y));
+
+            return 0; // meaning they are equal = no reason to pick one or the other
+        }
+    }
 }

--- a/src/Hazelcast.Net/NearCaching/NearCacheBase.cs
+++ b/src/Hazelcast.Net/NearCaching/NearCacheBase.cs
@@ -462,6 +462,7 @@ namespace Hazelcast.NearCaching
                 EvictionPolicy.Lfu => new LfuComparer(),
                 EvictionPolicy.Lru => new LruComparer(),
                 EvictionPolicy.None => new DefaultComparer(),
+                EvictionPolicy.Random => new RandomComparer(),
                 _ => throw new NotSupportedException()
             };
         }

--- a/src/Hazelcast.Net/NearCaching/RandomComparer.cs
+++ b/src/Hazelcast.Net/NearCaching/RandomComparer.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,9 +18,9 @@ using System.Collections.Generic;
 namespace Hazelcast.NearCaching
 {
     /// <summary>
-    /// Compares <see cref="NearCacheEntry"/> using the least-frequently-used comparison.
+    /// Compares <see cref="NearCacheEntry"/> randomly.
     /// </summary>
-    internal class LfuComparer : IComparer<NearCacheEntry>
+    internal class RandomComparer : IComparer<NearCacheEntry>
     {
         /// <inheritdoc />
         public int Compare(NearCacheEntry x, NearCacheEntry y)
@@ -28,16 +28,7 @@ namespace Hazelcast.NearCaching
             if (x == null) throw new ArgumentNullException(nameof(x));
             if (y == null) throw new ArgumentNullException(nameof(y));
 
-            var cx = x.Hits;
-            var cy = y.Hits;
-
-            var c = cx.CompareTo(cy);
-            if (c != 0) return c;
-
-            cx = x.KeyData.GetHashCode();
-            cy = y.KeyData.GetHashCode();
-
-            return cx.CompareTo(cy);
+            return 0; // meaning they are equal = no reason to pick one or the other
         }
     }
 }

--- a/src/Hazelcast.Net/Properties/AssemblyInfo.cs
+++ b/src/Hazelcast.Net/Properties/AssemblyInfo.cs
@@ -20,6 +20,7 @@ using Hazelcast;
 
 [assembly: InternalsVisibleTo("Hazelcast.Net.Tests, PublicKey=" + AssemblySigning.PublicKey)]
 [assembly: InternalsVisibleTo("Hazelcast.Net.Testing, PublicKey=" + AssemblySigning.PublicKey)]
+[assembly: InternalsVisibleTo("hb, PublicKey=" + AssemblySigning.PublicKey)]
 [assembly: InternalsVisibleTo("Hazelcast.Net.DependencyInjection, PublicKey=" + AssemblySigning.PublicKey)]
 
 // We propose to accept that the code is not CLS Compliant anymore (remove

--- a/src/Hazelcast.Net/Serialization/ByteArrayObjectDataInput.cs
+++ b/src/Hazelcast.Net/Serialization/ByteArrayObjectDataInput.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Buffers;
 using Hazelcast.Core;
 using Hazelcast.Exceptions;
 
@@ -412,7 +411,7 @@ namespace Hazelcast.Serialization
             // each char can be 1, 2 or 3 bytes - surrogate pairs are reported as 2 chars
             // note: this is consistent with Java
 
-            return _data.ReadUtf8String(ref _position, length);
+            return length == 0 ? "" : _data.ReadUtf8String(ref _position, length);
         }
 
         /// <inheritdoc />

--- a/src/Hazelcast.Net/Serialization/ByteArrayObjectDataInput.cs
+++ b/src/Hazelcast.Net/Serialization/ByteArrayObjectDataInput.cs
@@ -408,17 +408,11 @@ namespace Hazelcast.Serialization
             var length = ReadInt();
             if (length == ArraySerializer.NullArrayLength) return null;
 
-            var buffer = ArrayPool<char>.Shared.Rent(length);
-            try
-            {
-                for (var i = 0; i < length; i++)
-                    buffer[i] = _data.ReadUtf8Char(ref _position);
-                return new string(buffer, 0, length);
-            }
-            finally
-            {
-                ArrayPool<char>.Shared.Return(buffer);
-            }
+            // length is the length of the string, in chars
+            // each char can be 1, 2 or 3 bytes - surrogate pairs are reported as 2 chars
+            // note: this is consistent with Java
+
+            return _data.ReadUtf8String(ref _position, length);
         }
 
         /// <inheritdoc />

--- a/src/Hazelcast.Net/Serialization/ByteArrayObjectDataOutput.cs
+++ b/src/Hazelcast.Net/Serialization/ByteArrayObjectDataOutput.cs
@@ -363,13 +363,18 @@ namespace Hazelcast.Serialization
         {
             endianness = endianness.Resolve(DefaultEndianness);
 
+            // length is the length of the string, in chars
+            // each char can be 1, 2 or 3 bytes - surrogate pairs are reported as 2 chars
+            // note: this is consistent with Java
+
             var length = value?.Length ?? ArraySerializer.NullArrayLength;
             Write(length, endianness);
             if (value == null || length <= 0) return;
 
-            Validate(_position, length * 3 * BytesExtensions.SizeOfByte); // UTF8 char is max 3 bytes
-            for (var i = 0; i < length; i++)
-                _data.WriteUtf8Char(ref _position, value[i]);
+            // and so, this is safe for ensuring we have enough bytes
+            Validate(_position, length * 4 * BytesExtensions.SizeOfByte);
+
+            _data.WriteUtf8Chars(ref _position, value);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
IndexOptions - Equivalent of ValidateAttribute(IndexOptions, String) is private on Java.
ProtocolType - Related to advanced network configuration, can also be made private.
IndexType - There is no enum variant for Bitmap indexes - added
BytesExtensions - I believe we don't expose buffer objects we operate on - internal
EndpointQualifier - I believe this class is added to make protocol code generator happy. It is only useful for advanced network configuration(which Java has, but I believe other clients don't), so it should be good to make it private. - internal
MemberInfo - AddressMap this is also related to advanced network config, I believe this one can be made private too - internal
BytesExtensions#ReadUtf8Char(Byte[], ref Int32) (and write too) - The documentation says that it operates on 1,2 or 3 bytes chars. What about 4 bytes chars like 😁? - fixed, chars are only for 1, 2 or 3 but added support for strings with support for surrogate pairs (4 bytes)
BitmapIndexOptions - There is no documentation for the class and its fields. - documented
IndexOptions - There are some missing documentation (documentation for class, BitmapIndexOptions, addAttributes method) - added
NearCacheOptions#EvictionPolicy - Java also have Random eviction option - implemented