### PR TITLE
Misc fixes (warnings, dependencies...)

### DIFF
--- a/doc/dev/doc/gettingStarted.md
+++ b/doc/dev/doc/gettingStarted.md
@@ -26,6 +26,12 @@ var client = await HazelcastClientFactory.StartNewClientAsync(options);
 
 Refer to the [Configuration](configuration.md) page for details on the various ways to build an @Hazelcast.HazelcastOptions instance, including handling command-line parameters, and to the @Hazelcast.HazelcastOptions reference for a list of all the configurable elements.
 
+## Logging
+
+The Hazelcast .NET client uses the logging abstractions proposed by the [Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging) namespace. By default, the client supports the abstractions, but does not come with any actual implementation. This means that, by default, the client will not output any log information. To actually log, an implementation must be added to the project.
+
+See the [Logging](logging.md) documentation for details.
+
 ## Distributed Objects
 
 The client can be used to obtain *distributed objects* that are managed by the cluster. For instance, the cluster can manage @Hazelcast.DistributedObjects.IHDictionary`2 objects, which are an asynchronous equivalent of .NET @System.Collections.Generic.IDictionary`2. Each object is identified by a unique name, which is used to retrieve the object. Finally, distributed objects need to be disposed after usage, to ensure they release their resources.

--- a/doc/dev/doc/obtaining.md
+++ b/doc/dev/doc/obtaining.md
@@ -33,3 +33,9 @@ Or manually added to the project as a package reference:
 ```
 <PackageReference Include="Hazelcast.NET" Version="4.0.0" />
 ```
+
+## Notes
+
+The Hazelcast .NET client uses the logging abstractions proposed by the [Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging) namespace. By default, the client supports the abstractions, but does not come with any actual implementation. This means that, by default, the client will not output any log information. To actually log, an implementation must be added to the project.
+
+See the [Logging](logging.md) documentation for details.

