### PR TITLE
Bugfix: memory leak in stream ReadAsync

### DIFF
--- a/src/Hazelcast.Net/Networking/SocketConnectionBase.cs
+++ b/src/Hazelcast.Net/Networking/SocketConnectionBase.cs
@@ -170,7 +170,7 @@ namespace Hazelcast.Networking
         protected Pipe Pipe => _pipe;
 
         /// <summary>
-        /// Gets the stream read cancellation token source - for unit tests exclusively.
+        /// (protected for tests only) Gets the stream read cancellation token source.
         /// </summary>
         // ReSharper disable once InconsistentNaming
         protected CancellationTokenSource StreamReadCancellationTokenSource => _streamReadCancellationTokenSource;


### PR DESCRIPTION
There was a nasty memory leak in stream `ReadAsync` that has been exposed by soak tests.
Fixed.