### PR TITLE
Rename .CAF() into .CfAwait()

### DIFF
--- a/src/Hazelcast.Net.Testing/AssertEx.cs
+++ b/src/Hazelcast.Net.Testing/AssertEx.cs
@@ -75,7 +75,7 @@ namespace Hazelcast.Testing
                 {
                     try
                     {
-                        await action().CAF();
+                        await action().CfAwait();
                         break;
                     }
                     catch (AssertionException e)

--- a/src/Hazelcast.Net.Testing/ClusterRemoteTestBase.cs
+++ b/src/Hazelcast.Net.Testing/ClusterRemoteTestBase.cs
@@ -28,8 +28,8 @@ namespace Hazelcast.Testing
         public async Task ClusterOneTimeSetUp()
         {
             // create remote client and cluster
-            RcClient = await ConnectToRemoteControllerAsync().CAF();
-            RcCluster = await RcClient.CreateClusterAsync(RcClusterConfiguration).CAF();
+            RcClient = await ConnectToRemoteControllerAsync().CfAwait();
+            RcCluster = await RcClient.CreateClusterAsync(RcClusterConfiguration).CfAwait();
         }
 
         [OneTimeTearDown]
@@ -39,8 +39,8 @@ namespace Hazelcast.Testing
             if (RcClient != null)
             {
                 if (RcCluster != null)
-                    await RcClient.ShutdownClusterAsync(RcCluster).CAF();
-                await RcClient.ExitAsync().CAF();
+                    await RcClient.ShutdownClusterAsync(RcCluster).CfAwait();
+                await RcClient.ExitAsync().CfAwait();
             }
         }
 

--- a/src/Hazelcast.Net.Testing/Networking/ManualResetEventAsync.cs
+++ b/src/Hazelcast.Net.Testing/Networking/ManualResetEventAsync.cs
@@ -55,7 +55,7 @@ namespace Hazelcast.Testing.Networking
             var cancellationSource = new TaskCompletionSource<object>();
             using var reg = cancellationToken.Register(() => cancellationSource.TrySetResult(null));
 
-            var task = await Task.WhenAny(_completionSource.Task, cancellationSource.Task).CAF();
+            var task = await Task.WhenAny(_completionSource.Task, cancellationSource.Task).CfAwait();
 
             if (task != cancellationSource.Task) return;
 