--- a/hz.ps1
+++ b/hz.ps1
@@ -56,7 +56,7 @@ param (
 
     # Test selector
     # Is a simplified version of $testFilter which ends up adding a test filter as
-    # "name == /$framework.$test/"
+    # "name =~ /$framework.$test/"
     [string]
     $test,
 
@@ -366,7 +366,7 @@ if(!($enterprise)) {
 }
 if (-not [System.String]::IsNullOrWhiteSpace($test)) {
     if (-not [System.String]::IsNullOrWhiteSpace($testFilter)) { $testFilter += " && " } else { $testFilter = "" }
-    $testFilter += "name == /<FRAMEWORK>.$test/"
+    $testFilter += "name =~ /$test/"
 }
 
 # determine tests name
@@ -876,7 +876,7 @@ if ($doTests -or $doRc -or $doServer) {
     $v = $v.SubString($p0+1,$p1-$p0-1)
 
     Write-Output ""
-    Write-Output "Running Java v$v"
+    Write-Output "Detected Java v$v"
 
     if (-not $v.StartsWith("1.8")) {
         # starting with Java 9 ... weird things can happen

--- a/src/Hazelcast.Net.Testing/Hazelcast.Net.Testing.csproj
+++ b/src/Hazelcast.Net.Testing/Hazelcast.Net.Testing.csproj
@@ -29,8 +29,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="NuGet.Versioning" Version="5.8.0" />
-    <!-- stick with 3.11.1 - see Tests.csproj -->
-    <PackageReference Include="NUnit" Version="3.11.1" />
+    <!-- see Tests.csproj for NUnit verison -->
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
   </ItemGroup>
 

--- a/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
+++ b/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
@@ -32,8 +32,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="NuGet.Versioning" Version="5.8.0" />
-    <!-- stick with 3.11.1 / 3.16.1 as long as https://github.com/nunit/nunit3-vs-adapter/issues/780 is not fixed! -->
-    <PackageReference Include="nunit" Version="3.11.1" />
+    <!-- stick with 3.12.0 / 3.16.1 as long as https://github.com/nunit/nunit3-vs-adapter/issues/780 is not fixed! -->
+    <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Hazelcast.Net.Tests/Networking/AddressProviderTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/AddressProviderTests.cs
@@ -94,24 +94,31 @@ namespace Hazelcast.Tests.Networking
             options.Addresses.Clear();
 
             CloudDiscovery.SetResponse(@"[
+    { ""private-address"":""192.0.0.6:5788"", ""public-address"":""192.147.0.6"" },
     { ""private-address"":""192.0.0.7"", ""public-address"":""192.147.0.7"" },
-    { ""private-address"":""192.0.0.8"", ""public-address"":""192.147.0.8"" },
+    { ""private-address"":""192.0.0.8:5777"", ""public-address"":""192.147.0.8:5703"" },
     { ""private-address"":""192.0.0.9"", ""public-address"":""192.147.0.9:5707"" },
 ]");
+
+            static void AssertMap(AddressProvider ap, string priv, string pub)
+                => Assert.That(ap.Map(NetworkAddress.Parse(priv)), Is.EqualTo(NetworkAddress.Parse(pub)));
 
             try
             {
                 var addressProvider = new AddressProvider(options, loggerFactory);
 
-                Assert.That(addressProvider.Map(new NetworkAddress("192.0.0.7")), Is.EqualTo(new NetworkAddress("192.147.0.7")));
-                Assert.That(addressProvider.Map(new NetworkAddress("192.0.0.8")), Is.EqualTo(new NetworkAddress("192.147.0.8")));
-                Assert.That(addressProvider.Map(new NetworkAddress("192.0.0.9", 5707)), Is.EqualTo(new NetworkAddress("192.147.0.9", 5707)));
+                AssertMap(addressProvider, "192.0.0.6:5788", "192.147.0.6:5701");
+                AssertMap(addressProvider, "192.0.0.7:5701", "192.147.0.7:5701");
+                AssertMap(addressProvider, "192.0.0.8:5777", "192.147.0.8:5703");
+                AssertMap(addressProvider, "192.0.0.9:5707", "192.147.0.9:5707");
+
                 Assert.That(addressProvider.Map(new NetworkAddress("192.0.0.10")), Is.Null);
 
-                Assert.That(addressProvider.GetAddresses().Count(), Is.EqualTo(3));
-                Assert.That(addressProvider.GetAddresses(), Does.Contain(new NetworkAddress("192.0.0.7")));
-                Assert.That(addressProvider.GetAddresses(), Does.Contain(new NetworkAddress("192.0.0.8")));
-                Assert.That(addressProvider.GetAddresses(), Does.Contain(new NetworkAddress("192.0.0.9", 5707)));
+                Assert.That(addressProvider.GetAddresses().Count(), Is.EqualTo(4));
+                Assert.That(addressProvider.GetAddresses(), Does.Contain(NetworkAddress.Parse("192.0.0.6:5788")));
+                Assert.That(addressProvider.GetAddresses(), Does.Contain(NetworkAddress.Parse("192.0.0.7:5701")));
+                Assert.That(addressProvider.GetAddresses(), Does.Contain(NetworkAddress.Parse("192.0.0.8:5777")));
+                Assert.That(addressProvider.GetAddresses(), Does.Contain(NetworkAddress.Parse("192.0.0.9:5707")));
 
                 addressProvider = new AddressProvider(options, loggerFactory);
                 Assert.That(addressProvider.Map(new NetworkAddress("192.0.0.10")), Is.Null);

--- a/src/Hazelcast.Net.Tests/Remote/ClientMapTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientMapTest.cs
@@ -62,9 +62,10 @@ namespace Hazelcast.Tests.Remote
                 return id;
             }
 
-            public async Task SetId(int id)
+            public Task SetId(int id)
             {
                 this.id = id;
+                return Task.CompletedTask;
             }
         }
 

--- a/src/Hazelcast.Net.Tests/Remote/DnsTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/DnsTests.cs
@@ -40,8 +40,7 @@ namespace Hazelcast.Tests.Remote
         {
             using var _ = HConsoleForTest();
 
-            // FIXME RESTORE THIS LINE
-            //using var altDns = HDns.Override(new AltDns(2));
+            using var altDns = HDns.Override(new AltDns(2));
 
             await using var client = await CreateAndStartClientAsync();
 

--- a/src/Hazelcast.Net/Core/Attempt`TResult.cs
+++ b/src/Hazelcast.Net/Core/Attempt`TResult.cs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#nullable enable
+// have to comment this out, C# 8 will not allow us to write TResult?
+// without specifying whether TResult is a class or a struct
+// TODO: uncomment + make exception Exception? eventually (requires C# 9)
+//#nullable enable
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -49,7 +52,7 @@ namespace Hazelcast.Core
         /// <param name="success">Whether the attempt succeeded.</param>
         /// <param name="value">The optional value of the result.</param>
         /// <param name="exception">An optional captured exception.</param>
-        internal Attempt(bool success, TResult value = default, Exception? exception = default)
+        internal Attempt(bool success, TResult value = default, Exception exception = default)
         {
             Success = success;
             Value = value;
@@ -59,9 +62,7 @@ namespace Hazelcast.Core
         /// <summary>
         /// Represents a failed attempt with no result and no exception.
         /// </summary>
-#pragma warning disable CA1000 // Do not declare static members on generic types - fine here
         public static Attempt<TResult> Failed => new Attempt<TResult>(false); // no such thing as 'struct' singletons!
-#pragma warning restore CA1000 // Do not declare static members on generic types
 
         /// <summary>
         /// Gets a value indicating whether the attempt succeeded.
@@ -103,7 +104,7 @@ namespace Hazelcast.Core
         /// <summary>
         /// Gets a captured exception.
         /// </summary>
-        public Exception? Exception { get; }
+        public Exception Exception { get; }
 
         /// <summary>
         /// Gets a value indicating whether the attempt contains an exception.
@@ -128,11 +129,7 @@ namespace Hazelcast.Core
         /// Implicitly converts a non-generic attempt into a generic one.
         /// </summary>
         /// <param name="attempt">The attempt.</param>
-#pragma warning disable IDE0060 // Remove unused parameter - needed for implicit conversion
-#pragma warning disable CA1801 // Review unused parameters
         public static implicit operator Attempt<TResult>(Attempt attempt)
-#pragma warning restore CA1801
-#pragma warning restore IDE0060
             => new Attempt<TResult>(attempt.Success);
 
         /// <summary>

--- a/src/Hazelcast.Net/Networking/CloudDiscovery.cs
+++ b/src/Hazelcast.Net/Networking/CloudDiscovery.cs
@@ -46,14 +46,14 @@ namespace Hazelcast.Networking
             if (string.IsNullOrWhiteSpace(discoveryToken)) throw new ArgumentException(ExceptionMessages.NullOrEmpty, nameof(discoveryToken));
             if (cloudBaseUrl == null) throw new ArgumentNullException(nameof(cloudBaseUrl));
 
+            _defaultPort = defaultPort;
             _endpointUrl = new Uri(cloudBaseUrl, CloudUrlPath + discoveryToken);
             _connectionTimeoutMilliseconds = connectionTimeoutMilliseconds;
             _logger = loggerFactory?.CreateLogger<CloudDiscovery>() ?? throw new ArgumentNullException(nameof(loggerFactory));
         }
 
         /// <summary>
-        /// (internal for tests only)
-        /// Sets the response.
+        /// (internal for tests only) Sets the constant response for tests.
         /// </summary>
         internal static void SetResponse(string response)
         {


### PR DESCRIPTION
A set of minor fixes:
* Cleanup the `hz` script for running tests
* Commit the protocol submodule version, now that latest changes have been merged into the protocol repo
* Fix NUnit versions mismatches that produced warnings when building
* Fix a missing line in `CouldDiscovery` and fix the corresponding tests
* Fix various files to get rid of warnings when building