--- a/src/Hazelcast.Net.Testing/Remote/Cluster.cs
+++ b/src/Hazelcast.Net.Testing/Remote/Cluster.cs
@@ -62,10 +62,10 @@ namespace Hazelcast.Testing.Remote
       try
       {
         TField field;
-        await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+        await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
         while (true)
         {
-          field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+          field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
           if (field.Type == TType.Stop)
           {
             break;
@@ -76,22 +76,22 @@ namespace Hazelcast.Testing.Remote
             case 1:
               if (field.Type == TType.String)
               {
-                Id = await iprot.ReadStringAsync(cancellationToken).CAF();
+                Id = await iprot.ReadStringAsync(cancellationToken).CfAwait();
               }
               else
               {
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               }
               break;
             default:
-              await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+              await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               break;
           }
 
-          await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+          await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
         }
 
-        await iprot.ReadStructEndAsync(cancellationToken).CAF();
+        await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
       }
       finally
       {
@@ -105,19 +105,19 @@ namespace Hazelcast.Testing.Remote
       try
       {
         var struc = new TStruct("Cluster");
-        await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+        await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
         var field = new TField();
         if (Id != null && __isset.id)
         {
           field.Name = "id";
           field.Type = TType.String;
           field.ID = 1;
-          await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-          await oprot.WriteStringAsync(Id, cancellationToken).CAF();
-          await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+          await oprot.WriteStringAsync(Id, cancellationToken).CfAwait();
+          await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
         }
-        await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-        await oprot.WriteStructEndAsync(cancellationToken).CAF();
+        await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+        await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
       }
       finally
       {

--- a/src/Hazelcast.Net.Testing/Remote/Member.cs
+++ b/src/Hazelcast.Net.Testing/Remote/Member.cs
@@ -92,10 +92,10 @@ namespace Hazelcast.Testing.Remote
       try
       {
         TField field;
-        await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+        await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
         while (true)
         {
-          field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+          field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
           if (field.Type == TType.Stop)
           {
             break;
@@ -106,42 +106,42 @@ namespace Hazelcast.Testing.Remote
             case 1:
               if (field.Type == TType.String)
               {
-                Uuid = await iprot.ReadStringAsync(cancellationToken).CAF();
+                Uuid = await iprot.ReadStringAsync(cancellationToken).CfAwait();
               }
               else
               {
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               }
               break;
             case 2:
               if (field.Type == TType.String)
               {
-                Host = await iprot.ReadStringAsync(cancellationToken).CAF();
+                Host = await iprot.ReadStringAsync(cancellationToken).CfAwait();
               }
               else
               {
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               }
               break;
             case 3:
               if (field.Type == TType.I32)
               {
-                Port = await iprot.ReadI32Async(cancellationToken).CAF();
+                Port = await iprot.ReadI32Async(cancellationToken).CfAwait();
               }
               else
               {
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               }
               break;
             default:
-              await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+              await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               break;
           }
 
-          await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+          await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
         }
 
-        await iprot.ReadStructEndAsync(cancellationToken).CAF();
+        await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
       }
       finally
       {
@@ -155,37 +155,37 @@ namespace Hazelcast.Testing.Remote
       try
       {
         var struc = new TStruct("Member");
-        await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+        await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
         var field = new TField();
         if (Uuid != null && __isset.uuid)
         {
           field.Name = "uuid";
           field.Type = TType.String;
           field.ID = 1;
-          await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-          await oprot.WriteStringAsync(Uuid, cancellationToken).CAF();
-          await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+          await oprot.WriteStringAsync(Uuid, cancellationToken).CfAwait();
+          await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
         }
         if (Host != null && __isset.host)
         {
           field.Name = "host";
           field.Type = TType.String;
           field.ID = 2;
-          await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-          await oprot.WriteStringAsync(Host, cancellationToken).CAF();
-          await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+          await oprot.WriteStringAsync(Host, cancellationToken).CfAwait();
+          await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
         }
         if (__isset.port)
         {
           field.Name = "port";
           field.Type = TType.I32;
           field.ID = 3;
-          await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-          await oprot.WriteI32Async(Port, cancellationToken).CAF();
-          await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+          await oprot.WriteI32Async(Port, cancellationToken).CfAwait();
+          await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
         }
-        await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-        await oprot.WriteStructEndAsync(cancellationToken).CAF();
+        await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+        await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
       }
       finally
       {

--- a/src/Hazelcast.Net.Testing/Remote/RemoteController.cs
+++ b/src/Hazelcast.Net.Testing/Remote/RemoteController.cs
@@ -78,25 +78,25 @@ namespace Hazelcast.Testing.Remote
       }
       public async Task<bool> pingAsync(CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("ping", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("ping", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new pingArgs();
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new pingResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -106,25 +106,25 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> cleanAsync(CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("clean", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("clean", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new cleanArgs();
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new cleanResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -134,25 +134,25 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> exitAsync(CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("exit", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("exit", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new exitArgs();
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new exitResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -162,27 +162,27 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<Cluster> createClusterAsync(string hzVersion, string xmlconfig, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("createCluster", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("createCluster", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new createClusterArgs();
         args.HzVersion = hzVersion;
         args.Xmlconfig = xmlconfig;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new createClusterResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -196,26 +196,26 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<Member> startMemberAsync(string clusterId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("startMember", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("startMember", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new startMemberArgs();
         args.ClusterId = clusterId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new startMemberResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -229,27 +229,27 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> shutdownMemberAsync(string clusterId, string memberId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("shutdownMember", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("shutdownMember", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new shutdownMemberArgs();
         args.ClusterId = clusterId;
         args.MemberId = memberId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new shutdownMemberResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -259,27 +259,27 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> terminateMemberAsync(string clusterId, string memberId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("terminateMember", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("terminateMember", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new terminateMemberArgs();
         args.ClusterId = clusterId;
         args.MemberId = memberId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new terminateMemberResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -289,27 +289,27 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> suspendMemberAsync(string clusterId, string memberId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("suspendMember", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("suspendMember", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new suspendMemberArgs();
         args.ClusterId = clusterId;
         args.MemberId = memberId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new suspendMemberResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -319,27 +319,27 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> resumeMemberAsync(string clusterId, string memberId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("resumeMember", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("resumeMember", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new resumeMemberArgs();
         args.ClusterId = clusterId;
         args.MemberId = memberId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new resumeMemberResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -349,26 +349,26 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> shutdownClusterAsync(string clusterId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("shutdownCluster", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("shutdownCluster", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new shutdownClusterArgs();
         args.ClusterId = clusterId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new shutdownClusterResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -378,26 +378,26 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> terminateClusterAsync(string clusterId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("terminateCluster", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("terminateCluster", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new terminateClusterArgs();
         args.ClusterId = clusterId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new terminateClusterResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -407,26 +407,26 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<Cluster> splitMemberFromClusterAsync(string memberId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("splitMemberFromCluster", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("splitMemberFromCluster", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new splitMemberFromClusterArgs();
         args.MemberId = memberId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new splitMemberFromClusterResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -436,27 +436,27 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<Cluster> mergeMemberToClusterAsync(string clusterId, string memberId, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("mergeMemberToCluster", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("mergeMemberToCluster", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new mergeMemberToClusterArgs();
         args.ClusterId = clusterId;
         args.MemberId = memberId;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new mergeMemberToClusterResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -466,28 +466,28 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<Response> executeOnControllerAsync(string clusterId, string script, Lang lang, CancellationToken cancellationToken = default(CancellationToken))
       {
-        await OutputProtocol.WriteMessageBeginAsync(new TMessage("executeOnController", TMessageType.Call, SeqId), cancellationToken).CAF();
+        await OutputProtocol.WriteMessageBeginAsync(new TMessage("executeOnController", TMessageType.Call, SeqId), cancellationToken).CfAwait();
 
         var args = new executeOnControllerArgs();
         args.ClusterId = clusterId;
         args.Script = script;
         args.Lang = lang;
 
-        await args.WriteAsync(OutputProtocol, cancellationToken).CAF();
-        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CAF();
-        await OutputProtocol.Transport.FlushAsync(cancellationToken).CAF();
+        await args.WriteAsync(OutputProtocol, cancellationToken).CfAwait();
+        await OutputProtocol.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await OutputProtocol.Transport.FlushAsync(cancellationToken).CfAwait();
 
-        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CAF();
+        var msg = await InputProtocol.ReadMessageBeginAsync(cancellationToken).CfAwait();
         if (msg.Type == TMessageType.Exception)
         {
-          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CAF();
-          await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+          var x = await TApplicationException.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+          await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
           throw x;
         }
 
         var result = new executeOnControllerResult();
-        await result.ReadAsync(InputProtocol, cancellationToken).CAF();
-        await InputProtocol.ReadMessageEndAsync(cancellationToken).CAF();
+        await result.ReadAsync(InputProtocol, cancellationToken).CfAwait();
+        await InputProtocol.ReadMessageEndAsync(cancellationToken).CfAwait();
         if (result.__isset.success)
         {
           return result.Success;
@@ -527,31 +527,31 @@ namespace Hazelcast.Testing.Remote
 
       public async Task<bool> ProcessAsync(TProtocol iprot, TProtocol oprot)
       {
-        return await ProcessAsync(iprot, oprot, CancellationToken.None).CAF();
+        return await ProcessAsync(iprot, oprot, CancellationToken.None).CfAwait();
       }
 
       public async Task<bool> ProcessAsync(TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         try
         {
-          var msg = await iprot.ReadMessageBeginAsync(cancellationToken).CAF();
+          var msg = await iprot.ReadMessageBeginAsync(cancellationToken).CfAwait();
 
           ProcessFunction fn;
           processMap_.TryGetValue(msg.Name, out fn);
 
           if (fn == null)
           {
-            await TProtocolUtil.SkipAsync(iprot, TType.Struct, cancellationToken).CAF();
-            await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+            await TProtocolUtil.SkipAsync(iprot, TType.Struct, cancellationToken).CfAwait();
+            await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
             var x = new TApplicationException (TApplicationException.ExceptionType.UnknownMethod, "Invalid method name: '" + msg.Name + "'");
-            await oprot.WriteMessageBeginAsync(new TMessage(msg.Name, TMessageType.Exception, msg.SeqID), cancellationToken).CAF();
-            await x.WriteAsync(oprot, cancellationToken).CAF();
-            await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-            await oprot.Transport.FlushAsync(cancellationToken).CAF();
+            await oprot.WriteMessageBeginAsync(new TMessage(msg.Name, TMessageType.Exception, msg.SeqID), cancellationToken).CfAwait();
+            await x.WriteAsync(oprot, cancellationToken).CfAwait();
+            await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+            await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
             return true;
           }
 
-          await fn(msg.SeqID, iprot, oprot, cancellationToken).CAF();
+          await fn(msg.SeqID, iprot, oprot, cancellationToken).CfAwait();
 
         }
         catch (IOException)
@@ -565,14 +565,14 @@ namespace Hazelcast.Testing.Remote
       public async Task ping_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new pingArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new pingResult();
         try
         {
-          result.Success = await _iAsync.pingAsync(cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("ping", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.pingAsync(cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("ping", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -583,24 +583,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("ping", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("ping", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task clean_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new cleanArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new cleanResult();
         try
         {
-          result.Success = await _iAsync.cleanAsync(cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("clean", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.cleanAsync(cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("clean", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -611,24 +611,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("clean", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("clean", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task exit_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new exitArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new exitResult();
         try
         {
-          result.Success = await _iAsync.exitAsync(cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("exit", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.exitAsync(cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("exit", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -639,31 +639,31 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("exit", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("exit", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task createCluster_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new createClusterArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new createClusterResult();
         try
         {
           try
           {
-            result.Success = await _iAsync.createClusterAsync(args.HzVersion, args.Xmlconfig, cancellationToken).CAF();
+            result.Success = await _iAsync.createClusterAsync(args.HzVersion, args.Xmlconfig, cancellationToken).CfAwait();
           }
           catch (ServerException serverException)
           {
             result.ServerException = serverException;
           }
-          await oprot.WriteMessageBeginAsync(new TMessage("createCluster", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("createCluster", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -674,31 +674,31 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("createCluster", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("createCluster", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task startMember_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new startMemberArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new startMemberResult();
         try
         {
           try
           {
-            result.Success = await _iAsync.startMemberAsync(args.ClusterId, cancellationToken).CAF();
+            result.Success = await _iAsync.startMemberAsync(args.ClusterId, cancellationToken).CfAwait();
           }
           catch (ServerException serverException)
           {
             result.ServerException = serverException;
           }
-          await oprot.WriteMessageBeginAsync(new TMessage("startMember", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("startMember", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -709,24 +709,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("startMember", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("startMember", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task shutdownMember_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new shutdownMemberArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new shutdownMemberResult();
         try
         {
-          result.Success = await _iAsync.shutdownMemberAsync(args.ClusterId, args.MemberId, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("shutdownMember", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.shutdownMemberAsync(args.ClusterId, args.MemberId, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("shutdownMember", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -737,24 +737,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("shutdownMember", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("shutdownMember", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task terminateMember_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new terminateMemberArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new terminateMemberResult();
         try
         {
-          result.Success = await _iAsync.terminateMemberAsync(args.ClusterId, args.MemberId, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("terminateMember", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.terminateMemberAsync(args.ClusterId, args.MemberId, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("terminateMember", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -765,24 +765,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("terminateMember", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("terminateMember", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task suspendMember_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new suspendMemberArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new suspendMemberResult();
         try
         {
-          result.Success = await _iAsync.suspendMemberAsync(args.ClusterId, args.MemberId, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("suspendMember", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.suspendMemberAsync(args.ClusterId, args.MemberId, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("suspendMember", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -793,24 +793,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("suspendMember", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("suspendMember", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task resumeMember_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new resumeMemberArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new resumeMemberResult();
         try
         {
-          result.Success = await _iAsync.resumeMemberAsync(args.ClusterId, args.MemberId, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("resumeMember", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.resumeMemberAsync(args.ClusterId, args.MemberId, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("resumeMember", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -821,24 +821,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("resumeMember", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("resumeMember", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task shutdownCluster_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new shutdownClusterArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new shutdownClusterResult();
         try
         {
-          result.Success = await _iAsync.shutdownClusterAsync(args.ClusterId, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("shutdownCluster", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.shutdownClusterAsync(args.ClusterId, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("shutdownCluster", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -849,24 +849,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("shutdownCluster", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("shutdownCluster", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task terminateCluster_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new terminateClusterArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new terminateClusterResult();
         try
         {
-          result.Success = await _iAsync.terminateClusterAsync(args.ClusterId, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("terminateCluster", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.terminateClusterAsync(args.ClusterId, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("terminateCluster", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -877,24 +877,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("terminateCluster", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("terminateCluster", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task splitMemberFromCluster_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new splitMemberFromClusterArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new splitMemberFromClusterResult();
         try
         {
-          result.Success = await _iAsync.splitMemberFromClusterAsync(args.MemberId, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("splitMemberFromCluster", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.splitMemberFromClusterAsync(args.MemberId, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("splitMemberFromCluster", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -905,24 +905,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("splitMemberFromCluster", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("splitMemberFromCluster", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task mergeMemberToCluster_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new mergeMemberToClusterArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new mergeMemberToClusterResult();
         try
         {
-          result.Success = await _iAsync.mergeMemberToClusterAsync(args.ClusterId, args.MemberId, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("mergeMemberToCluster", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.mergeMemberToClusterAsync(args.ClusterId, args.MemberId, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("mergeMemberToCluster", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -933,24 +933,24 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("mergeMemberToCluster", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("mergeMemberToCluster", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
       public async Task executeOnController_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)
       {
         var args = new executeOnControllerArgs();
-        await args.ReadAsync(iprot, cancellationToken).CAF();
-        await iprot.ReadMessageEndAsync(cancellationToken).CAF();
+        await args.ReadAsync(iprot, cancellationToken).CfAwait();
+        await iprot.ReadMessageEndAsync(cancellationToken).CfAwait();
         var result = new executeOnControllerResult();
         try
         {
-          result.Success = await _iAsync.executeOnControllerAsync(args.ClusterId, args.Script, args.Lang, cancellationToken).CAF();
-          await oprot.WriteMessageBeginAsync(new TMessage("executeOnController", TMessageType.Reply, seqid), cancellationToken).CAF();
-          await result.WriteAsync(oprot, cancellationToken).CAF();
+          result.Success = await _iAsync.executeOnControllerAsync(args.ClusterId, args.Script, args.Lang, cancellationToken).CfAwait();
+          await oprot.WriteMessageBeginAsync(new TMessage("executeOnController", TMessageType.Reply, seqid), cancellationToken).CfAwait();
+          await result.WriteAsync(oprot, cancellationToken).CfAwait();
         }
         catch (TTransportException)
         {
@@ -961,11 +961,11 @@ namespace Hazelcast.Testing.Remote
           Console.Error.WriteLine("Error occurred in processor:");
           Console.Error.WriteLine(ex.ToString());
           var x = new TApplicationException(TApplicationException.ExceptionType.InternalError," Internal error.");
-          await oprot.WriteMessageBeginAsync(new TMessage("executeOnController", TMessageType.Exception, seqid), cancellationToken).CAF();
-          await x.WriteAsync(oprot, cancellationToken).CAF();
+          await oprot.WriteMessageBeginAsync(new TMessage("executeOnController", TMessageType.Exception, seqid), cancellationToken).CfAwait();
+          await x.WriteAsync(oprot, cancellationToken).CfAwait();
         }
-        await oprot.WriteMessageEndAsync(cancellationToken).CAF();
-        await oprot.Transport.FlushAsync(cancellationToken).CAF();
+        await oprot.WriteMessageEndAsync(cancellationToken).CfAwait();
+        await oprot.Transport.FlushAsync(cancellationToken).CfAwait();
       }
 
     }
@@ -984,10 +984,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -996,14 +996,14 @@ namespace Hazelcast.Testing.Remote
             switch (field.ID)
             {
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1017,9 +1017,9 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("ping_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1085,10 +1085,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -1099,22 +1099,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1128,7 +1128,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("ping_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -1136,12 +1136,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1196,10 +1196,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -1208,14 +1208,14 @@ namespace Hazelcast.Testing.Remote
             switch (field.ID)
             {
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1229,9 +1229,9 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("clean_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1297,10 +1297,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -1311,22 +1311,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1340,7 +1340,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("clean_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -1348,12 +1348,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1408,10 +1408,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -1420,14 +1420,14 @@ namespace Hazelcast.Testing.Remote
             switch (field.ID)
             {
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1441,9 +1441,9 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("exit_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1509,10 +1509,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -1523,22 +1523,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1552,7 +1552,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("exit_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -1560,12 +1560,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1656,10 +1656,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -1670,32 +1670,32 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  HzVersion = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  HzVersion = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 2:
                 if (field.Type == TType.String)
                 {
-                  Xmlconfig = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  Xmlconfig = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1709,28 +1709,28 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("createCluster_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (HzVersion != null && __isset.hzVersion)
           {
             field.Name = "hzVersion";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(HzVersion, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(HzVersion, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
           if (Xmlconfig != null && __isset.xmlconfig)
           {
             field.Name = "xmlconfig";
             field.Type = TType.String;
             field.ID = 2;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(Xmlconfig, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(Xmlconfig, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1831,10 +1831,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -1846,33 +1846,33 @@ namespace Hazelcast.Testing.Remote
                 if (field.Type == TType.Struct)
                 {
                   Success = new Cluster();
-                  await Success.ReadAsync(iprot, cancellationToken).CAF();
+                  await Success.ReadAsync(iprot, cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 1:
                 if (field.Type == TType.Struct)
                 {
                   ServerException = new ServerException();
-                  await ServerException.ReadAsync(iprot, cancellationToken).CAF();
+                  await ServerException.ReadAsync(iprot, cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -1886,7 +1886,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("createCluster_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -1896,9 +1896,9 @@ namespace Hazelcast.Testing.Remote
               field.Name = "Success";
               field.Type = TType.Struct;
               field.ID = 0;
-              await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-              await Success.WriteAsync(oprot, cancellationToken).CAF();
-              await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+              await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+              await Success.WriteAsync(oprot, cancellationToken).CfAwait();
+              await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
             }
           }
           else if(this.__isset.serverException)
@@ -1908,13 +1908,13 @@ namespace Hazelcast.Testing.Remote
               field.Name = "ServerException";
               field.Type = TType.Struct;
               field.ID = 1;
-              await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-              await ServerException.WriteAsync(oprot, cancellationToken).CAF();
-              await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+              await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+              await ServerException.WriteAsync(oprot, cancellationToken).CfAwait();
+              await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
             }
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2000,10 +2000,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -2014,22 +2014,22 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2043,19 +2043,19 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("startMember_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2146,10 +2146,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -2161,33 +2161,33 @@ namespace Hazelcast.Testing.Remote
                 if (field.Type == TType.Struct)
                 {
                   Success = new Member();
-                  await Success.ReadAsync(iprot, cancellationToken).CAF();
+                  await Success.ReadAsync(iprot, cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 1:
                 if (field.Type == TType.Struct)
                 {
                   ServerException = new ServerException();
-                  await ServerException.ReadAsync(iprot, cancellationToken).CAF();
+                  await ServerException.ReadAsync(iprot, cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2201,7 +2201,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("startMember_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -2211,9 +2211,9 @@ namespace Hazelcast.Testing.Remote
               field.Name = "Success";
               field.Type = TType.Struct;
               field.ID = 0;
-              await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-              await Success.WriteAsync(oprot, cancellationToken).CAF();
-              await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+              await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+              await Success.WriteAsync(oprot, cancellationToken).CfAwait();
+              await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
             }
           }
           else if(this.__isset.serverException)
@@ -2223,13 +2223,13 @@ namespace Hazelcast.Testing.Remote
               field.Name = "ServerException";
               field.Type = TType.Struct;
               field.ID = 1;
-              await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-              await ServerException.WriteAsync(oprot, cancellationToken).CAF();
-              await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+              await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+              await ServerException.WriteAsync(oprot, cancellationToken).CfAwait();
+              await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
             }
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2330,10 +2330,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -2344,32 +2344,32 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 2:
                 if (field.Type == TType.String)
                 {
-                  MemberId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  MemberId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2383,28 +2383,28 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("shutdownMember_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
           if (MemberId != null && __isset.memberId)
           {
             field.Name = "memberId";
             field.Type = TType.String;
             field.ID = 2;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(MemberId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(MemberId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2490,10 +2490,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -2504,22 +2504,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2533,7 +2533,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("shutdownMember_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -2541,12 +2541,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2637,10 +2637,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -2651,32 +2651,32 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 2:
                 if (field.Type == TType.String)
                 {
-                  MemberId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  MemberId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2690,28 +2690,28 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("terminateMember_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
           if (MemberId != null && __isset.memberId)
           {
             field.Name = "memberId";
             field.Type = TType.String;
             field.ID = 2;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(MemberId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(MemberId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2797,10 +2797,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -2811,22 +2811,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2840,7 +2840,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("terminateMember_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -2848,12 +2848,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2944,10 +2944,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -2958,32 +2958,32 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 2:
                 if (field.Type == TType.String)
                 {
-                  MemberId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  MemberId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -2997,28 +2997,28 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("suspendMember_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
           if (MemberId != null && __isset.memberId)
           {
             field.Name = "memberId";
             field.Type = TType.String;
             field.ID = 2;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(MemberId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(MemberId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3104,10 +3104,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -3118,22 +3118,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3147,7 +3147,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("suspendMember_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -3155,12 +3155,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3251,10 +3251,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -3265,32 +3265,32 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 2:
                 if (field.Type == TType.String)
                 {
-                  MemberId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  MemberId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3304,28 +3304,28 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("resumeMember_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
           if (MemberId != null && __isset.memberId)
           {
             field.Name = "memberId";
             field.Type = TType.String;
             field.ID = 2;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(MemberId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(MemberId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3411,10 +3411,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -3425,22 +3425,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3454,7 +3454,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("resumeMember_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -3462,12 +3462,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3543,10 +3543,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -3557,22 +3557,22 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3586,19 +3586,19 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("shutdownCluster_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3674,10 +3674,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -3688,22 +3688,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3717,7 +3717,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("shutdownCluster_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -3725,12 +3725,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3806,10 +3806,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -3820,22 +3820,22 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3849,19 +3849,19 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("terminateCluster_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3937,10 +3937,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -3951,22 +3951,22 @@ namespace Hazelcast.Testing.Remote
               case 0:
                 if (field.Type == TType.Bool)
                 {
-                  Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                  Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -3980,7 +3980,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("terminateCluster_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -3988,12 +3988,12 @@ namespace Hazelcast.Testing.Remote
             field.Name = "Success";
             field.Type = TType.Bool;
             field.ID = 0;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4069,10 +4069,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -4083,22 +4083,22 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  MemberId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  MemberId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4112,19 +4112,19 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("splitMemberFromCluster_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (MemberId != null && __isset.memberId)
           {
             field.Name = "memberId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(MemberId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(MemberId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4200,10 +4200,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -4215,22 +4215,22 @@ namespace Hazelcast.Testing.Remote
                 if (field.Type == TType.Struct)
                 {
                   Success = new Cluster();
-                  await Success.ReadAsync(iprot, cancellationToken).CAF();
+                  await Success.ReadAsync(iprot, cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4244,7 +4244,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("splitMemberFromCluster_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -4254,13 +4254,13 @@ namespace Hazelcast.Testing.Remote
               field.Name = "Success";
               field.Type = TType.Struct;
               field.ID = 0;
-              await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-              await Success.WriteAsync(oprot, cancellationToken).CAF();
-              await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+              await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+              await Success.WriteAsync(oprot, cancellationToken).CfAwait();
+              await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
             }
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4351,10 +4351,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -4365,32 +4365,32 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 2:
                 if (field.Type == TType.String)
                 {
-                  MemberId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  MemberId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4404,28 +4404,28 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("mergeMemberToCluster_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
           if (MemberId != null && __isset.memberId)
           {
             field.Name = "memberId";
             field.Type = TType.String;
             field.ID = 2;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(MemberId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(MemberId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4511,10 +4511,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -4526,22 +4526,22 @@ namespace Hazelcast.Testing.Remote
                 if (field.Type == TType.Struct)
                 {
                   Success = new Cluster();
-                  await Success.ReadAsync(iprot, cancellationToken).CAF();
+                  await Success.ReadAsync(iprot, cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4555,7 +4555,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("mergeMemberToCluster_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -4565,13 +4565,13 @@ namespace Hazelcast.Testing.Remote
               field.Name = "Success";
               field.Type = TType.Struct;
               field.ID = 0;
-              await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-              await Success.WriteAsync(oprot, cancellationToken).CAF();
-              await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+              await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+              await Success.WriteAsync(oprot, cancellationToken).CfAwait();
+              await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
             }
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4681,10 +4681,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -4695,42 +4695,42 @@ namespace Hazelcast.Testing.Remote
               case 1:
                 if (field.Type == TType.String)
                 {
-                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  ClusterId = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 2:
                 if (field.Type == TType.String)
                 {
-                  Script = await iprot.ReadStringAsync(cancellationToken).CAF();
+                  Script = await iprot.ReadStringAsync(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               case 3:
                 if (field.Type == TType.I32)
                 {
-                  Lang = (Lang)await iprot.ReadI32Async(cancellationToken).CAF();
+                  Lang = (Lang)await iprot.ReadI32Async(cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4744,37 +4744,37 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("executeOnController_args");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
           if (ClusterId != null && __isset.clusterId)
           {
             field.Name = "clusterId";
             field.Type = TType.String;
             field.ID = 1;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(ClusterId, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(ClusterId, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
           if (Script != null && __isset.script)
           {
             field.Name = "script";
             field.Type = TType.String;
             field.ID = 2;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteStringAsync(Script, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteStringAsync(Script, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
           if (__isset.lang)
           {
             field.Name = "lang";
             field.Type = TType.I32;
             field.ID = 3;
-            await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-            await oprot.WriteI32Async((int)Lang, cancellationToken).CAF();
-            await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+            await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+            await oprot.WriteI32Async((int)Lang, cancellationToken).CfAwait();
+            await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4870,10 +4870,10 @@ namespace Hazelcast.Testing.Remote
         try
         {
           TField field;
-          await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+          await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
           while (true)
           {
-            field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+            field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
             if (field.Type == TType.Stop)
             {
               break;
@@ -4885,22 +4885,22 @@ namespace Hazelcast.Testing.Remote
                 if (field.Type == TType.Struct)
                 {
                   Success = new Response();
-                  await Success.ReadAsync(iprot, cancellationToken).CAF();
+                  await Success.ReadAsync(iprot, cancellationToken).CfAwait();
                 }
                 else
                 {
-                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                  await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 }
                 break;
               default:
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
                 break;
             }
 
-            await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+            await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
           }
 
-          await iprot.ReadStructEndAsync(cancellationToken).CAF();
+          await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {
@@ -4914,7 +4914,7 @@ namespace Hazelcast.Testing.Remote
         try
         {
           var struc = new TStruct("executeOnController_result");
-          await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+          await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
           var field = new TField();
 
           if(this.__isset.success)
@@ -4924,13 +4924,13 @@ namespace Hazelcast.Testing.Remote
               field.Name = "Success";
               field.Type = TType.Struct;
               field.ID = 0;
-              await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-              await Success.WriteAsync(oprot, cancellationToken).CAF();
-              await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+              await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+              await Success.WriteAsync(oprot, cancellationToken).CfAwait();
+              await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
             }
           }
-          await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-          await oprot.WriteStructEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+          await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
         }
         finally
         {

--- a/src/Hazelcast.Net.Testing/Remote/RemoteControllerClient.cs
+++ b/src/Hazelcast.Net.Testing/Remote/RemoteControllerClient.cs
@@ -63,11 +63,11 @@ namespace Hazelcast.Testing.Remote
 
         private async Task<T> WithLock<T>(Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken)
         {
-            await _lock.WaitAsync(cancellationToken).CAF();
+            await _lock.WaitAsync(cancellationToken).CfAwait();
             try
             {
                 if (!cancellationToken.IsCancellationRequested)
-                    return await action(cancellationToken).CAF();
+                    return await action(cancellationToken).CfAwait();
                 else
                     return default;
             }
@@ -98,7 +98,7 @@ namespace Hazelcast.Testing.Remote
         /// <inheritdoc />
         public async Task<bool> ExitAsync(CancellationToken cancellationToken = default)
         {
-            var result = await WithLock(exitAsync, cancellationToken).CAF();
+            var result = await WithLock(exitAsync, cancellationToken).CfAwait();
             InputProtocol?.Transport?.Close();
             return result;
         }

--- a/src/Hazelcast.Net.Testing/Remote/Response.cs
+++ b/src/Hazelcast.Net.Testing/Remote/Response.cs
@@ -93,10 +93,10 @@ namespace Hazelcast.Testing.Remote
       try
       {
         TField field;
-        await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+        await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
         while (true)
         {
-          field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+          field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
           if (field.Type == TType.Stop)
           {
             break;
@@ -107,42 +107,42 @@ namespace Hazelcast.Testing.Remote
             case 1:
               if (field.Type == TType.Bool)
               {
-                Success = await iprot.ReadBoolAsync(cancellationToken).CAF();
+                Success = await iprot.ReadBoolAsync(cancellationToken).CfAwait();
               }
               else
               {
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               }
               break;
             case 2:
               if (field.Type == TType.String)
               {
-                Message = await iprot.ReadStringAsync(cancellationToken).CAF();
+                Message = await iprot.ReadStringAsync(cancellationToken).CfAwait();
               }
               else
               {
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               }
               break;
             case 3:
               if (field.Type == TType.String)
               {
-                Result = await iprot.ReadBinaryAsync(cancellationToken).CAF();
+                Result = await iprot.ReadBinaryAsync(cancellationToken).CfAwait();
               }
               else
               {
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               }
               break;
             default:
-              await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+              await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               break;
           }
 
-          await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+          await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
         }
 
-        await iprot.ReadStructEndAsync(cancellationToken).CAF();
+        await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
       }
       finally
       {
@@ -156,37 +156,37 @@ namespace Hazelcast.Testing.Remote
       try
       {
         var struc = new TStruct("Response");
-        await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+        await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
         var field = new TField();
         if (__isset.success)
         {
           field.Name = "success";
           field.Type = TType.Bool;
           field.ID = 1;
-          await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-          await oprot.WriteBoolAsync(Success, cancellationToken).CAF();
-          await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+          await oprot.WriteBoolAsync(Success, cancellationToken).CfAwait();
+          await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
         }
         if (Message != null && __isset.message)
         {
           field.Name = "message";
           field.Type = TType.String;
           field.ID = 2;
-          await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-          await oprot.WriteStringAsync(Message, cancellationToken).CAF();
-          await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+          await oprot.WriteStringAsync(Message, cancellationToken).CfAwait();
+          await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
         }
         if (Result != null && __isset.result)
         {
           field.Name = "result";
           field.Type = TType.String;
           field.ID = 3;
-          await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-          await oprot.WriteBinaryAsync(Result, cancellationToken).CAF();
-          await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+          await oprot.WriteBinaryAsync(Result, cancellationToken).CfAwait();
+          await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
         }
-        await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-        await oprot.WriteStructEndAsync(cancellationToken).CAF();
+        await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+        await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
       }
       finally
       {

--- a/src/Hazelcast.Net.Testing/Remote/ServerException.cs
+++ b/src/Hazelcast.Net.Testing/Remote/ServerException.cs
@@ -63,10 +63,10 @@ namespace Hazelcast.Testing.Remote
       try
       {
         TField field;
-        await iprot.ReadStructBeginAsync(cancellationToken).CAF();
+        await iprot.ReadStructBeginAsync(cancellationToken).CfAwait();
         while (true)
         {
-          field = await iprot.ReadFieldBeginAsync(cancellationToken).CAF();
+          field = await iprot.ReadFieldBeginAsync(cancellationToken).CfAwait();
           if (field.Type == TType.Stop)
           {
             break;
@@ -77,22 +77,22 @@ namespace Hazelcast.Testing.Remote
             case 1:
               if (field.Type == TType.String)
               {
-                Message = await iprot.ReadStringAsync(cancellationToken).CAF();
+                Message = await iprot.ReadStringAsync(cancellationToken).CfAwait();
               }
               else
               {
-                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+                await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               }
               break;
             default:
-              await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CAF();
+              await TProtocolUtil.SkipAsync(iprot, field.Type, cancellationToken).CfAwait();
               break;
           }
 
-          await iprot.ReadFieldEndAsync(cancellationToken).CAF();
+          await iprot.ReadFieldEndAsync(cancellationToken).CfAwait();
         }
 
-        await iprot.ReadStructEndAsync(cancellationToken).CAF();
+        await iprot.ReadStructEndAsync(cancellationToken).CfAwait();
       }
       finally
       {
@@ -106,19 +106,19 @@ namespace Hazelcast.Testing.Remote
       try
       {
         var struc = new TStruct("ServerException");
-        await oprot.WriteStructBeginAsync(struc, cancellationToken).CAF();
+        await oprot.WriteStructBeginAsync(struc, cancellationToken).CfAwait();
         var field = new TField();
         if (Message != null && __isset.message)
         {
           field.Name = "message";
           field.Type = TType.String;
           field.ID = 1;
-          await oprot.WriteFieldBeginAsync(field, cancellationToken).CAF();
-          await oprot.WriteStringAsync(Message, cancellationToken).CAF();
-          await oprot.WriteFieldEndAsync(cancellationToken).CAF();
+          await oprot.WriteFieldBeginAsync(field, cancellationToken).CfAwait();
+          await oprot.WriteStringAsync(Message, cancellationToken).CfAwait();
+          await oprot.WriteFieldEndAsync(cancellationToken).CfAwait();
         }
-        await oprot.WriteFieldStopAsync(cancellationToken).CAF();
-        await oprot.WriteStructEndAsync(cancellationToken).CAF();
+        await oprot.WriteFieldStopAsync(cancellationToken).CfAwait();
+        await oprot.WriteStructEndAsync(cancellationToken).CfAwait();
       }
       finally
       {

--- a/src/Hazelcast.Net.Testing/RemoteControllerClientExtensions.cs
+++ b/src/Hazelcast.Net.Testing/RemoteControllerClientExtensions.cs
@@ -61,8 +61,8 @@ namespace Hazelcast.Testing
         /// <returns>Whether the cluster was properly shut down.</returns>
         public static async Task ShutdownClusterDownAsync(this IRemoteControllerClient rc, Cluster cluster)
         {
-            while (!await rc.ShutdownClusterAsync(cluster).CAF())
-                await Task.Delay(1_000).CAF();
+            while (!await rc.ShutdownClusterAsync(cluster).CfAwait())
+                await Task.Delay(1_000).CfAwait();
         }
 
         /// <summary>
@@ -97,17 +97,17 @@ namespace Hazelcast.Testing
                     {
                         partitions.Release();
                     }))
-                .CAF();
+                .CfAwait();
 
-            var member = await rc.StartMemberAsync(cluster).CAF();
-            await added.WaitAsync(TimeSpan.FromSeconds(120)).CAF();
+            var member = await rc.StartMemberAsync(cluster).CfAwait();
+            await added.WaitAsync(TimeSpan.FromSeconds(120)).CfAwait();
 
             // trigger the partition table creation
-            var map = await client.GetMapAsync<object, object>("default").CAF();
+            var map = await client.GetMapAsync<object, object>("default").CfAwait();
             _ = map.GetAsync(new object());
 
-            await partitions.WaitAsync(TimeSpan.FromSeconds(120)).CAF();
-            await clientInternal.UnsubscribeAsync(subscriptionId).CAF();
+            await partitions.WaitAsync(TimeSpan.FromSeconds(120)).CfAwait();
+            await clientInternal.UnsubscribeAsync(subscriptionId).CfAwait();
 
             var partitioner = clientInternal.Cluster.Partitioner;
             var partitionsCount = partitioner.Count;
@@ -150,11 +150,11 @@ namespace Hazelcast.Testing
                     {
                         if (args.RemovedMembers.Count > 0) removed.Release();
                     }))
-                .CAF();
+                .CfAwait();
 
-            await rc.StopMemberAsync(cluster, member).CAF();
-            await removed.WaitAsync(TimeSpan.FromSeconds(120)).CAF();
-            await clientInternal.UnsubscribeAsync(subscriptionId).CAF();
+            await rc.StopMemberAsync(cluster, member).CfAwait();
+            await removed.WaitAsync(TimeSpan.FromSeconds(120)).CfAwait();
+            await clientInternal.UnsubscribeAsync(subscriptionId).CfAwait();
         }
 
         /// <summary>

--- a/src/Hazelcast.Net.Testing/RemoteTestBase.Remoting.cs
+++ b/src/Hazelcast.Net.Testing/RemoteTestBase.Remoting.cs
@@ -57,7 +57,7 @@ namespace Hazelcast.Testing
                 var transport = new Thrift.Transport.TFramedTransport(tSocketTransport);
                 if (!transport.IsOpen)
                 {
-                    await transport.OpenAsync().CAF();
+                    await transport.OpenAsync().CfAwait();
                 }
                 var protocol = new Thrift.Protocol.TBinaryProtocol(transport);
                 return RemoteControllerClient.Create(protocol);

--- a/src/Hazelcast.Net.Testing/RemoteTestBase.cs
+++ b/src/Hazelcast.Net.Testing/RemoteTestBase.cs
@@ -70,7 +70,7 @@ namespace Hazelcast.Testing
         {
             Logger.LogInformation("Create new client");
 
-            var client = await HazelcastClientFactory.StartNewClientAsync(CreateHazelcastOptions(), CreateAndStartClientTimeout).CAF();
+            var client = await HazelcastClientFactory.StartNewClientAsync(CreateHazelcastOptions(), CreateAndStartClientTimeout).CfAwait();
             return client;
         }
 
@@ -84,7 +84,7 @@ namespace Hazelcast.Testing
 
             var options = CreateHazelcastOptions();
             configure(options);
-            var client = await HazelcastClientFactory.StartNewClientAsync(options, CreateAndStartClientTimeout).CAF();
+            var client = await HazelcastClientFactory.StartNewClientAsync(options, CreateAndStartClientTimeout).CfAwait();
             return client;
         }
 

--- a/src/Hazelcast.Net.Testing/SingleMemberClientRemoteTestBase.cs
+++ b/src/Hazelcast.Net.Testing/SingleMemberClientRemoteTestBase.cs
@@ -27,7 +27,7 @@ namespace Hazelcast.Testing
         {
             // note: if this fails, teardown will not run,
             // and there is no way we can render HConsole :(
-            Client = await CreateAndStartClientAsync().CAF();
+            Client = await CreateAndStartClientAsync().CfAwait();
         }
 
         [OneTimeTearDown]

--- a/src/Hazelcast.Net.Testing/TestServer/Server.cs
+++ b/src/Hazelcast.Net.Testing/TestServer/Server.cs
@@ -96,7 +96,7 @@ namespace Hazelcast.Testing.TestServer
             _listener = new ServerSocketListener(_endpoint, _hcname) { OnAcceptConnection = AcceptConnection, OnShutdown = ListenerShutdown};
 
             _open = true;
-            await _listener.StartAsync().CAF();
+            await _listener.StartAsync().CfAwait();
 
             HConsole.WriteLine(this, "Server started");
         }
@@ -115,7 +115,7 @@ namespace Hazelcast.Testing.TestServer
             {
                 try
                 {
-                    await connection.DisposeAsync().CAF();
+                    await connection.DisposeAsync().CfAwait();
                 }
                 catch { /* ignore */ }
             }
@@ -137,8 +137,8 @@ namespace Hazelcast.Testing.TestServer
             HConsole.WriteLine(this, "Stop server");
 
             // stop accepting new connections
-            await listener.StopAsync().CAF();
-            await listener.DisposeAsync().CAF();
+            await listener.StopAsync().CfAwait();
+            await listener.DisposeAsync().CfAwait();
 
             HConsole.WriteLine(this, "Server stopped");
         }
@@ -170,7 +170,7 @@ namespace Hazelcast.Testing.TestServer
         {
             eventMessage.CorrelationId = correlationId;
             eventMessage.Flags |= ClientMessageFlags.BeginFragment | ClientMessageFlags.EndFragment;
-            await connection.SendAsync(eventMessage).CAF();
+            await connection.SendAsync(eventMessage).CfAwait();
         }
 
         private void ReceiveMessage(ClientMessageConnection connection, ClientMessage requestMessage)
@@ -208,7 +208,7 @@ namespace Hazelcast.Testing.TestServer
         /// <inheritdoc />
         public async ValueTask DisposeAsync()
         {
-            await StopAsync().CAF();
+            await StopAsync().CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net.Testing/TestServer/ServerSocketListener.cs
+++ b/src/Hazelcast.Net.Testing/TestServer/ServerSocketListener.cs
@@ -167,7 +167,7 @@ namespace Hazelcast.Testing.TestServer
 
             // notify
             if (_onShutdown != null)
-                await _onShutdown(this).CAF();
+                await _onShutdown(this).CfAwait();
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Hazelcast.Testing.TestServer
             HConsole.WriteLine(this, "Stop listener");
 
             _cancellationTokenSource.Cancel();
-            await _listeningThenShutdown.CAF();
+            await _listeningThenShutdown.CfAwait();
 
             HConsole.WriteLine(this, "Stopped listener");
         }
@@ -267,7 +267,7 @@ namespace Hazelcast.Testing.TestServer
             try
             {
                 if (_serverConnection != null)
-                    await _serverConnection.DisposeAsync().CAF();
+                    await _serverConnection.DisposeAsync().CfAwait();
             }
             catch { /* ignore */ }
 

--- a/src/Hazelcast.Net.Tests/Core/TaskCoreExtensionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Core/TaskCoreExtensionsTests.cs
@@ -74,7 +74,7 @@ namespace Hazelcast.Tests.Core
             var task = Task.Run(() => 42);
             Assert.That(task, Is.InstanceOf<Task<int>>());
 
-            var configured = task.CAF();
+            var configured = task.CfAwait();
             Assert.That(GetContinueOnCapturedContext(configured), Is.False);
         }
 
@@ -84,7 +84,7 @@ namespace Hazelcast.Tests.Core
             var task = new ValueTask<int>(42);
             Assert.That(task, Is.InstanceOf<ValueTask<int>>());
 
-            var configured = task.CAF();
+            var configured = task.CfAwait();
             Assert.That(GetContinueOnCapturedContext(configured), Is.False);
         }
 
@@ -94,7 +94,7 @@ namespace Hazelcast.Tests.Core
             var task = Task.Run(() => Task.CompletedTask);
             Assert.That(task, Is.InstanceOf<Task>());
 
-            var configured = task.CAF();
+            var configured = task.CfAwait();
             Assert.That(GetContinueOnCapturedContext(configured), Is.False);
         }
 
@@ -104,7 +104,7 @@ namespace Hazelcast.Tests.Core
             var task = new ValueTask();
             Assert.That(task, Is.InstanceOf<ValueTask>());
 
-            var configured = task.CAF();
+            var configured = task.CfAwait();
             Assert.That(GetContinueOnCapturedContext(configured), Is.False);
         }
 
@@ -150,10 +150,10 @@ namespace Hazelcast.Tests.Core
         public void ArgumentExceptions()
         {
             Task task = null;
-            Assert.Throws<ArgumentNullException>(() => task.CAF());
+            Assert.Throws<ArgumentNullException>(() => task.CfAwait());
 
             Task<int> taskOfT = null;
-            Assert.Throws<ArgumentNullException>(() => taskOfT.CAF());
+            Assert.Throws<ArgumentNullException>(() => taskOfT.CfAwait());
         }
 
         [Test]

--- a/src/Hazelcast.Net.Tests/DotNet/AsyncTests.cs
+++ b/src/Hazelcast.Net.Tests/DotNet/AsyncTests.cs
@@ -43,17 +43,17 @@ namespace Hazelcast.Tests.DotNet
             var task = Task.Run(async () =>
             {
                 steps.Add("task.start");
-                await Task.Delay(2000).CAF();
+                await Task.Delay(2000).CfAwait();
                 steps.Add("task.complete");
                 taskCompletionSource.SetResult(42); // this is NOT fire-and-forget !!
                 steps.Add("task.end");
             });
 
             steps.Add("wait");
-            await taskCompletionSource.Task.CAF();
+            await taskCompletionSource.Task.CfAwait();
             steps.Add("end");
 
-            await Task.Delay(100).CAF();
+            await Task.Delay(100).CfAwait();
 
             Console.WriteLine(steps);
 
@@ -87,12 +87,12 @@ namespace Hazelcast.Tests.DotNet
             });
 
             steps.Add("wait");
-            await Task.Delay(200).CAF();
+            await Task.Delay(200).CfAwait();
             ev.Set();
-            await taskCompletionSource.Task.CAF();
+            await taskCompletionSource.Task.CfAwait();
             steps.Add("end");
 
-            await Task.Delay(100).CAF();
+            await Task.Delay(100).CfAwait();
 
             Console.WriteLine(steps);
 
@@ -123,7 +123,7 @@ namespace Hazelcast.Tests.DotNet
             var wait = Task.Run(async () =>
             {
 
-                return await Task.WhenAll(sources.Select(x => x.Task)).CAF();
+                return await Task.WhenAll(sources.Select(x => x.Task)).CfAwait();
             });
 
             static void Throw(int j)
@@ -133,7 +133,7 @@ namespace Hazelcast.Tests.DotNet
             var i = 0;
             foreach (var source in sources)
             {
-                await Task.Delay(100).CAF();
+                await Task.Delay(100).CfAwait();
 
                 //source.SetException(new Exception("bang_" + i));
                 try
@@ -147,7 +147,7 @@ namespace Hazelcast.Tests.DotNet
 
                 i++;
 
-                await Task.Delay(100).CAF();
+                await Task.Delay(100).CfAwait();
 
                 // wait becomes Faulted only when all tasks have completed
                 var expected = i == 5 ? TaskStatus.Faulted : TaskStatus.WaitingForActivation;
@@ -157,7 +157,7 @@ namespace Hazelcast.Tests.DotNet
             Assert.AreEqual(5, i);
 
             // throws the "bang" exception
-            Assert.ThrowsAsync<Exception>(async () => await wait.CAF());
+            Assert.ThrowsAsync<Exception>(async () => await wait.CfAwait());
 
             i = 0;
             foreach (var source in sources)
@@ -183,14 +183,14 @@ namespace Hazelcast.Tests.DotNet
         public async Task DelayCancel()
         {
             var cancellation = new CancellationTokenSource(100);
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.Delay(2_000, cancellation.Token).CAF());
-            await Task.Delay(100, CancellationToken.None).CAF();
+            Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.Delay(2_000, cancellation.Token).CfAwait());
+            await Task.Delay(100, CancellationToken.None).CfAwait();
 
             // TaskCancelledException inherits from OperationCancelledException
             cancellation = new CancellationTokenSource(100);
             try
             {
-                await Task.Delay(2_000, cancellation.Token).CAF();
+                await Task.Delay(2_000, cancellation.Token).CfAwait();
             }
             catch (OperationCanceledException)
             { }
@@ -202,8 +202,8 @@ namespace Hazelcast.Tests.DotNet
             var semaphore = new SemaphoreSlim(0);
 
             var cancellation = new CancellationTokenSource(100);
-            Assert.ThrowsAsync<OperationCanceledException>(async () => await semaphore.WaitAsync(cancellation.Token).CAF());
-            await Task.Delay(100, CancellationToken.None).CAF();
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await semaphore.WaitAsync(cancellation.Token).CfAwait());
+            await Task.Delay(100, CancellationToken.None).CfAwait();
         }
 
         [Test]
@@ -217,7 +217,7 @@ namespace Hazelcast.Tests.DotNet
             var task2 = semaphore.WaitAsync(cancellation.Token);
 
             var t = await Task.WhenAny(task1, task2); // does not throw
-            await Task.Delay(100, CancellationToken.None).CAF();
+            await Task.Delay(100, CancellationToken.None).CfAwait();
 
             Assert.IsTrue(t.IsCompleted);
             Assert.IsTrue(t.IsCanceled);
@@ -235,8 +235,8 @@ namespace Hazelcast.Tests.DotNet
             var task1 = Task.Delay(2_000, cancellation.Token);
             var task2 = semaphore.WaitAsync(cancellation.Token);
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.WhenAll(task1, task2).CAF());
-            await Task.Delay(100, CancellationToken.None).CAF();
+            Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.WhenAll(task1, task2).CfAwait());
+            await Task.Delay(100, CancellationToken.None).CfAwait();
 
             Assert.IsTrue(task1.IsCanceled);
             Assert.IsTrue(task2.IsCanceled);

--- a/src/Hazelcast.Net.Tests/DotNet/SemaphoreTests.cs
+++ b/src/Hazelcast.Net.Tests/DotNet/SemaphoreTests.cs
@@ -27,13 +27,13 @@ namespace Hazelcast.Tests.DotNet
         {
             var semaphore = new SemaphoreSlim(1);
 
-            await semaphore.WaitAsync().CAF();
+            await semaphore.WaitAsync().CfAwait();
 
             // zero means we could not enter, if we tried
             Assert.AreEqual(0, semaphore.CurrentCount);
 
             // better: either take it immediately, or fail
-            var taken = await semaphore.WaitAsync(0).CAF();
+            var taken = await semaphore.WaitAsync(0).CfAwait();
 
             Assert.IsFalse(taken);
         }

--- a/src/Hazelcast.Net.Tests/DotNet/StreamAsyncTests.cs
+++ b/src/Hazelcast.Net.Tests/DotNet/StreamAsyncTests.cs
@@ -36,7 +36,7 @@ namespace Hazelcast.Tests.DotNet
             //source.CancelAfter(2000);
 
             // note: a memory stream is non blocking!
-            var count = await stream.ReadAsync(memory, source.Token).CAF();
+            var count = await stream.ReadAsync(memory, source.Token).CfAwait();
             Console.WriteLine(count);
 
             // should end ok

--- a/src/Hazelcast.Net.Tests/NearCache/NearCacheClearedBySetTest.cs
+++ b/src/Hazelcast.Net.Tests/NearCache/NearCacheClearedBySetTest.cs
@@ -189,14 +189,14 @@ namespace Hazelcast.Tests.NearCache
                 // put new value and update last state
                 // note: the value in the map/Near Cache is *always* larger or equal to valuePut
                 // assertion: valueMap >= valuePut
-                await dictionary.SetAsync(Key, i.ToString()).CAF();
+                await dictionary.SetAsync(Key, i.ToString()).CfAwait();
                 _valuePut = i;
 
                 // ensure we have a value
                 if (i == 1) started.Release();
 
                 // check if we see our last update
-                var valueStr = await dictionary.GetAsync(Key).CAF();
+                var valueStr = await dictionary.GetAsync(Key).CfAwait();
                 if (valueStr == null) continue; // not found
 
                 var valueInt = int.Parse(valueStr);
@@ -206,10 +206,10 @@ namespace Hazelcast.Tests.NearCache
                 Logger.LogWarning($"Err: set {i} but got {valueInt}.");
 
                 // maybe it needs a bit of time?
-                await Task.Delay(200).CAF();
+                await Task.Delay(200).CfAwait();
 
                 // test again and stop if really lost
-                valueStr = await dictionary.GetAsync(Key).CAF();
+                valueStr = await dictionary.GetAsync(Key).CfAwait();
                 valueInt = int.Parse(valueStr);
                 if (valueInt == i) continue; // fixed
 
@@ -232,7 +232,7 @@ namespace Hazelcast.Tests.NearCache
                 n++;
 
                 // get the value
-                var valueStr = await dictionary.GetAsync(Key).CAF();
+                var valueStr = await dictionary.GetAsync(Key).CfAwait();
 
                 // that should never happen!
                 Assert.That(valueStr, Is.Not.Null);
@@ -242,7 +242,7 @@ namespace Hazelcast.Tests.NearCache
                 Assert.AreEqual(valueInt.ToString(), valueStr);
 
                 // slow down
-                await Task.Delay(100).CAF();
+                await Task.Delay(100).CfAwait();
             }
             Logger.LogInformation($"Get task {id} performed {n} operations.");
         }

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
@@ -63,10 +63,10 @@ namespace Hazelcast.Tests.Networking
             {
                 if (RcCluster != null)
                 {
-                    await RcClient.ShutdownClusterAsync(RcCluster).CAF();
+                    await RcClient.ShutdownClusterAsync(RcCluster).CfAwait();
                     RcCluster = null;
                 }
-                await RcClient.ExitAsync().CAF();
+                await RcClient.ExitAsync().CfAwait();
                 RcClient = null;
             }
         }
@@ -84,7 +84,7 @@ namespace Hazelcast.Tests.Networking
             // terminate & remove cluster
             if (RcCluster != null)
             {
-                await RcClient.ShutdownClusterAsync(RcCluster).CAF();
+                await RcClient.ShutdownClusterAsync(RcCluster).CfAwait();
                 RcCluster = null;
             }
         }

--- a/src/Hazelcast.Net.Tests/Remote/ClientRingbufferTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientRingbufferTest.cs
@@ -105,7 +105,7 @@ namespace Hazelcast.Tests.Remote
             {
                 // so with this model, the invocation task
 
-                await rb.ReadManyAsync(0, Capacity + 1, Capacity + 1).CAF();
+                await rb.ReadManyAsync(0, Capacity + 1, Capacity + 1).CfAwait();
             });
         }
 

--- a/src/Hazelcast.Net.Tests/Remote/MapTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/MapTests.cs
@@ -29,23 +29,23 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Set()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // Set adds a new value, or replaces an existing value,
             // and does not return anything
             // NOTE: no way to know whether it added or replaced?
 
-            await map.SetAsync("key", 42).CAF();
-            await map.SetAsync("key", 43).CAF();
+            await map.SetAsync("key", 42).CfAwait();
+            await map.SetAsync("key", 43).CfAwait();
 
-            var value = await map.GetAsync("key").CAF();
+            var value = await map.GetAsync("key").CfAwait();
             Assert.AreEqual(43, value);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(1, count);
 
-            value = await TaskEx.RunWithTimeout(t=> map.GetAsync("key"), TimeSpan.FromSeconds(30)).CAF();
+            value = await TaskEx.RunWithTimeout(t=> map.GetAsync("key"), TimeSpan.FromSeconds(30)).CfAwait();
             Assert.AreEqual(43, value);
         }
 
@@ -53,25 +53,25 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task SetWithTimeout()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // AddOrReplace adds a new value, or replaces an existing value,
             // and does not return anything
             // NOTE: no way to know whether it added or replaced?
 
-            await map.SetAsync("key", 42).CAF();
+            await map.SetAsync("key", 42).CfAwait();
 
             // add-or-replace with a 3 seconds timeout and a potential TaskTimeoutException
             // in case of a TaskTimeoutException - map.SetAsync() will keep running in the
             // background, its exception will be observed, but the end result (whether the
             // value was actually set or not) is unspecified.
-            await TaskEx.RunWithTimeout(t => map.SetAsync("key", 43), TimeSpan.FromSeconds(12)).CAF();
+            await TaskEx.RunWithTimeout(t => map.SetAsync("key", 43), TimeSpan.FromSeconds(12)).CfAwait();
 
-            var value = await map.GetAsync("key").CAF();
+            var value = await map.GetAsync("key").CfAwait();
             Assert.AreEqual(43, value);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(1, count);
         }
 
@@ -79,7 +79,7 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task GetMissingValValue()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             Assert.That(await map.GetAsync("key"), Is.Zero);
@@ -93,7 +93,7 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task GetMissingNullableValue()
         {
-            var map = await Client.GetMapAsync<string, int?>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int?>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             Assert.That(await map.GetAsync("key"), Is.Null);
@@ -108,7 +108,7 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task GetMissingRefValue()
         {
-            var map = await Client.GetMapAsync<string, string>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, string>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             var value = await map.GetAsync("key");
@@ -125,7 +125,7 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task GetAndSet()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // AddOrReplace adds a new value, or replaces an existing value,
@@ -138,7 +138,7 @@ namespace Hazelcast.Tests.Remote
 
             Assert.That(await map.GetAsync("key"), Is.EqualTo(43));
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(1, count);
         }
 
@@ -146,7 +146,7 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task GetAndSetNullable()
         {
-            var map = await Client.GetMapAsync<string, int?>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int?>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // AddOrReplace adds a new value, or replaces an existing value,
@@ -159,7 +159,7 @@ namespace Hazelcast.Tests.Remote
 
             Assert.That(await map.GetAsync("key"), Is.EqualTo(43));
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(1, count);
         }
 
@@ -167,28 +167,28 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Add()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // TryAdd adds a new value if no value exists already,
             // and returns the existing value, or the default value
             // NOTE: no way to know if the default value existed (eg zero)?
 
-            await map.SetAsync("key1", 42).CAF();
+            await map.SetAsync("key1", 42).CfAwait();
 
-            var result1 = await map.PutIfAbsentAsync("key1", 43).CAF();
+            var result1 = await map.PutIfAbsentAsync("key1", 43).CfAwait();
             Assert.That(result1, Is.EqualTo(42));
 
-            var result2 = await map.PutIfAbsentAsync("key2", 43).CAF();
+            var result2 = await map.PutIfAbsentAsync("key2", 43).CfAwait();
             Assert.That(result2, Is.EqualTo(0));
 
-            var value1 = await map.GetAsync("key1").CAF();
+            var value1 = await map.GetAsync("key1").CfAwait();
             Assert.AreEqual(42, value1);
 
-            var value2 = await map.GetAsync("key2").CAF();
+            var value2 = await map.GetAsync("key2").CfAwait();
             Assert.AreEqual(43, value2);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(2, count);
         }
 
@@ -196,15 +196,15 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task SetMany()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // AddOrReplace adds new values, or replaces existing values
             // NOTE: no way to know what happened
 
-            await map.SetAsync("key1", 42).CAF();
+            await map.SetAsync("key1", 42).CfAwait();
 
-            var value1 = await map.GetAsync("key1").CAF();
+            var value1 = await map.GetAsync("key1").CfAwait();
             Assert.AreEqual(42, value1);
 
             await map.SetAllAsync(new Dictionary<string, int>
@@ -213,13 +213,13 @@ namespace Hazelcast.Tests.Remote
                 ["key2"] = 44
             });
 
-            value1 = await map.GetAsync("key1").CAF();
+            value1 = await map.GetAsync("key1").CfAwait();
             Assert.AreEqual(43, value1);
 
-            var value2 = await map.GetAsync("key2").CAF();
+            var value2 = await map.GetAsync("key2").CfAwait();
             Assert.AreEqual(44, value2);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(2, count);
         }
 
@@ -227,20 +227,20 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task ReplaceByKey()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // Replace replaces an existing value, and returns the existing value,
             // else does nothing if no value exists already (does not add)
 
-            await map.SetAsync("key1", 42).CAF();
+            await map.SetAsync("key1", 42).CfAwait();
 
-            var result = await map.ReplaceAsync("key1", 43).CAF();
+            var result = await map.ReplaceAsync("key1", 43).CfAwait();
             Assert.That(result, Is.EqualTo(42));
 
             Assert.That(await map.ReplaceAsync("key2", 43), Is.Zero);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(1, count);
         }
 
@@ -248,20 +248,20 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task ReplaceNullableByKey()
         {
-            var map = await Client.GetMapAsync<string, int?>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int?>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // Replace replaces an existing value, and returns the existing value,
             // else does nothing if no value exists already (does not add)
 
-            await map.SetAsync("key1", 42).CAF();
+            await map.SetAsync("key1", 42).CfAwait();
 
-            var result = await map.ReplaceAsync("key1", 43).CAF();
+            var result = await map.ReplaceAsync("key1", 43).CfAwait();
             Assert.That(result, Is.EqualTo(42));
 
             Assert.That(await map.ReplaceAsync("key2", 43), Is.Null);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(1, count);
         }
 
@@ -269,21 +269,21 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task ReplaceByKeyAndValue()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // Replace replaces an existing value, and returns the existing value,
             // else does nothing if no value exists already (does not add)
 
-            await map.SetAsync("key1", 42).CAF();
+            await map.SetAsync("key1", 42).CfAwait();
 
-            var result1 = await map.ReplaceAsync("key1", 43, 44).CAF();
+            var result1 = await map.ReplaceAsync("key1", 43, 44).CfAwait();
             Assert.IsFalse(result1);
 
-            var result2 = await map.ReplaceAsync("key1", 42, 44).CAF();
+            var result2 = await map.ReplaceAsync("key1", 42, 44).CfAwait();
             Assert.IsTrue(result2);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(1, count);
         }
 
@@ -291,22 +291,22 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task SetWithTimeToLive()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // AddOrReplace adds a new value, or replaces an existing value,
             // and does not return anything
             // NOTE: no way to know whether it added or replaced?
 
-            await map.SetAsync("key", 42, TimeSpan.FromSeconds(1)).CAF();
-            var value = await map.GetAsync("key").CAF();
+            await map.SetAsync("key", 42, TimeSpan.FromSeconds(1)).CfAwait();
+            var value = await map.GetAsync("key").CfAwait();
             Assert.AreEqual(42, value);
 
             await Task.Delay(1000); // wait for 1 second
 
             Assert.That(await map.GetAsync("key"), Is.Zero);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(0, count);
         }
 
@@ -314,7 +314,7 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task SetTransient()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // AddTransient adds a new value, or replaces an existing value,
@@ -322,16 +322,16 @@ namespace Hazelcast.Tests.Remote
             // (so it's "add or replace" really)
             // NOTE: no way to know whether it added or replaced?
 
-            await map.PutTransientAsync("key", 42, TimeSpan.Zero).CAF();
+            await map.PutTransientAsync("key", 42, TimeSpan.Zero).CfAwait();
 
-            await map.PutTransientAsync("key", 43, TimeSpan.Zero).CAF();
+            await map.PutTransientAsync("key", 43, TimeSpan.Zero).CfAwait();
 
-            await map.PutTransientAsync("key1", 43, TimeSpan.Zero).CAF();
+            await map.PutTransientAsync("key1", 43, TimeSpan.Zero).CfAwait();
 
-            var value = await map.GetAsync("key").CAF();
+            var value = await map.GetAsync("key").CfAwait();
             Assert.AreEqual(43, value);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(2, count);
         }
 
@@ -339,20 +339,20 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task TrySet()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             // TryAddOrReplace is like AddOrReplace but with a timeout
 
-            await map.TryPutAsync("key", 42, TimeSpan.FromSeconds(1)).CAF();
-            var value = await map.GetAsync("key").CAF();
+            await map.TryPutAsync("key", 42, TimeSpan.FromSeconds(1)).CfAwait();
+            var value = await map.GetAsync("key").CfAwait();
             Assert.AreEqual(42, value);
 
-            await map.TryPutAsync("key", 43, TimeSpan.FromSeconds(1)).CAF();
-            value = await map.GetAsync("key").CAF();
+            await map.TryPutAsync("key", 43, TimeSpan.FromSeconds(1)).CfAwait();
+            value = await map.GetAsync("key").CfAwait();
             Assert.AreEqual(43, value);
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(1, count);
         }
 
@@ -360,21 +360,21 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Clear()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             var entries = new Dictionary<string, int>();
             for (var i = 0; i < 100; i++)
                 entries["key" + i] = i;
 
-            await map.SetAllAsync(entries).CAF();
+            await map.SetAllAsync(entries).CfAwait();
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(100, count);
 
-            await map.ClearAsync().CAF();
+            await map.ClearAsync().CfAwait();
 
-            count = await map.GetSizeAsync().CAF();
+            count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(0, count);
         }
 
@@ -382,19 +382,19 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task GetAll()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             var entries = new Dictionary<string, int>();
             for (var i = 0; i < 100; i++)
                 entries["key" + i] = i;
 
-            await map.SetAllAsync(entries).CAF();
+            await map.SetAllAsync(entries).CfAwait();
 
-            var count = await map.GetSizeAsync().CAF();
+            var count = await map.GetSizeAsync().CfAwait();
             Assert.AreEqual(100, count);
 
-            var keys = await map.GetKeysAsync().CAF();
+            var keys = await map.GetKeysAsync().CfAwait();
             Assert.AreEqual(100, keys.Count);
 
             var s = new HashSet<int>();
@@ -406,7 +406,7 @@ namespace Hazelcast.Tests.Remote
 
             Assert.AreEqual(0, s.Count);
 
-            var values = await map.GetValuesAsync().CAF();
+            var values = await map.GetValuesAsync().CfAwait();
             Assert.AreEqual(100, values.Count);
 
             s = new HashSet<int>();
@@ -426,7 +426,7 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task Events()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             var eventsCount = 0;
@@ -437,17 +437,17 @@ namespace Hazelcast.Tests.Remote
                     Interlocked.Increment(ref eventsCount);
                 }));
 
-            await map.SetAsync("a", 1).CAF();
-            await map.SetAsync("b", 2).CAF();
+            await map.SetAsync("a", 1).CfAwait();
+            await map.SetAsync("b", 2).CfAwait();
 
             await AssertEx.SucceedsEventually(() =>
                     Assert.That(eventsCount, Is.EqualTo(2)),
                 4000, 500);
 
-            await map.UnsubscribeAsync(id).CAF();
+            await map.UnsubscribeAsync(id).CfAwait();
 
-            await map.SetAsync("c", 3).CAF();
-            await Task.Delay(500).CAF();
+            await map.SetAsync("c", 3).CfAwait();
+            await Task.Delay(500).CfAwait();
 
             Assert.AreEqual(2, eventsCount);
         }
@@ -456,7 +456,7 @@ namespace Hazelcast.Tests.Remote
         [Timeout(TestTimeoutMilliseconds)]
         public async Task AsyncEvents()
         {
-            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            var map = await Client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
             await using var _ = DestroyAndDispose(map);
 
             var eventsCount = 0;
@@ -468,16 +468,16 @@ namespace Hazelcast.Tests.Remote
                     Interlocked.Increment(ref eventsCount);
                 }));
 
-            await map.SetAsync("a", 1).CAF();
-            await map.SetAsync("b", 2).CAF();
+            await map.SetAsync("a", 1).CfAwait();
+            await map.SetAsync("b", 2).CfAwait();
 
             while (eventsCount < 2)
-                await Task.Delay(500).CAF();
+                await Task.Delay(500).CfAwait();
 
-            await map.UnsubscribeAsync(id).CAF();
+            await map.UnsubscribeAsync(id).CfAwait();
 
-            await map.SetAsync("c", 3).CAF();
-            await Task.Delay(500).CAF();
+            await map.SetAsync("c", 3).CfAwait();
+            await Task.Delay(500).CfAwait();
 
             Assert.AreEqual(2, eventsCount);
         }
@@ -499,8 +499,8 @@ namespace Hazelcast.Tests.Remote
             }
 
             // here we have to create our own client with a different configuration
-            await using var client = await CreateAndStartClientAsync(ConfigureClient).CAF();
-            var map = await client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CAF();
+            await using var client = await CreateAndStartClientAsync(ConfigureClient).CfAwait();
+            var map = await client.GetMapAsync<string, int>("map_" + CreateUniqueName()).CfAwait();
 
             await eventHandled.WaitAsync();
             await client.DestroyAsync(map);

--- a/src/Hazelcast.Net.Tests/Sandbox/AsyncEvent.cs
+++ b/src/Hazelcast.Net.Tests/Sandbox/AsyncEvent.cs
@@ -102,7 +102,7 @@ namespace Hazelcast.Tests.Sandbox
             {
                 try
                 {
-                    await method(args).CAF();
+                    await method(args).CfAwait();
                 }
                 catch (Exception e)
                 {

--- a/src/Hazelcast.Net.Tests/Sandbox/EventTests.cs
+++ b/src/Hazelcast.Net.Tests/Sandbox/EventTests.cs
@@ -28,11 +28,11 @@ namespace Hazelcast.Tests.Sandbox
 
             var testing = new Testing();
 
-            await testing.TriggerSomething(1).CAF();
+            await testing.TriggerSomething(1).CfAwait();
             Assert.AreEqual(0, count);
 
             testing.OnSomething.Add(args => count += args);
-            await testing.TriggerSomething(1).CAF();
+            await testing.TriggerSomething(1).CfAwait();
             Assert.AreEqual(1, count);
 
             testing.OnSomething.Add(args =>
@@ -40,7 +40,7 @@ namespace Hazelcast.Tests.Sandbox
                 count += args;
                 return default;
             });
-            await testing.TriggerSomething(1).CAF();
+            await testing.TriggerSomething(1).CfAwait();
             Assert.AreEqual(3, count);
         }
 
@@ -51,7 +51,7 @@ namespace Hazelcast.Tests.Sandbox
             /// </summary>
             public MixedEvent<int> OnSomething { get; } = new MixedEvent<int>();
 
-            public async ValueTask TriggerSomething(int args) => await OnSomething.InvokeAsync(args).CAF();
+            public async ValueTask TriggerSomething(int args) => await OnSomething.InvokeAsync(args).CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/Sandbox/MixedEvent.cs
+++ b/src/Hazelcast.Net.Tests/Sandbox/MixedEvent.cs
@@ -162,7 +162,7 @@ namespace Hazelcast.Tests.Sandbox
             {
                 try
                 {
-                    await method(args).CAF();
+                    await method(args).CfAwait();
                 }
                 catch (Exception e)
                 {

--- a/src/Hazelcast.Net/Clustering/AddressLocker.cs
+++ b/src/Hazelcast.Net/Clustering/AddressLocker.cs
@@ -80,7 +80,7 @@ namespace Hazelcast.Clustering
         public async Task<IDisposable> LockAsync(NetworkAddress address)
         {
             var lockInfo = GetLockInfo(address);
-            await lockInfo.Semaphore.WaitAsync().CAF();
+            await lockInfo.Semaphore.WaitAsync().CfAwait();
             return lockInfo;
         }
     }

--- a/src/Hazelcast.Net/Clustering/Authenticator.cs
+++ b/src/Hazelcast.Net/Clustering/Authenticator.cs
@@ -66,7 +66,7 @@ namespace Hazelcast.Clustering
             using var temp = credentialsFactory != null ? null : new DefaultCredentialsFactory();
             credentialsFactory ??= temp;
 
-            var result = await TryAuthenticateAsync(client, clusterName, clusterClientId, clusterClientName, labels, credentialsFactory, cancellationToken).CAF();
+            var result = await TryAuthenticateAsync(client, clusterName, clusterClientId, clusterClientName, labels, credentialsFactory, cancellationToken).CfAwait();
             if (result != null) return result;
 
             // result is null, credentials failed but we may want to retry
@@ -75,7 +75,7 @@ namespace Hazelcast.Clustering
                 resettableCredentialsFactory.Reset();
 
                 // try again
-                result = await TryAuthenticateAsync(client, clusterName, clusterClientId, clusterClientName, labels, credentialsFactory, cancellationToken).CAF();
+                result = await TryAuthenticateAsync(client, clusterName, clusterClientId, clusterClientName, labels, credentialsFactory, cancellationToken).CfAwait();
                 if (result != null) return result;
             }
 
@@ -127,7 +127,7 @@ namespace Hazelcast.Clustering
             cancellationToken.ThrowIfCancellationRequested();
 
             HConsole.WriteLine(this, "Send auth request");
-            var responseMessage = await client.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await client.SendAsync(requestMessage, cancellationToken).CfAwait();
             HConsole.WriteLine(this, "Rcvd auth response");
             var response = ClientAuthenticationCodec.DecodeResponse(responseMessage);
             HConsole.WriteLine(this, "Auth response is: " + (AuthenticationStatus) response.Status);

--- a/src/Hazelcast.Net/Clustering/Cluster.cs
+++ b/src/Hazelcast.Net/Clustering/Cluster.cs
@@ -178,7 +178,7 @@ namespace Hazelcast.Clustering
             State.NotifyState(ClientState.ShuttingDown);
 
             // we don't need heartbeat anymore
-            await _heartbeat.DisposeAsync().CAF();
+            await _heartbeat.DisposeAsync().CfAwait();
 
             // ClusterMessaging has nothing to dispose
 
@@ -186,25 +186,25 @@ namespace Hazelcast.Clustering
             // - the events scheduler (always running)
             // - the task that ensures FIXME DOCUMENT
             // - the task that deals with ghost subscriptions (if it's running)
-            await Events.DisposeAsync().CAF();
+            await Events.DisposeAsync().CfAwait();
 
             // ClusterClusterEvents need to shutdown
             // - the two ObjectLifeCycle and PartitionLost subscriptions
-            await ClusterEvents.DisposeAsync().CAF();
+            await ClusterEvents.DisposeAsync().CfAwait();
 
             // now it's time to dispose the connections, ie close all of them
             // and shutdown
             // - the reconnect task (if it's running)
             // - the task that connects members (always running)
-            await Connections.DisposeAsync().CAF();
+            await Connections.DisposeAsync().CfAwait();
 
             // at that point we can get rid of members
-            await Members.DisposeAsync().CAF();
+            await Members.DisposeAsync().CfAwait();
 
             // and finally, of the state itself
             // which will shutdown
             // - the state changed queue (always running)
-            await State.DisposeAsync().CAF();
+            await State.DisposeAsync().CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/Clustering/ClusterClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterClusterEvents.cs
@@ -128,8 +128,8 @@ namespace Hazelcast.Clustering
         /// <inheritdoc />
         public async ValueTask DisposeAsync()
         {
-            await _objectLifecycleEventSubscription.DisposeAsync().CAF();
-            await _partitionLostEventSubscription.DisposeAsync().CAF();
+            await _objectLifecycleEventSubscription.DisposeAsync().CfAwait();
+            await _partitionLostEventSubscription.DisposeAsync().CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -175,7 +175,7 @@ namespace Hazelcast.Clustering
                         HConsole.WriteLine(this, $"Removed member {member.Id}");
                         removed.Add(member);
                         if (_connections.TryGetValue(member.Id, out var client))
-                            await client.TerminateAsync().CAF(); // TODO: consider dying in the background?
+                            await client.TerminateAsync().CfAwait(); // TODO: consider dying in the background?
                         break;
 
                     case 2: // new but not old = added
@@ -283,7 +283,7 @@ namespace Hazelcast.Clustering
 
                 // no clients => wait for clients
                 // this *may* throw
-                await Task.Delay(_clusterState.Options.WaitForConnectionMilliseconds, cancellationToken).CAF();
+                await Task.Delay(_clusterState.Options.WaitForConnectionMilliseconds, cancellationToken).CfAwait();
             }
 
             // this *will* throw
@@ -335,7 +335,7 @@ namespace Hazelcast.Clustering
         /// <returns>A task that will complete when the first member view event has been received.</returns>
         public async ValueTask WaitForMembersAsync(CancellationToken cancellationToken)
         {
-            await _firstMembersView.WaitAsync(cancellationToken).CAF();
+            await _firstMembersView.WaitAsync(cancellationToken).CfAwait();
             _firstMembersView.Dispose();
             _firstMembersView = null;
         }

--- a/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
@@ -52,7 +52,7 @@ namespace Hazelcast.Clustering
             if (message == null) throw new ArgumentNullException(nameof(message));
 
             using var cancellation = _clusterState.GetLinkedCancellation(cancellationToken);
-            return await SendAsyncInternal(message, null, -1, default, cancellation.Token).CAF();
+            return await SendAsyncInternal(message, null, -1, default, cancellation.Token).CfAwait();
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Hazelcast.Clustering
             if (message == null) throw new ArgumentNullException(nameof(message));
 
             using var cancellation = _clusterState.GetLinkedCancellation(cancellationToken);
-            return await SendAsyncInternal(message, null, -1, memberId, cancellation.Token).CAF();
+            return await SendAsyncInternal(message, null, -1, memberId, cancellation.Token).CfAwait();
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Hazelcast.Clustering
             if (memberConnection == null) throw new ArgumentNullException(nameof(memberConnection));
 
             using var cancellation = _clusterState.GetLinkedCancellation(cancellationToken);
-            return await SendAsyncInternal(message, memberConnection, -1, default, cancellation.Token).CAF();
+            return await SendAsyncInternal(message, memberConnection, -1, default, cancellation.Token).CfAwait();
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Hazelcast.Clustering
             if (memberConnection == null) throw new ArgumentNullException(nameof(memberConnection));
 
             using var cancellation = _clusterState.GetLinkedCancellation(cancellationToken);
-            return await SendAsyncInternal(message, memberConnection, -1, default, correlationId, cancellation.Token).CAF();
+            return await SendAsyncInternal(message, memberConnection, -1, default, correlationId, cancellation.Token).CfAwait();
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Hazelcast.Clustering
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -158,7 +158,7 @@ namespace Hazelcast.Clustering
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -182,7 +182,7 @@ namespace Hazelcast.Clustering
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -214,7 +214,7 @@ namespace Hazelcast.Clustering
                                    targetMemberId != default ? new Invocation(message, _clusterState.Options.Messaging, targetMemberId, cancellationToken) :
                                    new Invocation(message, _clusterState.Options.Messaging, cancellationToken);
 
-            return await SendAsyncInternal(invocation).CAF();
+            return await SendAsyncInternal(invocation).CfAwait();
         }
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace Hazelcast.Clustering
                 {
                     var connection = GetInvocationConnection(invocation); // non-null, throws if no connections
                     var timeoutMs = _clusterState.Options.Messaging.InvocationTimeoutMilliseconds;
-                    return await connection.SendAsync(invocation, timeoutMs).CAF();
+                    return await connection.SendAsync(invocation, timeoutMs).CfAwait();
                 }
                 catch (TaskCanceledException)
                 {
@@ -250,7 +250,7 @@ namespace Hazelcast.Clustering
                     // note that CanRetryAsync may wait (depending on the retry strategy)
                     // and may throw if canceled while waiting - and then the exception is rethrown
                     if (invocation.IsRetryable(exception, _clusterState.Options.Networking.RedoOperations) &&
-                        await invocation.CanRetryAsync(() => _clusterState.GetNextCorrelationId()).CAF())
+                        await invocation.CanRetryAsync(() => _clusterState.GetNextCorrelationId()).CfAwait())
                     {
                         HConsole.WriteLine(this, "Retrying...");
                         continue;

--- a/src/Hazelcast.Net/Clustering/ClusterState.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterState.cs
@@ -141,7 +141,7 @@ namespace Hazelcast.Clustering
         /// <exception cref="InvalidOperationException">The current state was not the expected state.</exception>
         public async ValueTask TransitionAsync(ClientState newState)
         {
-            await _lock.WaitAsync(CancellationToken.None).CAF();
+            await _lock.WaitAsync(CancellationToken.None).CfAwait();
 
             try
             {
@@ -296,7 +296,7 @@ namespace Hazelcast.Clustering
         /// <inheritdoc />
         public async ValueTask DisposeAsync()
         {
-            await _stateChangeQueue.DisposeAsync().CAF();
+            await _stateChangeQueue.DisposeAsync().CfAwait();
             _clusterCancellation.Dispose();
             _lock.Dispose();
         }

--- a/src/Hazelcast.Net/Clustering/ClusterSubscription.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterSubscription.cs
@@ -182,7 +182,7 @@ namespace Hazelcast.Clustering
         public async ValueTask HandleAsync(ClientMessage eventMessage)
         {
             if (!_active) return;
-            await _eventHandler(eventMessage, State).CAF();
+            await _eventHandler(eventMessage, State).CfAwait();
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/Clustering/ConnectAddresses.cs
+++ b/src/Hazelcast.Net/Clustering/ConnectAddresses.cs
@@ -74,7 +74,7 @@ namespace Hazelcast.Clustering
 
             _pausing = true;
             _addresses.Post(null); // force receive
-            await _paused.WaitAsync().CAF();
+            await _paused.WaitAsync().CfAwait();
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace Hazelcast.Clustering
 
             if (drain)
             {
-                await _drained.WaitAsync().CAF();
+                await _drained.WaitAsync().CfAwait();
             }
         }
 
@@ -129,13 +129,13 @@ namespace Hazelcast.Clustering
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // wait for an address, or the special Drainer or Ignored members
-                var address = await _addresses.ReceiveAsync(cancellationToken).CAF();
+                var address = await _addresses.ReceiveAsync(cancellationToken).CfAwait();
 
                 // pause
                 if (_pausing)
                 {
                     _paused.Release();
-                    await _resume.WaitAsync(cancellationToken).CAF();
+                    await _resume.WaitAsync(cancellationToken).CfAwait();
                     _pausing = false;
                 }
 
@@ -155,7 +155,7 @@ namespace Hazelcast.Clustering
                 {
                     try
                     {
-                        await _connect(address, cancellationToken).CAF();
+                        await _connect(address, cancellationToken).CfAwait();
                     }
                     catch (OperationCanceledException)
                     {
@@ -179,7 +179,7 @@ namespace Hazelcast.Clustering
                 return;
 
             _cancel.Cancel();
-            await _connecting.ObserveCanceled().CAF();
+            await _connecting.ObserveCanceled().CfAwait();
             _cancel.Dispose();
 
             _paused.Dispose();

--- a/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
+++ b/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
@@ -170,7 +170,7 @@ namespace Hazelcast.Clustering
             try
             {
                 HConsole.WriteLine(this, "Execute event handler");
-                await state.Subscription.HandleAsync(state.Message).CAF();
+                await state.Subscription.HandleAsync(state.Message).CfAwait();
             }
             catch (Exception e)
             {
@@ -219,7 +219,7 @@ namespace Hazelcast.Clustering
             try
             {
                 // ReSharper disable once InconsistentlySynchronizedField - _disposed is true, all is safe
-                await Task.WhenAll(_partitionTasks.Values).CAF();
+                await Task.WhenAll(_partitionTasks.Values).CfAwait();
             }
             catch (Exception e)
             {

--- a/src/Hazelcast.Net/Clustering/EventSubscriptionBase.cs
+++ b/src/Hazelcast.Net/Clustering/EventSubscriptionBase.cs
@@ -45,14 +45,14 @@ namespace Hazelcast.Clustering
 
             // accepted race condition, _busy can be disposed here and will throw an ObjectDisposedException
 
-            await _busy.WaitAsync().CAF();
+            await _busy.WaitAsync().CfAwait();
             try
             {
                 _subscriptionsCount++;
                 if (_subscriptionsCount > 1) return;
 
                 var subscription = CreateSubscription();
-                await ClusterEvents.InstallSubscriptionAsync(subscription).CAF();
+                await ClusterEvents.InstallSubscriptionAsync(subscription).CfAwait();
                 _subscriptionId = subscription.Id;
             }
             finally
@@ -67,13 +67,13 @@ namespace Hazelcast.Clustering
 
             // accepted race condition, _busy can be disposed here and will throw an ObjectDisposedException
 
-            await _busy.WaitAsync().CAF();
+            await _busy.WaitAsync().CfAwait();
             try
             {
                 if (_subscriptionsCount == 0) return true; // TODO: should we throw?
                 if (_subscriptionsCount > 1) return true;
 
-                var removed = await ClusterEvents.RemoveSubscriptionAsync(_subscriptionId).CAF();
+                var removed = await ClusterEvents.RemoveSubscriptionAsync(_subscriptionId).CfAwait();
                 if (removed) _subscriptionsCount--;
                 return removed;
             }
@@ -88,13 +88,13 @@ namespace Hazelcast.Clustering
             if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 1)
                 return;
 
-            await _busy.WaitAsync().CAF();
+            await _busy.WaitAsync().CfAwait();
             try
             {
                 if (_subscriptionsCount == 0) return;
 
                 // remove, ignore result
-                await ClusterEvents.RemoveSubscriptionAsync(_subscriptionId).CAF();
+                await ClusterEvents.RemoveSubscriptionAsync(_subscriptionId).CfAwait();
             }
             finally
             {

--- a/src/Hazelcast.Net/Clustering/Heartbeat.cs
+++ b/src/Hazelcast.Net/Clustering/Heartbeat.cs
@@ -73,7 +73,7 @@ namespace Hazelcast.Clustering
 
             try
             {
-                await _heartbeating.ObserveCanceled().CAF();
+                await _heartbeating.ObserveCanceled().CfAwait();
             }
             catch (Exception e)
             {
@@ -86,10 +86,10 @@ namespace Hazelcast.Clustering
         {
             while (true)
             {
-                await Task.Delay(_period, cancellationToken).CAF();
+                await Task.Delay(_period, cancellationToken).CfAwait();
                 try
                 {
-                    await RunAsync(cancellationToken).ObserveCanceled().CAF();
+                    await RunAsync(cancellationToken).ObserveCanceled().CfAwait();
                 }
                 catch (Exception e)
                 {
@@ -113,7 +113,7 @@ namespace Hazelcast.Clustering
                 .Select(x => RunAsync(x, now, cancellationToken))
                 .ToList();
 
-            await Task.WhenAll(tasks).CAF(); // may throw in case of cancellation
+            await Task.WhenAll(tasks).CfAwait(); // may throw in case of cancellation
         }
 
         // runs once on a connection to a member
@@ -134,7 +134,7 @@ namespace Hazelcast.Clustering
             if (readElapsed > _timeout && writeElapsed < _period)
             {
                 _logger.LogWarning("Heartbeat timeout for connection {ConnectionId}.", connection.Id);
-                if (connection.Active) await connection.TerminateAsync().CAF(); // does not throw;
+                if (connection.Active) await connection.TerminateAsync().CfAwait(); // does not throw;
                 return;
             }
 
@@ -151,7 +151,7 @@ namespace Hazelcast.Clustering
                     // ping should complete within the default invocation timeout
                     var responseMessage = await _clusterMessaging
                         .SendToMemberAsync(requestMessage, connection, cancellationToken)
-                        .CAF();
+                        .CfAwait();
 
                     // just to be sure everything is ok
                     _ = ClientPingCodec.DecodeResponse(responseMessage);
@@ -159,7 +159,7 @@ namespace Hazelcast.Clustering
                 catch (TaskTimeoutException)
                 {
                     _logger.LogWarning("Heartbeat ping timeout for connection {ConnectionId}.", connection.Id);
-                    if (connection.Active) await connection.TerminateAsync().CAF(); // does not throw;
+                    if (connection.Active) await connection.TerminateAsync().CfAwait(); // does not throw;
                 }
                 catch (Exception e)
                 {

--- a/src/Hazelcast.Net/Clustering/Invocation.cs
+++ b/src/Hazelcast.Net/Clustering/Invocation.cs
@@ -253,7 +253,7 @@ namespace Hazelcast.Clustering
             // will be 1, 2, 4, 8, 16 etc milliseconds but never less that invocationRetryDelayMilliseconds
             // we *may* want to tweak this?
             var delayMilliseconds = Math.Min(1 << (_attemptsCount - _messagingOptions.MaxFastInvocationCount), _messagingOptions.MinRetryDelayMilliseconds);
-            await System.Threading.Tasks.Task.Delay(delayMilliseconds, _cancellationToken).CAF(); // throws if cancelled
+            await System.Threading.Tasks.Task.Delay(delayMilliseconds, _cancellationToken).CfAwait(); // throws if cancelled
 
             InitializeNewCompletionSource();
             return true;

--- a/src/Hazelcast.Net/Clustering/RetryStrategy.cs
+++ b/src/Hazelcast.Net/Clustering/RetryStrategy.cs
@@ -106,7 +106,7 @@ namespace Hazelcast.Clustering
 
             try
             {
-                await Task.Delay(delay, cancellationToken).CAF();
+                await Task.Delay(delay, cancellationToken).CfAwait();
             }
             catch (OperationCanceledException)
             {

--- a/src/Hazelcast.Net/Clustering/StateChangeQueue.cs
+++ b/src/Hazelcast.Net/Clustering/StateChangeQueue.cs
@@ -89,12 +89,12 @@ namespace Hazelcast.Clustering
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // wait for a state change
-                var state = await _states.ReceiveAsync(cancellationToken).CAF();
+                var state = await _states.ReceiveAsync(cancellationToken).CfAwait();
 
                 // raise event
                 try
                 {
-                    await _stateChanged.AwaitEach(state).CAF();
+                    await _stateChanged.AwaitEach(state).CfAwait();
                 }
                 catch (Exception e)
                 {
@@ -112,7 +112,7 @@ namespace Hazelcast.Clustering
                 return;
 
             _cancel.Cancel();
-            await _raising.ObserveCanceled().CAF();
+            await _raising.ObserveCanceled().CfAwait();
             _cancel.Dispose();
         }
     }

--- a/src/Hazelcast.Net/Core/BackgroundTask.cs
+++ b/src/Hazelcast.Net/Core/BackgroundTask.cs
@@ -44,7 +44,7 @@ namespace Hazelcast.Core
             {
                 try
                 {
-                    await function(_cancellation.Token).CAF();
+                    await function(_cancellation.Token).CfAwait();
                 }
                 finally
                 {
@@ -83,7 +83,7 @@ namespace Hazelcast.Core
 
             // observe all exceptions, or only the canceled exception
             var task = observeException ? Task.ObserveException() : Task.ObserveCanceled();
-            await task.CAF();
+            await task.CfAwait();
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/Core/ConcurrentAsyncDictionary.cs
+++ b/src/Hazelcast.Net/Core/ConcurrentAsyncDictionary.cs
@@ -63,7 +63,7 @@ namespace Hazelcast.Core
             try
             {
                 // await - may throw - meaning the factory has thrown, entry is failed
-                var value = await entry.GetValue(factory, cancellationToken).CAF();
+                var value = await entry.GetValue(factory, cancellationToken).CfAwait();
                 if (value != null) return value;
 
                 // remove the invalid entry (with null value) from the dictionary
@@ -97,7 +97,7 @@ namespace Hazelcast.Core
             try
             {
                 // await - may throw - meaning the factory has thrown, entry is failed
-                var value = await entry.GetValue(factory, cancellationToken).CAF();
+                var value = await entry.GetValue(factory, cancellationToken).CfAwait();
                 if (value != null) return true;
 
                 // remove the invalid entry (with null value) from the dictionary
@@ -122,7 +122,7 @@ namespace Hazelcast.Core
             if (!_dictionary.TryGetValue(key, out var entry)) return Attempt.Failed;
 
             // it is not possible to get a null value
-            return await TryGetEntryValueAsync(entry).CAF();
+            return await TryGetEntryValueAsync(entry).CfAwait();
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Hazelcast.Core
             if (!_dictionary.TryRemove(key, out var entry)) return Attempt.Failed;
 
             // it is not possible to get a null value
-            return await TryGetEntryValueAsync(entry).CAF();
+            return await TryGetEntryValueAsync(entry).CfAwait();
         }
 
         internal static async ValueTask<Attempt<TValue>> TryGetEntryValueAsync(Entry entry)
@@ -151,7 +151,7 @@ namespace Hazelcast.Core
 
             try
             {
-                var value = await entry.GetValue().CAF();
+                var value = await entry.GetValue().CfAwait();
                 if (value != null) return value;
             }
             catch
@@ -183,7 +183,7 @@ namespace Hazelcast.Core
 
             // a null value is not a value
             // return the attempt at getting the entry value
-            return await TryGetEntryValueAsync(entry).CAF();
+            return await TryGetEntryValueAsync(entry).CfAwait();
         }
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace Hazelcast.Core
 
                     try
                     {
-                        var value = entry.HasValue ? entry.Value : await entry.GetValue().CAF();
+                        var value = entry.HasValue ? entry.Value : await entry.GetValue().CfAwait();
                         if (value == null) continue; // skip null values
                         _current = new KeyValuePair<TKey, TValue>(key, value);
                         return true;
@@ -308,7 +308,7 @@ namespace Hazelcast.Core
                     creating = _creating ??= factory(_key, cancellationToken).AsTask();
                 }
 
-                _value = await creating.CAF();
+                _value = await creating.CfAwait();
 
                 lock (_lock)
                 {
@@ -328,7 +328,7 @@ namespace Hazelcast.Core
                     creating = _creating;
                 }
 
-                return await creating.CAF();
+                return await creating.CfAwait();
             }
         }
     }

--- a/src/Hazelcast.Net/Core/FuncExtensions.cs
+++ b/src/Hazelcast.Net/Core/FuncExtensions.cs
@@ -49,7 +49,7 @@ namespace Hazelcast.Core
             {
                 foreach (var d in function.GetInvocationList())
                 {
-                    await ((Func<ValueTask>) d)().CAF();
+                    await ((Func<ValueTask>) d)().CfAwait();
                 }
             }
         }
@@ -68,7 +68,7 @@ namespace Hazelcast.Core
             {
                 foreach (var d in function.GetInvocationList())
                 {
-                    await ((Func<T, ValueTask>) d)(arg).CAF();
+                    await ((Func<T, ValueTask>) d)(arg).CfAwait();
                 }
             }
         }
@@ -89,7 +89,7 @@ namespace Hazelcast.Core
             {
                 foreach (var d in function.GetInvocationList())
                 {
-                    await ((Func<T1, T2, ValueTask>) d)(arg1, arg2).CAF();
+                    await ((Func<T1, T2, ValueTask>) d)(arg1, arg2).CfAwait();
                 }
             }
         }
@@ -112,7 +112,7 @@ namespace Hazelcast.Core
             {
                 foreach (var d in function.GetInvocationList())
                 {
-                    await ((Func<T1, T2, T3, ValueTask>) d)(arg1, arg2, arg3).CAF();
+                    await ((Func<T1, T2, T3, ValueTask>) d)(arg1, arg2, arg3).CfAwait();
                 }
             }
         }

--- a/src/Hazelcast.Net/Core/SocketExtensions.cs
+++ b/src/Hazelcast.Net/Core/SocketExtensions.cs
@@ -59,13 +59,13 @@ namespace Hazelcast.Core
 
             try
             {
-                var t = await Task.WhenAny(tcs.Task, Task.Delay(timeoutMilliseconds, cancellation.Token)).CAF();
+                var t = await Task.WhenAny(tcs.Task, Task.Delay(timeoutMilliseconds, cancellation.Token)).CfAwait();
 
                 // if the connect task has completed successfully...
                 if (t == tcs.Task)
                 {
                     cancellation.Cancel(); // cancel the delay
-                    await t.CAF(); // may throw
+                    await t.CfAwait(); // may throw
                     return;
                 }
             }
@@ -81,7 +81,7 @@ namespace Hazelcast.Core
             // and then everything will be ok
 
             TryCloseAndDispose(socket);
-            await TryAwait(tcs.Task).CAF();
+            await TryAwait(tcs.Task).CfAwait();
 
             // finally, throw the correct exception
             // favor cancellation over timeout
@@ -107,7 +107,7 @@ namespace Hazelcast.Core
         {
             try
             {
-                await task.CAF();
+                await task.CfAwait();
             }
             catch { /* may happen, don't care */ }
         }

--- a/src/Hazelcast.Net/Core/TaskCoreExtensions.cs
+++ b/src/Hazelcast.Net/Core/TaskCoreExtensions.cs
@@ -36,7 +36,7 @@ namespace Hazelcast.Core
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         // ReSharper disable once InconsistentNaming
-        public static ConfiguredTaskAwaitable CAF([NotNull] this Task task)
+        public static ConfiguredTaskAwaitable CfAwait([NotNull] this Task task)
         {
             if (task == null) throw new ArgumentNullException(nameof(task));
             return task.ConfigureAwait(false);
@@ -52,7 +52,7 @@ namespace Hazelcast.Core
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         // ReSharper disable once InconsistentNaming
-        public static ConfiguredTaskAwaitable<T> CAF<T>([NotNull] this Task<T> task)
+        public static ConfiguredTaskAwaitable<T> CfAwait<T>([NotNull] this Task<T> task)
         {
             if (task == null) throw new ArgumentNullException(nameof(task));
             return task.ConfigureAwait(false);
@@ -68,7 +68,7 @@ namespace Hazelcast.Core
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         // ReSharper disable once InconsistentNaming
-        public static ConfiguredValueTaskAwaitable CAF(this ValueTask task)
+        public static ConfiguredValueTaskAwaitable CfAwait(this ValueTask task)
             => task.ConfigureAwait(false);
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Hazelcast.Core
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         // ReSharper disable once InconsistentNaming
-        public static ConfiguredValueTaskAwaitable<T> CAF<T>(this ValueTask<T> task)
+        public static ConfiguredValueTaskAwaitable<T> CfAwait<T>(this ValueTask<T> task)
             => task.ConfigureAwait(false);
     }
 }

--- a/src/Hazelcast.Net/Core/TaskEx.cs
+++ b/src/Hazelcast.Net/Core/TaskEx.cs
@@ -75,7 +75,7 @@ namespace Hazelcast.Core
 
             if (timeoutMilliseconds < 0) // infinite
             {
-                await taskAction(cancellationToken).CAF();
+                await taskAction(cancellationToken).CfAwait();
                 return;
             }
 
@@ -84,7 +84,7 @@ namespace Hazelcast.Core
             using var delayCancel = new CancellationTokenSource();
             var delay = Task.Delay(timeoutMilliseconds, delayCancel.Token);
 
-            await Task.WhenAny(task, delay).CAF();
+            await Task.WhenAny(task, delay).CfAwait();
 
             // if the delay is not completed, cancel it & observe the corresponding exception
             if (!delay.IsCompleted)
@@ -96,7 +96,7 @@ namespace Hazelcast.Core
             // if the task is completed (success or fault...), return
             if (task.IsCompleted)
             {
-                await task.CAF();
+                await task.CfAwait();
                 return;
             }
 
@@ -158,7 +158,7 @@ namespace Hazelcast.Core
 
             if (timeoutMilliseconds < 0) // infinite
             {
-                await taskAction(arg, cancellationToken).CAF();
+                await taskAction(arg, cancellationToken).CfAwait();
                 return;
             }
 
@@ -167,7 +167,7 @@ namespace Hazelcast.Core
             using var delayCancel = new CancellationTokenSource();
             var delay = Task.Delay(timeoutMilliseconds, delayCancel.Token);
 
-            await Task.WhenAny(task, delay).CAF();
+            await Task.WhenAny(task, delay).CfAwait();
 
             // if the delay is not completed, cancel it & observe the corresponding exception
             if (!delay.IsCompleted)
@@ -179,7 +179,7 @@ namespace Hazelcast.Core
             // if the task is completed (success or fault...), return
             if (task.IsCompleted)
             {
-                await task.CAF(); // might have thrown
+                await task.CfAwait(); // might have thrown
                 return;
             }
 
@@ -238,14 +238,14 @@ namespace Hazelcast.Core
             if (taskAction == null) throw new ArgumentNullException(nameof(taskAction));
 
             if (timeoutMilliseconds < 0) // infinite
-                return await taskAction(cancellationToken).CAF();
+                return await taskAction(cancellationToken).CfAwait();
 
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var task = taskAction(cancellation.Token);
             using var delayCancel = new CancellationTokenSource();
             var delay = Task.Delay(timeoutMilliseconds, delayCancel.Token);
 
-            await Task.WhenAny(task, delay).CAF();
+            await Task.WhenAny(task, delay).CfAwait();
 
             // if the delay is not completed, cancel it & observe the corresponding exception
             if (!delay.IsCompleted)
@@ -256,7 +256,7 @@ namespace Hazelcast.Core
 
             // if the task is completed (success or fault...), return
             if (task.IsCompleted)
-                return await task.CAF();
+                return await task.CfAwait();
 
             // else timeout
             throw CreateTaskTimeoutException(task, cancellation);
@@ -317,14 +317,14 @@ namespace Hazelcast.Core
             if (taskAction == null) throw new ArgumentNullException(nameof(taskAction));
 
             if (timeoutMilliseconds < 0) // infinite
-                return await taskAction(arg, cancellationToken).CAF();
+                return await taskAction(arg, cancellationToken).CfAwait();
 
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var task = taskAction(arg, cancellation.Token);
             using var delayCancel = new CancellationTokenSource();
             var delay = Task.Delay(timeoutMilliseconds, delayCancel.Token);
 
-            await Task.WhenAny(task, delay).CAF();
+            await Task.WhenAny(task, delay).CfAwait();
 
             // if the delay is not completed, cancel it & observe the corresponding exception
             if (!delay.IsCompleted)
@@ -335,7 +335,7 @@ namespace Hazelcast.Core
 
             // if the task is completed (success or fault...), return
             if (task.IsCompleted)
-                return await task.CAF();
+                return await task.CfAwait();
 
             // else, timeout
             throw CreateTaskTimeoutException(task, cancellation);

--- a/src/Hazelcast.Net/DistributedObjects/DistributedObjectBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DistributedObjectBase.cs
@@ -132,7 +132,7 @@ namespace Hazelcast.DistributedObjects
 
         /// <inheritdoc />
         public async ValueTask DestroyAsync()
-            => await _factory.DestroyAsync(this).CAF();
+            => await _factory.DestroyAsync(this).CfAwait();
 
         /// <summary>
         /// Serializes an object to <see cref="IData"/>.
@@ -308,7 +308,7 @@ namespace Hazelcast.DistributedObjects
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HCollectionBase.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HCollectionBase.Events.cs
@@ -38,7 +38,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 ReadSubscribeResponse, CreateUnsubscribeRequest, ReadUnsubscribeResponse, HandleEventAsync,
                 new SubscriptionState<CollectionItemEventHandlers<T>>(Name, handlers, state));
 
-            await Cluster.Events.InstallSubscriptionAsync(subscription).CAF();
+            await Cluster.Events.InstallSubscriptionAsync(subscription).CfAwait();
 
             return subscription.Id;
         }
@@ -63,7 +63,7 @@ namespace Hazelcast.DistributedObjects.Impl
             {
                 if (handler.EventType.HasAll(eventType))
                 {
-                    await handler.HandleAsync(this, member, item, sstate.HandlerState).CAF();
+                    await handler.HandleAsync(this, member, item, sstate.HandlerState).CfAwait();
                 }
             }
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HCollectionBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HCollectionBase.cs
@@ -33,7 +33,7 @@ namespace Hazelcast.DistributedObjects.Impl
             // all collections are async enumerable,
             // but by default we load the whole items set at once,
             // then iterate in memory
-            var items = await GetAllAsync().CAF();
+            var items = await GetAllAsync().CfAwait();
             foreach (var item in items)
                 yield return item;
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HList.Getting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HList.Getting.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public override async Task<IReadOnlyList<T>> GetAllAsync()
         {
             var requestMessage = ListGetAllCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = ListGetAllCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<T>(response, SerializationService);
         }
@@ -35,7 +35,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<T> GetAsync(int index)
         {
             var requestMessage = ListGetCodec.EncodeRequest(Name, index);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = ListGetCodec.DecodeResponse(responseMessage).Response;
             return ToObject<T>(response);
         }
@@ -44,7 +44,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<IReadOnlyList<T>> GetSublistAsync(int fromIndex, int toIndex)
         {
             var requestMessage = ListSubCodec.EncodeRequest(Name, fromIndex, toIndex);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = ListSubCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<T>(response, SerializationService);
         }
@@ -54,7 +54,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = ListIndexOfCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListIndexOfCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -63,7 +63,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = ListLastIndexOfCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListLastIndexOfCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -72,7 +72,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = ListContainsCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListContainsCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -81,7 +81,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = ListContainsAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListContainsAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -89,7 +89,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public override async Task<bool> IsEmptyAsync()
         {
             var requestMessage = ListIsEmptyCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListIsEmptyCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -97,7 +97,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public override async Task<int> GetSizeAsync()
         {
             var requestMessage = ListSizeCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListSizeCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HList.Removing.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HList.Removing.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = ListRemoveCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListRemoveCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -34,7 +34,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<T> RemoveAsync(int index)
         {
             var requestMessage = ListRemoveWithIndexCodec.EncodeRequest(Name, index);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = ListRemoveWithIndexCodec.DecodeResponse(responseMessage).Response;
             return ToObject<T>(response);
         }
@@ -44,7 +44,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = ListCompareAndRemoveAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListCompareAndRemoveAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -53,7 +53,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = ListCompareAndRetainAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListCompareAndRetainAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -61,7 +61,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public override async Task ClearAsync()
         {
             var requestMessage = ListClearCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             _ = ListClearCodec.DecodeResponse(responseMessage);
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HList.Setting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HList.Setting.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = ListSetCodec.EncodeRequest(Name, index, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = ListSetCodec.DecodeResponse(responseMessage).Response;
             return ToObject<T>(response);
         }
@@ -36,7 +36,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = ListAddWithIndexCodec.EncodeRequest(Name, index, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             _ = ListAddWithIndexCodec.DecodeResponse(responseMessage);
         }
 
@@ -45,7 +45,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = ListAddCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListAddCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -54,7 +54,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = ListAddAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListAddAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -64,7 +64,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = ListAddAllWithIndexCodec.EncodeRequest(Name, index, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return ListAddAllWithIndexCodec.DecodeResponse(responseMessage).Response;
         }
 

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HList.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HList.cs
@@ -36,7 +36,7 @@ namespace Hazelcast.DistributedObjects.Impl
 
         public override async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
         {
-            var items = await IterateAllAsync().CAF();
+            var items = await IterateAllAsync().CfAwait();
             foreach (var item in items)
                 yield return item;
         }
@@ -44,7 +44,7 @@ namespace Hazelcast.DistributedObjects.Impl
         private async Task<IReadOnlyList<T>> IterateAllAsync()
         {
             var requestMessage = ListIteratorCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = ListIteratorCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<T>(response, SerializationService);
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.AggrProj.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.AggrProj.cs
@@ -37,7 +37,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var aggregatorData = ToSafeData(aggregator);
 
             var requestMessage = MapAggregateCodec.EncodeRequest(Name, aggregatorData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapAggregateCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TResult>(response);
         }
@@ -51,7 +51,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var (aggregatorData, predicateData) = ToSafeData(aggregator, predicate);
 
             var requestMessage = MapAggregateWithPredicateCodec.EncodeRequest(Name, aggregatorData, predicateData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapAggregateWithPredicateCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TResult>(response);
         }
@@ -65,7 +65,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var projectionData = ToSafeData(projection);
 
             var requestMessage = MapProjectCodec.EncodeRequest(Name, projectionData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapProjectCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TResult>(response, SerializationService);
         }
@@ -79,7 +79,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var (projectionData, predicateData) = ToSafeData(projection, predicate);
 
             var requestMessage = MapProjectWithPredicateCodec.EncodeRequest(Name, projectionData, predicateData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapProjectWithPredicateCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TResult>(response, SerializationService);
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Caching.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Caching.cs
@@ -33,7 +33,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var keyData = ToSafeData(key);
 
             var requestMessage = MapEvictCodec.EncodeRequest(Name, keyData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapEvictCodec.DecodeResponse(responseMessage).Response;
             return response;
         }
@@ -45,7 +45,7 @@ namespace Hazelcast.DistributedObjects.Impl
         private async Task EvictAllAsync(CancellationToken cancellationToken)
         {
             var requestMessage = MapEvictAllCodec.EncodeRequest(Name);
-            await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
         }
 
         /// <inheritdoc />
@@ -55,14 +55,14 @@ namespace Hazelcast.DistributedObjects.Impl
         private async Task FlushAsync(CancellationToken cancellationToken)
         {
             var requestMessage = MapFlushCodec.EncodeRequest(Name);
-            await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
         }
 
         /// <inheritdoc />
         public async Task LoadAllAsync(bool replaceExistingValues)
         {
             var requestMessage = MapLoadAllCodec.EncodeRequest(Name, replaceExistingValues);
-            await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
         }
 
         /// <inheritdoc />
@@ -70,7 +70,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keysData = keys.Select(key => ToSafeData(key)).ToList();
             var requestMessage = MapLoadGivenKeysCodec.EncodeRequest(Name, keysData, replaceExistingValues);
-            await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Events.cs
@@ -62,7 +62,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 HandleEventAsync,
                 new MapSubscriptionState(mode, Name, handlers, state));
 
-            await Cluster.Events.InstallSubscriptionAsync(subscription, cancellationToken).CAF();
+            await Cluster.Events.InstallSubscriptionAsync(subscription, cancellationToken).CfAwait();
 
             return subscription.Id;
         }
@@ -128,7 +128,7 @@ namespace Hazelcast.DistributedObjects.Impl
                         IMapEventHandler<TKey, TValue, IHMap<TKey, TValue>> mapHandler => mapHandler.HandleAsync(this, member, numberOfAffectedEntries, state),
                         _ => throw new NotSupportedException()
                     };
-                    await task.CAF();
+                    await task.CfAwait();
                 }
             }
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Indexing.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Indexing.cs
@@ -50,7 +50,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Intercepting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Intercepting.cs
@@ -34,7 +34,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var interceptorData = ToSafeData(interceptor);
 
             var requestMessage = MapAddInterceptorCodec.EncodeRequest(Name, interceptorData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapAddInterceptorCodec.DecodeResponse(responseMessage).Response;
             return response;
         }
@@ -48,7 +48,7 @@ namespace Hazelcast.DistributedObjects.Impl
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException(ExceptionMessages.NullOrEmpty, nameof(id));
 
             var requestMessage = MapRemoveInterceptorCodec.EncodeRequest(Name, id);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapRemoveInterceptorCodec.DecodeResponse(responseMessage).Response;
             return response;
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Locking.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Locking.cs
@@ -35,7 +35,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -50,7 +50,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var leaseTimeMs = leaseTime.RoundedMilliseconds();
 
             var requestMessage = MapLockCodec.EncodeRequest(Name, keyData, ContextId, leaseTimeMs, refId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             _ = MapLockCodec.DecodeResponse(responseMessage);
         }
 
@@ -66,7 +66,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -82,7 +82,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -100,7 +100,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeToWaitMs = timeToWait.RoundedMilliseconds();
 
             var requestMessage = MapTryLockCodec.EncodeRequest(Name, keyData, ContextId, leaseTimeMs, timeToWaitMs, refId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             var response = MapTryLockCodec.DecodeResponse(responseMessage).Response;
             return response;
         }
@@ -114,7 +114,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var keyData = ToSafeData(key);
 
             var requestMessage = MapIsLockedCodec.EncodeRequest(Name, keyData);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapIsLockedCodec.DecodeResponse(responseMessage).Response;
             return response;
         }
@@ -135,7 +135,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -155,7 +155,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Processing.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Processing.cs
@@ -43,7 +43,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -60,7 +60,7 @@ namespace Hazelcast.DistributedObjects.Impl
         protected virtual async Task<TResult> ExecuteAsync<TResult>(IData processorData, IData keyData, CancellationToken cancellationToken)
         {
             var requestMessage = MapExecuteOnKeyCodec.EncodeRequest(Name, processorData, keyData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapExecuteOnKeyCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TResult>(response);
         }
@@ -78,7 +78,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var processorData = ToSafeData(processor);
 
             var requestMessage = MapExecuteOnKeysCodec.EncodeRequest(Name, processorData, keysmap.Keys);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapExecuteOnKeysCodec.DecodeResponse(responseMessage).Response;
 
             var result = new Dictionary<TKey, TResult>();
@@ -101,7 +101,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var processorData = ToSafeData(processor);
 
             var requestMessage = MapExecuteOnAllKeysCodec.EncodeRequest(Name, processorData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapExecuteOnAllKeysCodec.DecodeResponse(responseMessage).Response;
 
             var result = new Dictionary<TKey, TResult>();
@@ -120,7 +120,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var (processorData, predicateData) = ToSafeData(processor, predicate);
 
             var requestMessage = MapExecuteWithPredicateCodec.EncodeRequest(Name, processorData, predicateData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MapExecuteWithPredicateCodec.DecodeResponse(responseMessage).Response;
 
             var result = new Dictionary<TKey, TResult>();

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Removing.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Removing.cs
@@ -39,7 +39,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -60,7 +60,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeoutMs = timeToWait.RoundedMilliseconds();
 
             var requestMessage = MapTryRemoveCodec.EncodeRequest(Name, keyData, ContextId, timeoutMs);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapTryRemoveCodec.DecodeResponse(responseMessage).Response;
             return response;
         }
@@ -80,7 +80,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -93,7 +93,7 @@ namespace Hazelcast.DistributedObjects.Impl
         protected virtual async Task<TValue> GetAndRemoveAsync(IData keyData, CancellationToken cancellationToken)
         {
             var requestMessage = MapRemoveCodec.EncodeRequest(Name, keyData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapRemoveCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -114,7 +114,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -132,7 +132,7 @@ namespace Hazelcast.DistributedObjects.Impl
         protected virtual async Task<bool> RemoveAsync(IData keyData, IData valueData, CancellationToken cancellationToken)
         {
             var requestMessage = MapRemoveIfSameCodec.EncodeRequest(Name, keyData, valueData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapRemoveIfSameCodec.DecodeResponse(responseMessage).Response;
             return response;
         }
@@ -152,7 +152,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -169,7 +169,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var predicateData = ToSafeData(predicate);
 
             var requestMessage = MapRemoveAllCodec.EncodeRequest(Name, predicateData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             _ = MapRemoveAllCodec.DecodeResponse(responseMessage);
         }
 
@@ -194,7 +194,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -214,7 +214,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Setting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Setting.cs
@@ -56,7 +56,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 ? MapSetWithMaxIdleCodec.EncodeRequest(Name, keyData, valueData, ContextId, timeToLiveMs, maxIdleMs)
                 : MapSetCodec.EncodeRequest(Name, keyData, valueData, ContextId, timeToLiveMs);
 
-            await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
         }
 
         /// <inheritdoc />
@@ -83,7 +83,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 ? MapPutWithMaxIdleCodec.EncodeRequest(Name, keyData, valueData, ContextId, timeToLiveMs, maxIdleMs)
                 : MapPutCodec.EncodeRequest(Name, keyData, valueData, ContextId, timeToLiveMs);
 
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
 
             var response = withMaxIdle
                 ? MapPutWithMaxIdleCodec.DecodeResponse(responseMessage).Response
@@ -125,7 +125,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -168,7 +168,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -181,7 +181,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var (keyData, valueData) = ToSafeData(key, newValue);
 
             var requestMessage = MapReplaceCodec.EncodeRequest(Name, keyData, valueData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapReplaceCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -202,7 +202,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -217,7 +217,7 @@ namespace Hazelcast.DistributedObjects.Impl
         protected async Task<bool> TryUpdateAsync(IData keyData, IData expectedData, IData newData, CancellationToken cancellationToken)
         {
             var requestMessage = MapReplaceIfSameCodec.EncodeRequest(Name, keyData, expectedData, newData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapReplaceIfSameCodec.DecodeResponse(responseMessage).Response;
             return response;
         }
@@ -238,7 +238,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -259,7 +259,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeoutMs = serverTimeout.RoundedMilliseconds(false); // codec: 0 = server, -1 = infinite
 
             var requestMessage = MapTryPutCodec.EncodeRequest(Name, keyData, valueData, ContextId, timeoutMs);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
             var response = MapTryPutCodec.DecodeResponse(responseMessage).Response;
             return response;
         }
@@ -279,7 +279,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -303,7 +303,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -329,7 +329,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 ? MapPutIfAbsentWithMaxIdleCodec.EncodeRequest(Name, keyData, valueData, ContextId, timeToLiveMs, maxIdleMs)
                 : MapPutIfAbsentCodec.EncodeRequest(Name, keyData, valueData, ContextId, timeToLiveMs);
 
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData, cancellationToken).CfAwait();
 
             var response = withMaxIdle
                 ? MapPutIfAbsentWithMaxIdleCodec.DecodeResponse(responseMessage).Response
@@ -358,7 +358,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -387,7 +387,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.Getting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.Getting.cs
@@ -27,7 +27,7 @@ namespace Hazelcast.DistributedObjects.Impl
         /// <inheritdoc />
         protected override async Task<TValue> GetAsync(IData keyData, CancellationToken cancellationToken)
         {
-            var fromCache = await _cache.TryGetOrAddAsync(keyData, _ => GetDataAsync(keyData, cancellationToken)).CAF();
+            var fromCache = await _cache.TryGetOrAddAsync(keyData, _ => GetDataAsync(keyData, cancellationToken)).CfAwait();
             return fromCache.ValueOrDefault();
         }
 
@@ -46,7 +46,7 @@ namespace Hazelcast.DistributedObjects.Impl
                     cachedKeys.Clear();
                     foreach (var keyData in partitionKeys)
                     {
-                        var (hasValue, value) = await _cache.TryGetAsync(keyData).CAF();
+                        var (hasValue, value) = await _cache.TryGetAsync(keyData).CfAwait();
                         if (hasValue)
                         {
                             cachedKeys.Add(keyData);
@@ -59,7 +59,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 }
             }
 
-            var entries = await base.GetAllAsync(ownersKeys, cancellationToken).CAF();
+            var entries = await base.GetAllAsync(ownersKeys, cancellationToken).CfAwait();
 
             // 'entries' is a ReadOnlyLazyDictionary that contains values that are lazily
             // deserialized - and since we just fetched the entries, none have been deserialized
@@ -68,7 +68,7 @@ namespace Hazelcast.DistributedObjects.Impl
 
             // cache retrieved entries
             foreach (var (key, entry) in entries.Entries)
-                await _cache.TryAddAsync(key, entry.ValueData).CAF();
+                await _cache.TryAddAsync(key, entry.ValueData).CfAwait();
 
             // merge cached entries and retrieved entries
             foreach (var (keyData, valueObject) in cachedValues)
@@ -80,7 +80,7 @@ namespace Hazelcast.DistributedObjects.Impl
         /// <inheritdoc />
         protected override async Task<bool> ContainsKeyAsync(IData keyData, CancellationToken cancellationToken)
         {
-            return await _cache.ContainsKeyAsync(keyData).CAF() || await base.ContainsKeyAsync(keyData, cancellationToken).CAF();
+            return await _cache.ContainsKeyAsync(keyData).CfAwait() || await base.ContainsKeyAsync(keyData, cancellationToken).CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.Processing.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.Processing.cs
@@ -25,7 +25,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             try
             {
-                return await base.ExecuteAsync<TResult>(processorData, keyData, cancellationToken).CAF();
+                return await base.ExecuteAsync<TResult>(processorData, keyData, cancellationToken).CfAwait();
             }
             finally
             {

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.Removing.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.Removing.cs
@@ -40,7 +40,7 @@ namespace Hazelcast.DistributedObjects.Impl
         /// <inheritdoc />
         protected override async Task<bool> TryRemoveAsync(IData keyData, TimeSpan timeToWait, CancellationToken cancellationToken)
         {
-            var removed = await base.TryRemoveAsync(keyData, timeToWait, cancellationToken).CAF();
+            var removed = await base.TryRemoveAsync(keyData, timeToWait, cancellationToken).CfAwait();
             if (removed) _cache.Remove(keyData);
             return removed;
         }
@@ -50,7 +50,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             try
             {
-                return await base.GetAndRemoveAsync(keyData, cancellationToken).CAF();
+                return await base.GetAndRemoveAsync(keyData, cancellationToken).CfAwait();
             }
             finally
             {
@@ -63,7 +63,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             try
             {
-                return await base.RemoveAsync(keyData, valueData, cancellationToken).CAF();
+                return await base.RemoveAsync(keyData, valueData, cancellationToken).CfAwait();
             }
             finally
             {
@@ -90,7 +90,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             try
             {
-                await base.GetAndRemoveAsync(keyData, cancellationToken).CAF();
+                await base.GetAndRemoveAsync(keyData, cancellationToken).CfAwait();
             }
             finally
             {
@@ -103,7 +103,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             await base.ClearAsync(cancellationToken)
                 .ContinueWith(_ => _cache.Clear(), default, default, TaskScheduler.Current)
-                .CAF();
+                .CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.Setting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.Setting.cs
@@ -31,7 +31,7 @@ namespace Hazelcast.DistributedObjects.Impl
             // which would populate the cache with the wrong value - so we clear *after* the value has effectively
             // changed on the server - so a read between AddOrUpdate and Remove would get the old value, but
             // eventually all reads will get the correct value
-            await base.SetAsync(keyData, valueData, timeToLive, maxIdle).CAF();
+            await base.SetAsync(keyData, valueData, timeToLive, maxIdle).CfAwait();
             _cache.Remove(keyData);
         }
 
@@ -42,7 +42,7 @@ namespace Hazelcast.DistributedObjects.Impl
             // which would populate the cache with the wrong value - so we clear *after* the value has effectively
             // changed on the server - so a read between AddOrUpdate and Remove would get the old value, but
             // eventually all reads will get the correct value
-            var value = await base.GetAndSetAsync(keyData, valueData, timeToLive, maxIdle).CAF();
+            var value = await base.GetAndSetAsync(keyData, valueData, timeToLive, maxIdle).CfAwait();
             _cache.Remove(keyData);
             return value;
         }
@@ -85,14 +85,14 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
         /// <inheritdoc />
         protected override async Task<bool> TrySetAsync(IData keyData, IData valueData, TimeSpan serverTimeout, CancellationToken cancellationToken)
         {
-            var added = await base.TrySetAsync(keyData, valueData, serverTimeout, cancellationToken).CAF();
+            var added = await base.TrySetAsync(keyData, valueData, serverTimeout, cancellationToken).CfAwait();
             if (added) _cache.Remove(keyData);
             return added;
         }
@@ -110,7 +110,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -127,7 +127,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMapWithCache.cs
@@ -60,7 +60,7 @@ namespace Hazelcast.DistributedObjects.Impl
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()
         {
-            await _cache.DisposeAsync().CAF();
+            await _cache.DisposeAsync().CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMultiMap.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMultiMap.cs
@@ -72,7 +72,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 HandleEventAsync,
                 new MapSubscriptionState(mode, Name, handlers, state));
 
-            await Cluster.Events.InstallSubscriptionAsync(subscription).CAF();
+            await Cluster.Events.InstallSubscriptionAsync(subscription).CfAwait();
 
             return subscription.Id;
         }
@@ -124,7 +124,7 @@ namespace Hazelcast.DistributedObjects.Impl
                         IMapEventHandler<TKey, TValue, IHMultiMap<TKey, TValue>> mapHandler => mapHandler.HandleAsync(this, member, numberOfAffectedEntries, sstate.HandlerState),
                         _ => throw new NotSupportedException()
                     };
-                    await task.CAF();
+                    await task.CfAwait();
                 }
             }
         }
@@ -161,7 +161,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var (keyData, valueData) = ToSafeData(key, value);
             var requestMessage = MultiMapPutCodec.EncodeRequest(Name, keyData, valueData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             return MultiMapPutCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -170,7 +170,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = MultiMapGetCodec.EncodeRequest(Name, keyData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             var response = MultiMapGetCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TValue>(response, SerializationService);
         }
@@ -182,7 +182,7 @@ namespace Hazelcast.DistributedObjects.Impl
         private async Task<IReadOnlyCollection<KeyValuePair<TKey, TValue>>> GetEntrySetAsync(CancellationToken cancellationToken)
         {
             var requestMessage = MultiMapEntrySetCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
             var response = MultiMapEntrySetCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyKeyValuePairs<TKey, TValue>(response, SerializationService);
         }
@@ -191,7 +191,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<IReadOnlyCollection<TKey>> GetKeysAsync()
         {
             var requestMessage = MultiMapKeySetCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
             var response = MultiMapKeySetCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TKey>(response, SerializationService);
         }
@@ -200,7 +200,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<IReadOnlyCollection<TValue>> GetValuesAsync()
         {
             var requestMessage = MultiMapValuesCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
             var response  = MultiMapValuesCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TValue>(response, SerializationService);
         }
@@ -210,7 +210,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var (keyData, valueData) = ToSafeData(key, value);
             var requestMessage = MultiMapContainsEntryCodec.EncodeRequest(Name, keyData, valueData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             return MultiMapContainsEntryCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -219,7 +219,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = MultiMapContainsKeyCodec.EncodeRequest(Name, keyData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             return MultiMapContainsKeyCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -228,7 +228,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var valueData = ToSafeData(value);
             var requestMessage = MultiMapContainsValueCodec.EncodeRequest(Name, valueData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
             return MultiMapContainsValueCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -236,7 +236,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<int> GetSizeAsync()
         {
             var requestMessage = MultiMapSizeCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
             return MultiMapSizeCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -245,7 +245,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = MultiMapValueCountCodec.EncodeRequest(Name, keyData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             return MultiMapValueCountCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -255,7 +255,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var (keyData, valueData) = ToSafeData(key, value);
 
             var requestMessage = MultiMapRemoveEntryCodec.EncodeRequest(Name, keyData, valueData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             return MultiMapRemoveEntryCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -265,7 +265,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var keyData = ToSafeData(key);
 
             var requestMessage = MultiMapRemoveCodec.EncodeRequest(Name, keyData, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             var response = MultiMapRemoveCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TValue>(response, SerializationService);
         }
@@ -276,14 +276,14 @@ namespace Hazelcast.DistributedObjects.Impl
             var keyData = ToSafeData(key);
 
             var requestMessage = MultiMapDeleteCodec.EncodeRequest(Name, keyData, ContextId);
-            await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
         }
 
         /// <inheritdoc />
         public async Task ClearAsync()
         {
             var requestMessage = MultiMapClearCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
             _ = MultiMapClearCodec.DecodeResponse(responseMessage);
         }
 
@@ -306,7 +306,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var leaseTimeMs = leaseTime.RoundedMilliseconds();
             var timeToWaitMs = timeToWait.RoundedMilliseconds();
             var requestMessage = MultiMapTryLockCodec.EncodeRequest(Name, keyData, ContextId, leaseTimeMs, timeToWaitMs, _lockReferenceIdSequence.GetNext());
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             return MultiMapTryLockCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -316,7 +316,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var keyData = ToSafeData(key);
             var leaseTimeMs = leaseTime.RoundedMilliseconds();
             var requestMessage = MultiMapLockCodec.EncodeRequest(Name, keyData, ContextId, leaseTimeMs, _lockReferenceIdSequence.GetNext());
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             _ = MultiMapLockCodec.DecodeResponse(responseMessage);
         }
 
@@ -325,7 +325,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = MultiMapIsLockedCodec.EncodeRequest(Name, keyData);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             return MultiMapIsLockedCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -334,7 +334,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = MultiMapUnlockCodec.EncodeRequest(Name, keyData, ContextId, _lockReferenceIdSequence.GetNext());
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             _ = MultiMapUnlockCodec.DecodeResponse(responseMessage);
         }
 
@@ -343,7 +343,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = MultiMapForceUnlockCodec.EncodeRequest(Name, keyData, _lockReferenceIdSequence.GetNext());
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             _ = MultiMapForceUnlockCodec.DecodeResponse(responseMessage);
         }
 
@@ -353,7 +353,7 @@ namespace Hazelcast.DistributedObjects.Impl
             // all collections are async enumerable,
             // but by default we load the whole items set at once,
             // then iterate in memory
-            var items = await GetEntrySetAsync(cancellationToken).CAF();
+            var items = await GetEntrySetAsync(cancellationToken).CfAwait();
             foreach (var item in items)
                 yield return item;
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Dequeue.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Dequeue.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<T> PeekAsync() // peek, or null
         {
             var requestMessage = QueuePeekCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = QueuePeekCodec.DecodeResponse(responseMessage).Response;
             return ToObject<T>(response);
         }
@@ -34,7 +34,7 @@ namespace Hazelcast.DistributedObjects.Impl
         /// <inheritdoc />
         public async Task<T> GetElementAsync()
         {
-            return await PeekAsync().CAF() ?? throw new InvalidOperationException("The queue is empty.");
+            return await PeekAsync().CfAwait() ?? throw new InvalidOperationException("The queue is empty.");
         }
 
         /// <inheritdoc />
@@ -43,7 +43,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeToWaitMs = timeToWait.RoundedMilliseconds(); // codec: 0 = zero, -1 = infinite
 
             var requestMessage = QueuePollCodec.EncodeRequest(Name, timeToWaitMs);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = QueuePollCodec.DecodeResponse(responseMessage).Response;
             return ToObject<T>(response);
         }
@@ -52,7 +52,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<T> TakeAsync()
         {
             var requestMessage = QueueTakeCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = QueueTakeCodec.DecodeResponse(responseMessage).Response;
             return ToObject<T>(response);
         }
@@ -61,7 +61,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<int> DrainToAsync(ICollection<T> items)
         {
             var requestMessage = QueueDrainToCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = QueueDrainToMaxSizeCodec.DecodeResponse(responseMessage).Response;
 
             foreach (var itemData in response) items.Add(ToObject<T>(itemData));
@@ -72,7 +72,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<int> DrainToAsync(ICollection<T> items, int maxElements)
         {
             var requestMessage = QueueDrainToMaxSizeCodec.EncodeRequest(Name, maxElements);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = QueueDrainToMaxSizeCodec.DecodeResponse(responseMessage).Response;
 
             foreach (var itemData in response) items.Add(ToObject<T>(itemData));

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Getting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Getting.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public override async Task<int> GetSizeAsync()
         {
             var requestMessage = QueueSizeCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueSizeCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -35,7 +35,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = QueueContainsCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueContainsCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -43,7 +43,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public override async Task<IReadOnlyList<T>> GetAllAsync()
         {
             var requestMessage = QueueIteratorCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = QueueIteratorCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<T>(response, SerializationService);
         }
@@ -53,7 +53,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = QueueContainsAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueContainsAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -61,7 +61,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public override async Task<bool> IsEmptyAsync()
         {
             var requestMessage = QueueIsEmptyCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueIsEmptyCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -69,7 +69,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<int> GetRemainingCapacityAsync()
         {
             var requestMessage = QueueRemainingCapacityCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueRemainingCapacityCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Removing.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Removing.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = QueueRemoveCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueRemoveCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -35,7 +35,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = QueueCompareAndRemoveAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueCompareAndRemoveAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -44,7 +44,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = QueueCompareAndRetainAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueCompareAndRetainAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -61,7 +61,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Setting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HQueue.Setting.cs
@@ -26,11 +26,11 @@ namespace Hazelcast.DistributedObjects.Impl
         // <inheritdoc />
         // need that one because we are an HCollection - weird?
         // tries to enqueue immediately, does not wait & does not throw
-        public override async Task<bool> AddAsync(T item) => await OfferAsync(item).CAF();
+        public override async Task<bool> AddAsync(T item) => await OfferAsync(item).CfAwait();
 
         // <inheritdoc />
         public async Task<bool> OfferAsync(T item, TimeSpan timeToWait = default)
-            => await TryEnqueueAsync(item, timeToWait, CancellationToken.None).CAF();
+            => await TryEnqueueAsync(item, timeToWait, CancellationToken.None).CfAwait();
 
         // <inheritdoc />
         // was: Put - enqueue, wait indefinitely, may throw
@@ -49,7 +49,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -59,7 +59,7 @@ namespace Hazelcast.DistributedObjects.Impl
 
             var timeToWaitMilliseconds = (long)timeToWait.TotalMilliseconds;
             var requestMessage = QueueOfferCodec.EncodeRequest(Name, itemData, timeToWaitMilliseconds);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId, cancellationToken).CfAwait();
             return QueueOfferCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -70,7 +70,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = QueueAddAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return QueueAddAllCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HReplicatedMap.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HReplicatedMap.cs
@@ -49,7 +49,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeToLiveMs = timeToLive.RoundedMilliseconds(false); // codec: 0 = infinite, -1 = not supported?
 
             var requestMessage = ReplicatedMapPutCodec.EncodeRequest(Name, keyData, valueData, timeToLiveMs);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             var response = ReplicatedMapPutCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -64,7 +64,7 @@ namespace Hazelcast.DistributedObjects.Impl
             }
 
             var requestMessage = ReplicatedMapPutAllCodec.EncodeRequest(Name, entriesData);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
             _ = ReplicatedMapPutAllCodec.DecodeResponse(responseMessage);
         }
 
@@ -72,7 +72,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = ReplicatedMapRemoveCodec.EncodeRequest(Name, keyData);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             var response = ReplicatedMapRemoveCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -80,7 +80,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task ClearAsync()
         {
             var requestMessage = ReplicatedMapClearCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CAF();
+            var responseMessage = await Cluster.Messaging.SendAsync(requestMessage).CfAwait();
             _ = ReplicatedMapClearCodec.DecodeResponse(responseMessage);
         }
 
@@ -88,7 +88,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = ReplicatedMapGetCodec.EncodeRequest(Name, keyData);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             var response = ReplicatedMapGetCodec.DecodeResponse(responseMessage).Response;
 
             return ToObject<TValue>(response);
@@ -97,7 +97,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<IReadOnlyCollection<TKey>> GetKeysAsync()
         {
             var requestMessage = ReplicatedMapKeySetCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CfAwait();
             var response = ReplicatedMapKeySetCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TKey>(response, SerializationService);
         }
@@ -105,7 +105,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<IReadOnlyCollection<TValue>> GetValuesAsync()
         {
             var requestMessage = ReplicatedMapValuesCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CfAwait();
             var response = ReplicatedMapKeySetCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TValue>(response, SerializationService);
         }
@@ -115,7 +115,7 @@ namespace Hazelcast.DistributedObjects.Impl
         private async Task<IReadOnlyDictionary<TKey, TValue>> GetEntriesAsync(CancellationToken cancellationToken)
         {
             var requestMessage = ReplicatedMapEntrySetCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId, cancellationToken).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId, cancellationToken).CfAwait();
             var response = ReplicatedMapEntrySetCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyDictionary<TKey, TValue>(SerializationService) { response };
         }
@@ -123,14 +123,14 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<int> GetSizeAsync()
         {
             var requestMessage = ReplicatedMapSizeCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CfAwait();
             return ReplicatedMapSizeCodec.DecodeResponse(responseMessage).Response;
         }
 
         public async Task<bool> IsEmptyAsync()
         {
             var requestMessage = ReplicatedMapIsEmptyCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CfAwait();
             return ReplicatedMapIsEmptyCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -138,7 +138,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = ReplicatedMapContainsKeyCodec.EncodeRequest(Name, keyData);
-            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CAF();
+            var responseMessage = await Cluster.Messaging.SendToKeyPartitionOwnerAsync(requestMessage, keyData).CfAwait();
             return ReplicatedMapContainsKeyCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -146,7 +146,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var valueData = ToSafeData(value);
             var requestMessage = ReplicatedMapContainsValueCodec.EncodeRequest(Name, valueData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, _partitionId).CfAwait();
             return ReplicatedMapContainsValueCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -181,7 +181,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 HandleEventAsync,
                 new SubscriptionState(mode, Name, handlers, state));
 
-            await Cluster.Events.InstallSubscriptionAsync(subscription).CAF();
+            await Cluster.Events.InstallSubscriptionAsync(subscription).CfAwait();
 
             return subscription.Id;
         }
@@ -247,7 +247,7 @@ namespace Hazelcast.DistributedObjects.Impl
                         IMapEventHandler<TKey, TValue, HReplicatedMap<TKey, TValue>> mapHandler => mapHandler.HandleAsync(this, member, numberOfAffectedEntries, sstate.HandlerState),
                         _ => throw new NotSupportedException()
                     };
-                    await task.CAF();
+                    await task.CfAwait();
                 }
             }
         }
@@ -286,7 +286,7 @@ namespace Hazelcast.DistributedObjects.Impl
             // all collections are async enumerable,
             // but by default we load the whole items set at once,
             // then iterate in memory
-            var items = await GetEntriesAsync(cancellationToken).CAF();
+            var items = await GetEntriesAsync(cancellationToken).CfAwait();
             foreach (var item in items)
                 yield return item;
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HRingBuffer.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HRingBuffer.cs
@@ -52,14 +52,14 @@ namespace Hazelcast.DistributedObjects.Impl
 
         /// <inheritdoc />
         public async Task<long> AddAsync(TItem item)
-            => await AddAsync(item, OverflowPolicy.Overwrite).CAF();
+            => await AddAsync(item, OverflowPolicy.Overwrite).CfAwait();
 
         /// <inheritdoc />
         public async Task<long> AddAsync(TItem item, OverflowPolicy overflowPolicy)
         {
             var itemData = ToSafeData(item);
             var requestMessage = RingbufferAddCodec.EncodeRequest(Name, (int) overflowPolicy, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return RingbufferAddCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -70,7 +70,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var itemsData = ToSafeData(items);
 
             var requestMessage = RingbufferAddAllCodec.EncodeRequest(Name, itemsData, (int) overflowPolicy);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return RingbufferAddAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -80,7 +80,7 @@ namespace Hazelcast.DistributedObjects.Impl
             if (_capacity != -1) return _capacity;
 
             var requestMessage = RingbufferCapacityCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return _capacity = RingbufferCapacityCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -88,7 +88,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<long> GetHeadSequenceAsync()
         {
             var requestMessage = RingbufferHeadSequenceCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return RingbufferHeadSequenceCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -99,12 +99,12 @@ namespace Hazelcast.DistributedObjects.Impl
             if (minCount < 0) throw new ArgumentOutOfRangeException(nameof(minCount), "The value of minCount must be equal to, or greater than, zero.");
             if (maxCount < minCount) throw new ArgumentOutOfRangeException(nameof(maxCount), "The value of maxCount must be greater than, or equal to, the value of minCount.");
 
-            var capacity = await GetCapacityAsync().CAF();
+            var capacity = await GetCapacityAsync().CfAwait();
             if (minCount > capacity) throw new ArgumentOutOfRangeException(nameof(minCount), "The value of minCount must be smaller than, or equal to, the capacity.");
             if (maxCount > MaxBatchSize) throw new ArgumentOutOfRangeException(nameof(maxCount), "The value of maxCount must be lower than, or equal to, the max batch size.");
 
             var requestMessage = RingbufferReadManyCodec.EncodeRequest(Name, startSequence, minCount, maxCount, null);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = RingbufferReadManyCodec.DecodeResponse(responseMessage).Items;
             return new ReadOnlyLazyList<TItem>(response, SerializationService);
         }
@@ -115,7 +115,7 @@ namespace Hazelcast.DistributedObjects.Impl
             if (sequence < 0) throw new ArgumentOutOfRangeException(nameof(sequence));
 
             var requestMessage = RingbufferReadOneCodec.EncodeRequest(Name, sequence);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = RingbufferReadOneCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TItem>(response);
         }
@@ -124,7 +124,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<long> GetRemainingCapacityAsync()
         {
             var requestMessage = RingbufferRemainingCapacityCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return RingbufferRemainingCapacityCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -132,7 +132,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<long> GetSizeAsync()
         {
             var requestMessage = RingbufferSizeCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return RingbufferSizeCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -140,7 +140,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<long> GetTailSequenceAsync()
         {
             var requestMessage = RingbufferTailSequenceCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return RingbufferTailSequenceCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HSet.Getting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HSet.Getting.cs
@@ -25,7 +25,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public override async Task<IReadOnlyList<T>> GetAllAsync()
         {
             var requestMessage = SetGetAllCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             var response = SetGetAllCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<T>(response, SerializationService);
         }
@@ -34,14 +34,14 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = SetContainsCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetContainsCodec.DecodeResponse(responseMessage).Response;
         }
 
         public override async Task<int> GetSizeAsync()
         {
             var requestMessage = SetSizeCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetSizeCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -49,14 +49,14 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = SetContainsAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetContainsAllCodec.DecodeResponse(responseMessage).Response;
         }
 
         public override async Task<bool> IsEmptyAsync()
         {
             var requestMessage = SetIsEmptyCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetIsEmptyCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HSet.Removing.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HSet.Removing.cs
@@ -25,7 +25,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = SetRemoveCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetRemoveCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -33,7 +33,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = SetCompareAndRemoveAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetCompareAndRemoveAllCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -41,14 +41,14 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = SetCompareAndRetainAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetCompareAndRetainAllCodec.DecodeResponse(responseMessage).Response;
         }
 
         public override async Task ClearAsync()
         {
             var requestMessage = SetClearCodec.EncodeRequest(Name);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             _ = SetClearCodec.DecodeResponse(responseMessage);
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HSet.Setting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HSet.Setting.cs
@@ -25,7 +25,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = SetAddCodec.EncodeRequest(Name, itemData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetAddCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -33,7 +33,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemsData = ToSafeData(items);
             var requestMessage = SetAddAllCodec.EncodeRequest(Name, itemsData);
-            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CAF();
+            var responseMessage = await Cluster.Messaging.SendToPartitionOwnerAsync(requestMessage, PartitionId).CfAwait();
             return SetAddAllCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HTopic.Events.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HTopic.Events.cs
@@ -40,7 +40,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 HandleEventAsync,
                 new SubscriptionState<TopicEventHandlers<T>>(Name, handlers, state));
 
-            await Cluster.Events.InstallSubscriptionAsync(subscription).CAF();
+            await Cluster.Events.InstallSubscriptionAsync(subscription).CfAwait();
 
             return subscription.Id;
         }
@@ -63,7 +63,7 @@ namespace Hazelcast.DistributedObjects.Impl
             foreach (var handler in sstate.Handlers)
             {
                 // there is only one event type...
-                await handler.HandleAsync(this, member, publishTime, item, state).CAF();
+                await handler.HandleAsync(this, member, publishTime, item, state).CfAwait();
             }
         }
 

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HTopic.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HTopic.cs
@@ -57,7 +57,7 @@ namespace Hazelcast.DistributedObjects.Impl
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HTxList.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HTxList.cs
@@ -47,7 +47,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToData(item);
             var requestMessage = TransactionalListAddCodec.EncodeRequest(Name, TransactionId, ContextId, itemData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalListAddCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -56,7 +56,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToData(item);
             var requestMessage = TransactionalListRemoveCodec.EncodeRequest(Name, TransactionId, ContextId, itemData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalListRemoveCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -64,7 +64,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<int> GetSizeAsync()
         {
             var requestMessage = TransactionalListSizeCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalListSizeCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HTxMap.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HTxMap.cs
@@ -35,7 +35,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = TransactionalMapContainsKeyCodec.EncodeRequest(Name, TransactionId, ContextId, keyData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMapContainsKeyCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -43,7 +43,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = TransactionalMapDeleteCodec.EncodeRequest(Name, TransactionId, ContextId, keyData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             _ = TransactionalMapDeleteCodec.DecodeResponse(responseMessage);
         }
 
@@ -51,7 +51,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = TransactionalMapGetCodec.EncodeRequest(Name, TransactionId, ContextId, keyData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapGetCodec.DecodeResponse(responseMessage).Response;
 
             return ToObject<TValue>(response);
@@ -61,7 +61,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = TransactionalMapGetForUpdateCodec.EncodeRequest(Name, TransactionId, ContextId, keyData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapGetForUpdateCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -69,14 +69,14 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<bool> IsEmptyAsync()
         {
             var requestMessage = TransactionalMapIsEmptyCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMapIsEmptyCodec.DecodeResponse(responseMessage).Response;
         }
 
         public async Task<IReadOnlyList<TKey>> GetKeysAsync()
         {
             var requestMessage = TransactionalMapKeySetCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapKeySetCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TKey>(response, SerializationService);
         }
@@ -85,7 +85,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var predicateData = ToSafeData(predicate);
             var requestMessage = TransactionalMapKeySetWithPredicateCodec.EncodeRequest(Name, TransactionId, ContextId, predicateData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapKeySetWithPredicateCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TKey>(response, SerializationService);
         }
@@ -95,7 +95,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var (keyData, valueData) = ToSafeData(key, value);
 
             var requestMessage = TransactionalMapSetCodec.EncodeRequest(Name, TransactionId, ContextId, keyData, valueData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             _ = TransactionalMapSetCodec.DecodeResponse(responseMessage);
         }
 
@@ -109,7 +109,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeToLiveMs = timeToLive.RoundedMilliseconds(false);
 
              var requestMessage = TransactionalMapPutCodec.EncodeRequest(Name, TransactionId, ContextId, keyData, valueData, timeToLiveMs);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapPutCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -119,7 +119,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var (keyData, valueData) = ToSafeData(key, value);
 
             var requestMessage = TransactionalMapPutIfAbsentCodec.EncodeRequest(Name, TransactionId, ContextId, keyData, valueData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapPutIfAbsentCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -128,7 +128,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = TransactionalMapRemoveCodec.EncodeRequest(Name, TransactionId, ContextId, keyData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapRemoveCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -138,7 +138,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var (keyData, valueData) = ToSafeData(key, value);
             var requestMessage = TransactionalMapRemoveIfSameCodec.EncodeRequest(Name, TransactionId, ContextId, keyData, valueData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMapRemoveIfSameCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -147,7 +147,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var (keyData, valueData) = ToSafeData(key, newValue);
 
             var requestMessage = TransactionalMapReplaceCodec.EncodeRequest(Name, TransactionId, ContextId, keyData, valueData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapReplaceCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TValue>(response);
         }
@@ -157,21 +157,21 @@ namespace Hazelcast.DistributedObjects.Impl
             var (keyData, oldValueData, newValueData) = ToSafeData(key, oldValue, newValue);
 
             var requestMessage = TransactionalMapReplaceIfSameCodec.EncodeRequest(Name, TransactionId, ContextId, keyData, oldValueData, newValueData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMapReplaceIfSameCodec.DecodeResponse(responseMessage).Response;
         }
 
         public async Task<int> GetSizeAsync()
         {
             var requestMessage = TransactionalMapSizeCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMapSizeCodec.DecodeResponse(responseMessage).Response;
         }
 
         public async Task<IReadOnlyCollection<TValue>> GetValuesAsync()
         {
             var requestMessage = TransactionalMapValuesCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapValuesCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TValue>(response, SerializationService);
         }
@@ -180,7 +180,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var predicateData = ToSafeData(predicate);
             var requestMessage = TransactionalMapValuesWithPredicateCodec.EncodeRequest(Name, TransactionId, ContextId, predicateData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMapValuesWithPredicateCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TValue>(response, SerializationService);
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HTxMultiMap.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HTxMultiMap.cs
@@ -34,7 +34,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = TransactionalMultiMapGetCodec.EncodeRequest(Name, TransactionId, ContextId, keyData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMultiMapGetCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TValue>(response, SerializationService);
         }
@@ -43,7 +43,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var (keyData, valueData) = ToSafeData(key, value);
             var requestMessage = TransactionalMultiMapPutCodec.EncodeRequest(Name, TransactionId, ContextId, keyData, valueData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMultiMapPutCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -51,7 +51,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var (keyData, valueData) = ToSafeData(key, value);
             var requestMessage = TransactionalMultiMapRemoveEntryCodec.EncodeRequest(Name, TransactionId, ContextId, keyData, valueData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMultiMapRemoveEntryCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -59,7 +59,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToData(key);
             var requestMessage = TransactionalMultiMapRemoveCodec.EncodeRequest(Name, TransactionId, ContextId, keyData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalMultiMapRemoveCodec.DecodeResponse(responseMessage).Response;
             return new ReadOnlyLazyList<TValue>(response, SerializationService);
         }
@@ -67,7 +67,7 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<int> GetSizeAsync()
         {
             var requestMessage = TransactionalMultiMapSizeCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMultiMapSizeCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -75,7 +75,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var keyData = ToSafeData(key);
             var requestMessage = TransactionalMultiMapValueCountCodec.EncodeRequest(Name, TransactionId, ContextId, keyData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalMultiMapValueCountCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HTxQueue.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HTxQueue.cs
@@ -39,7 +39,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeToWaitMs = timeToWait.RoundedMilliseconds();
 
             var requestMessage = TransactionalQueueOfferCodec.EncodeRequest(Name, TransactionId, ContextId, itemData, timeToWaitMs);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalQueueOfferCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -49,7 +49,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeToWaitMs = timeToWait.RoundedMilliseconds();
 
             var requestMessage = TransactionalQueuePeekCodec.EncodeRequest(Name, TransactionId, ContextId, timeToWaitMs);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalQueuePeekCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TItem>(response);
         }
@@ -60,7 +60,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var timeToWaitMs = timeToWait.RoundedMilliseconds();
 
             var requestMessage = TransactionalQueuePollCodec.EncodeRequest(Name, TransactionId, ContextId, timeToWaitMs);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalQueuePollCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TItem>(response);
         }
@@ -68,14 +68,14 @@ namespace Hazelcast.DistributedObjects.Impl
         public async Task<int> GetSizeAsync()
         {
             var requestMessage = TransactionalQueueSizeCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalQueueSizeCodec.DecodeResponse(responseMessage).Response;
         }
 
         public async Task<TItem> TakeAsync()
         {
             var requestMessage = TransactionalQueueTakeCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             var response = TransactionalQueueTakeCodec.DecodeResponse(responseMessage).Response;
             return ToObject<TItem>(response);
         }

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HTxSet.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HTxSet.cs
@@ -32,7 +32,7 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = TransactionalSetAddCodec.EncodeRequest(Name, TransactionId, ContextId, itemData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalSetAddCodec.DecodeResponse(responseMessage).Response;
         }
 
@@ -40,14 +40,14 @@ namespace Hazelcast.DistributedObjects.Impl
         {
             var itemData = ToSafeData(item);
             var requestMessage = TransactionalSetRemoveCodec.EncodeRequest(Name, TransactionId, ContextId, itemData);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalSetRemoveCodec.DecodeResponse(responseMessage).Response;
         }
 
         public async Task<int> GetSizeAsync()
         {
             var requestMessage = TransactionalSetSizeCodec.EncodeRequest(Name, TransactionId, ContextId);
-            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CAF();
+            var responseMessage = await Cluster.Messaging.SendToMemberAsync(requestMessage, TransactionClientConnection).CfAwait();
             return TransactionalSetSizeCodec.DecodeResponse(responseMessage).Response;
         }
     }

--- a/src/Hazelcast.Net/HazelcastClient.Events.cs
+++ b/src/Hazelcast.Net/HazelcastClient.Events.cs
@@ -48,11 +48,11 @@ namespace Hazelcast
                 {
                     case DistributedObjectCreatedEventHandler _:
                     case DistributedObjectDestroyedEventHandler _:
-                        await Cluster.ClusterEvents.AddObjectLifecycleSubscription().CAF();
+                        await Cluster.ClusterEvents.AddObjectLifecycleSubscription().CfAwait();
                         break;
 
                     case PartitionLostEventHandler _:
-                        await Cluster.ClusterEvents.AddPartitionLostSubscription().CAF();
+                        await Cluster.ClusterEvents.AddPartitionLostSubscription().CfAwait();
                         break;
 
                     case MembersUpdatedEventHandler _ :
@@ -85,9 +85,9 @@ namespace Hazelcast
             {
                 var removed = handler switch
                 {
-                    DistributedObjectCreatedEventHandler _ => await Cluster.ClusterEvents.RemoveObjectLifecycleSubscription().CAF(),
-                    DistributedObjectDestroyedEventHandler _ => await Cluster.ClusterEvents.RemoveObjectLifecycleSubscription().CAF(),
-                    PartitionLostEventHandler _ => await Cluster.ClusterEvents.RemovePartitionLostSubscription().CAF(),
+                    DistributedObjectCreatedEventHandler _ => await Cluster.ClusterEvents.RemoveObjectLifecycleSubscription().CfAwait(),
+                    DistributedObjectDestroyedEventHandler _ => await Cluster.ClusterEvents.RemoveObjectLifecycleSubscription().CfAwait(),
+                    PartitionLostEventHandler _ => await Cluster.ClusterEvents.RemovePartitionLostSubscription().CfAwait(),
                     MembersUpdatedEventHandler _ => true,
                     PartitionsUpdatedEventHandler _ => true,
                     ConnectionOpenedEventHandler _ => true,
@@ -191,14 +191,14 @@ namespace Hazelcast
                 // FIXME should this be cancelable?
                 var cancellationToken = CancellationToken.None;
                 foreach (var subscriber in _options.Subscribers)
-                    await subscriber.SubscribeAsync(this, cancellationToken).CAF();
+                    await subscriber.SubscribeAsync(this, cancellationToken).CfAwait();
             }
 
             var args = new ConnectionOpenedEventArgs(isFirst);
 
             // trigger ConnectionOpened event
             await ForEachHandler<ConnectionOpenedEventHandler, ConnectionOpenedEventArgs>(
-                (handler, sender, a) => handler.HandleAsync(sender, a), args).CAF();
+                (handler, sender, a) => handler.HandleAsync(sender, a), args).CfAwait();
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace Hazelcast
             {
                 try
                 {
-                    await action(handler, this, args).CAF();
+                    await action(handler, this, args).CfAwait();
                 }
                 catch (Exception e)
                 {

--- a/src/Hazelcast.Net/HazelcastClient.Objects.cs
+++ b/src/Hazelcast.Net/HazelcastClient.Objects.cs
@@ -29,7 +29,7 @@ namespace Hazelcast
         /// <inheritdoc />
         public async ValueTask DestroyAsync(IDistributedObject o)
         {
-            await _distributedOjects.DestroyAsync(o).CAF();
+            await _distributedOjects.DestroyAsync(o).CfAwait();
         }
 
         /// <inheritdoc />
@@ -39,14 +39,14 @@ namespace Hazelcast
             var nearCacheOptions = _options.GetNearCacheOptions(name);
             var nearCache = nearCacheOptions == null
                 ? null
-                : await _nearCacheManager.GetOrCreateNearCacheAsync<TValue>(name, nearCacheOptions).CAF();
+                : await _nearCacheManager.GetOrCreateNearCacheAsync<TValue>(name, nearCacheOptions).CfAwait();
 
             HMap<TKey, TValue> CreateMap(string n, DistributedObjectFactory factory, Cluster cluster, SerializationService serializationService, ILoggerFactory loggerFactory)
                 => nearCacheOptions == null
                     ? new HMap<TKey, TValue>(n, factory, cluster, serializationService, _lockReferenceIdSequence, loggerFactory)
                     : new HMapWithCache<TKey, TValue>(n, factory, cluster, serializationService, _lockReferenceIdSequence, nearCache, loggerFactory);
 
-            return await _distributedOjects.GetOrCreateAsync<IHMap<TKey, TValue>, HMap<TKey, TValue>>(ServiceNames.Map, name, true, CreateMap).CAF();
+            return await _distributedOjects.GetOrCreateAsync<IHMap<TKey, TValue>, HMap<TKey, TValue>>(ServiceNames.Map, name, true, CreateMap).CfAwait();
         }
 
         /// <inheritdoc />
@@ -65,7 +65,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -83,7 +83,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -101,7 +101,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -119,7 +119,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -137,7 +137,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -155,7 +155,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
 
@@ -173,7 +173,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            return await task.CAF();
+            return await task.CfAwait();
 #endif
         }
     }

--- a/src/Hazelcast.Net/HazelcastClient.Transactions.cs
+++ b/src/Hazelcast.Net/HazelcastClient.Transactions.cs
@@ -30,7 +30,7 @@ namespace Hazelcast
             options ??= new TransactionOptions();
 
             var transactionContext = new TransactionContext(Cluster, options, SerializationService, _loggerFactory);
-            await transactionContext.BeginAsync().CAF();
+            await transactionContext.BeginAsync().CfAwait();
             return transactionContext;
         }
     }

--- a/src/Hazelcast.Net/HazelcastClient.cs
+++ b/src/Hazelcast.Net/HazelcastClient.cs
@@ -166,7 +166,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -186,7 +186,7 @@ namespace Hazelcast
 #if HZ_OPTIMIZE_ASYNC
             return task;
 #else
-            await task.CAF();
+            await task.CfAwait();
 #endif
         }
 
@@ -201,7 +201,7 @@ namespace Hazelcast
 
             try
             {
-                await _nearCacheManager.DisposeAsync().CAF();
+                await _nearCacheManager.DisposeAsync().CfAwait();
             }
             catch (Exception e)
             {
@@ -210,7 +210,7 @@ namespace Hazelcast
 
             try
             {
-                await _distributedOjects.DisposeAsync().CAF();
+                await _distributedOjects.DisposeAsync().CfAwait();
             }
             catch (Exception e)
             {
@@ -219,7 +219,7 @@ namespace Hazelcast
 
             try
             {
-                await Cluster.DisposeAsync().CAF();
+                await Cluster.DisposeAsync().CfAwait();
             }
             catch (Exception e)
             {

--- a/src/Hazelcast.Net/HazelcastClientEventSubscriber.cs
+++ b/src/Hazelcast.Net/HazelcastClientEventSubscriber.cs
@@ -69,7 +69,7 @@ namespace Hazelcast
         {
             if (_subscribeAsync != null)
             {
-                await _subscribeAsync(hazelcastClient, cancellationToken).CAF();
+                await _subscribeAsync(hazelcastClient, cancellationToken).CfAwait();
             }
             else
             {
@@ -77,7 +77,7 @@ namespace Hazelcast
                     ? ServiceFactory.CreateInstance<IHazelcastClientEventSubscriber>(_typename, null)
                     : ServiceFactory.CreateInstance<IHazelcastClientEventSubscriber>(_type, null));
 
-                await subscriber.SubscribeAsync(hazelcastClient, cancellationToken).CAF();
+                await subscriber.SubscribeAsync(hazelcastClient, cancellationToken).CfAwait();
             }
         }
     }

--- a/src/Hazelcast.Net/HazelcastClientFactory.cs
+++ b/src/Hazelcast.Net/HazelcastClientFactory.cs
@@ -112,7 +112,7 @@ namespace Hazelcast
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             var client = CreateClient(options);
-            await client.StartAsync(cancellationToken).CAF();
+            await client.StartAsync(cancellationToken).CfAwait();
             return client;
         }
 
@@ -143,7 +143,7 @@ namespace Hazelcast
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             var client = CreateClient(options);
-            await client.StartAsync(timeout).CAF();
+            await client.StartAsync(timeout).CfAwait();
             return client;
         }
 

--- a/src/Hazelcast.Net/NearCaching/NearCache.cs
+++ b/src/Hazelcast.Net/NearCaching/NearCache.cs
@@ -63,7 +63,7 @@ namespace Hazelcast.NearCaching
             {
                 try
                 {
-                    _subscriptionId = await SubscribeToInvalidationEventsAsync().CAF();
+                    _subscriptionId = await SubscribeToInvalidationEventsAsync().CfAwait();
                     RepairingHandler = new RepairingHandler(Cluster.ClientId, this, _maxToleratedMissCount, Cluster.Partitioner, SerializationService, LoggerFactory);
                     IsInvalidating = true;
                 }
@@ -79,7 +79,7 @@ namespace Hazelcast.NearCaching
         protected override async ValueTask DisposeAsyncCore()
         {
             if (_subscriptionId != default)
-                await Cluster.Events.RemoveSubscriptionAsync(_subscriptionId, CancellationToken.None).CAF();
+                await Cluster.Events.RemoveSubscriptionAsync(_subscriptionId, CancellationToken.None).CfAwait();
         }
 
         /// <inheritdoc />
@@ -132,7 +132,7 @@ namespace Hazelcast.NearCaching
                 (message, state) => MapAddNearCacheInvalidationListenerCodec.HandleEventAsync(message, HandleCodecSingleEvent, HandleCodecBatchEvent, null, LoggerFactory),
                 new EventState { Name = Name });
 
-            await Cluster.Events.InstallSubscriptionAsync(subscription, CancellationToken.None).CAF();
+            await Cluster.Events.InstallSubscriptionAsync(subscription, CancellationToken.None).CfAwait();
             return subscription.Id;
         }
 

--- a/src/Hazelcast.Net/NearCaching/NearCache`TValue.cs
+++ b/src/Hazelcast.Net/NearCaching/NearCache`TValue.cs
@@ -46,7 +46,7 @@ namespace Hazelcast.NearCaching
         /// <param name="valueData">The value data.</param>
         /// <returns><c>true</c> if the value could be added; otherwise <c>false</c>.</returns>
         public async ValueTask<bool> TryAddAsync(IData keyData, IData valueData)
-            => await InnerCache.TryAddAsync(keyData, valueData).CAF();
+            => await InnerCache.TryAddAsync(keyData, valueData).CfAwait();
 
         /// <summary>
         /// Tries to get a value from, or add a value to, the cache.
@@ -58,7 +58,7 @@ namespace Hazelcast.NearCaching
         {
             try
             {
-                var (success, valueObject) = await InnerCache.TryGetOrAddAsync(keyData, valueFactory).CAF();
+                var (success, valueObject) = await InnerCache.TryGetOrAddAsync(keyData, valueFactory).CfAwait();
                 var value = ToTValue(valueObject);
                 if (success) return value;
                 return Maybe.None;
@@ -77,7 +77,7 @@ namespace Hazelcast.NearCaching
         /// <returns>An attempt at getting the value from the cache.</returns>
         public async ValueTask<Attempt<TValue>> TryGetAsync(IData keyData)
         {
-            var (success, value) = await InnerCache.TryGetAsync(keyData).CAF();
+            var (success, value) = await InnerCache.TryGetAsync(keyData).CfAwait();
             if (!success) return Attempt.Failed;
 
             return ToTValue(value);
@@ -89,7 +89,7 @@ namespace Hazelcast.NearCaching
         /// <param name="keyData">The key data.</param>
         /// <returns>Whether the cache contains an entry with the specified key.</returns>
         public async ValueTask<bool> ContainsKeyAsync(IData keyData)
-            => await InnerCache.ContainsKeyAsync(keyData).CAF();
+            => await InnerCache.ContainsKeyAsync(keyData).CfAwait();
 
         /// <summary>
         /// Removes an entry from the cache.
@@ -127,7 +127,7 @@ namespace Hazelcast.NearCaching
         /// <inheritdoc />
         public async ValueTask DisposeAsync()
         {
-            await InnerCache.DisposeAsync().CAF();
+            await InnerCache.DisposeAsync().CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/NetStandard/StreamExtensions.cs
+++ b/src/Hazelcast.Net/NetStandard/StreamExtensions.cs
@@ -88,7 +88,7 @@ namespace System.IO
                 reg = cancellationToken.Register(() => completion.TrySetCanceled());
 
                 var reading = stream.ReadAsync(bytes, offset, count, cancellationToken);
-                var completed = await Task.WhenAny(reading, completion.Task).CAF();
+                var completed = await Task.WhenAny(reading, completion.Task).CfAwait();
 
                 if (completed != reading)
                 {

--- a/src/Hazelcast.Net/Networking/ClientSocketConnection.cs
+++ b/src/Hazelcast.Net/Networking/ClientSocketConnection.cs
@@ -85,7 +85,7 @@ namespace Hazelcast.Networking
 
             // connect to server
             HConsole.WriteLine(this, "Connect to server");
-            await socket.ConnectAsync(_endpoint, _socketOptions.ConnectionTimeoutMilliseconds, cancellationToken).CAF();
+            await socket.ConnectAsync(_endpoint, _socketOptions.ConnectionTimeoutMilliseconds, cancellationToken).CfAwait();
             HConsole.WriteLine(this, "Connected to server");
 
             // use a stream, because we may use SSL and require an SslStream
@@ -94,7 +94,7 @@ namespace Hazelcast.Networking
 #pragma warning restore CA2000
             if (_sslOptions.Enabled)
             {
-                stream = await new SslLayer(_sslOptions, _loggerFactory).GetStreamAsync(stream).CAF();
+                stream = await new SslLayer(_sslOptions, _loggerFactory).GetStreamAsync(stream).CfAwait();
             }
 
             // wire the pipe

--- a/src/Hazelcast.Net/Networking/SslLayer.cs
+++ b/src/Hazelcast.Net/Networking/SslLayer.cs
@@ -49,7 +49,7 @@ namespace Hazelcast.Networking
 
             try
             {
-                await sslStream.AuthenticateAsClientAsync(targetHost, clientCertificates, _options.Protocol, _options.CheckCertificateRevocation).CAF();
+                await sslStream.AuthenticateAsClientAsync(targetHost, clientCertificates, _options.Protocol, _options.CheckCertificateRevocation).CfAwait();
             }
             catch (Exception e)
             {

--- a/src/Hazelcast.Net/Transactions/TransactionContext.cs
+++ b/src/Hazelcast.Net/Transactions/TransactionContext.cs
@@ -105,7 +105,7 @@ namespace Hazelcast.Transactions
                 throw new InvalidOperationException("Nested transactions are not supported.");
 
             // TODO: think about race conditions?
-            _connection = await _cluster.Members.WaitRandomConnection().CAF();
+            _connection = await _cluster.Members.WaitRandomConnection().CfAwait();
             InTransaction = true;
 
             _threadId = ContextId;
@@ -119,7 +119,7 @@ namespace Hazelcast.Transactions
                 var timeoutMs = _options.Timeout.RoundedMilliseconds(false);
 
                 var requestMessage = TransactionCreateCodec.EncodeRequest(timeoutMs, _options.Durability, (int) _options.Type, ContextId);
-                var responseMessage = await _cluster.Messaging.SendToMemberAsync(requestMessage, _connection).CAF();
+                var responseMessage = await _cluster.Messaging.SendToMemberAsync(requestMessage, _connection).CfAwait();
                 TransactionId = TransactionCreateCodec.DecodeResponse(responseMessage).Response;
                 State = TransactionState.Active;
             }
@@ -151,7 +151,7 @@ namespace Hazelcast.Transactions
             try
             {
                 var requestMessage = TransactionCommitCodec.EncodeRequest(TransactionId, ContextId);
-                var responseMessage = await _cluster.Messaging.SendToMemberAsync(requestMessage, _connection).CAF();
+                var responseMessage = await _cluster.Messaging.SendToMemberAsync(requestMessage, _connection).CfAwait();
                 _ = TransactionCommitCodec.DecodeResponse(responseMessage);
                 State = TransactionState.Committed;
             }
@@ -189,7 +189,7 @@ namespace Hazelcast.Transactions
             try
             {
                 var requestMessage = TransactionRollbackCodec.EncodeRequest(TransactionId, ContextId);
-                var responseMessage = await _cluster.Messaging.SendToMemberAsync(requestMessage, _connection).CAF();
+                var responseMessage = await _cluster.Messaging.SendToMemberAsync(requestMessage, _connection).CfAwait();
                 _ = TransactionRollbackCodec.DecodeResponse(responseMessage);
                 State = TransactionState.RolledBack;
             }
@@ -215,7 +215,7 @@ namespace Hazelcast.Transactions
         {
             try
             {
-                await _distributedObjectFactory.DisposeAsync().CAF();
+                await _distributedObjectFactory.DisposeAsync().CfAwait();
             }
             catch
             { /* ignore */ } // TODO: log?
@@ -224,7 +224,7 @@ namespace Hazelcast.Transactions
             if (InTransaction)
             {
                 // may throw
-                await (_completed ? CommitAsync() : RollbackAsync()).CAF();
+                await (_completed ? CommitAsync() : RollbackAsync()).CfAwait();
             }
         }
 


### PR DESCRIPTION
The `.CAF()` method is a shortcut for `.ConfigureAwait(false)` but the name is not very nice + we want to implement more "configure await" methods with timeouts, etc. So, renaming it to `.CfAwait()`.