### PR TITLE
Refactor AsyncContext

### DIFF
--- a/src/Hazelcast.Net.Testing/HazelcastTestBase.cs
+++ b/src/Hazelcast.Net.Testing/HazelcastTestBase.cs
@@ -57,7 +57,7 @@ namespace Hazelcast.Testing
         {
             // creating the client via an async method means we may not have a context - ensure here
             // (before each test)
-            AsyncContext.EnsureNew();
+            AsyncContext.RequireNew();
         }
 
         [TearDown]

--- a/src/Hazelcast.Net/Core/AsyncContext.cs
+++ b/src/Hazelcast.Net/Core/AsyncContext.cs
@@ -24,15 +24,15 @@ namespace Hazelcast.Core
     /// <summary>
     /// Represents an ambient context that is local to a given asynchronous control flow, such as an asynchronous method.
     /// </summary>
-    internal sealed class AsyncContext
+    public sealed class AsyncContext
     {
         // the sequence of unique identifiers for contexts
         private static ISequence<long> _idSequence = new Int64Sequence();
 
 #if !HZ_CONSOLE
-        private static readonly AsyncLocal<AsyncContext> Current = new AsyncLocal<AsyncContext>();
+        private static readonly AsyncLocal<AsyncContext> AsyncLocalContext = new AsyncLocal<AsyncContext>();
 #else
-        private static readonly AsyncLocal<AsyncContext> Current = new AsyncLocal<AsyncContext>(ValueChangedHandler);
+        private static readonly AsyncLocal<AsyncContext> AsyncLocalContext = new AsyncLocal<AsyncContext>(ValueChangedHandler);
 
         private static AsyncContext HConsoleObject { get; } = new AsyncContext();
 
@@ -61,26 +61,25 @@ namespace Hazelcast.Core
         /// <summary>
         /// Gets or sets a value indicating whether the current asynchronous context is in a transaction.
         /// </summary>
-        public bool InTransaction { get; set; } // see discussion in TransactionContext
+        internal bool InTransaction { get; set; } // see discussion in TransactionContext
 
         /// <summary>
         /// Gets the current context.
         /// </summary>
-        public static AsyncContext CurrentContext => Current.Value ??= new AsyncContext();
+        public static AsyncContext Current => AsyncLocalContext.Value ??= new AsyncContext();
 
         /// <summary>
-        /// Whether there is a current context.
+        /// (internal for tests only) Whether there is a current context.
         /// </summary>
-        internal static bool HasCurrent => Current.Value != null;
+        internal static bool HasCurrent => AsyncLocalContext.Value != null;
 
         /// <summary>
-        /// Clears the current context (removes it).
+        /// (internal for tests only) Clears the current context (removes it).
         /// </summary>
-        internal static void ClearCurrent() => Current.Value = null;
+        internal static void ClearCurrent() => AsyncLocalContext.Value = null;
 
         /// <summary>
-        /// (internal for tests only)
-        /// Resets the sequence of unique identifiers.
+        /// (internal for tests only) Resets the sequence of unique identifiers.
         /// </summary>
         internal static void ResetSequence()
         {
@@ -92,240 +91,41 @@ namespace Hazelcast.Core
         /// </summary>
         internal static void Ensure()
         {
-            Current.Value ??= new AsyncContext();
+            AsyncLocalContext.Value ??= new AsyncContext();
         }
 
         /// <summary>
         /// Requires a new context.
         /// </summary>
-        public static void RequireNew()
+        internal static void RequireNew()
         {
-            Current.Value = new AsyncContext();
+            AsyncLocalContext.Value = new AsyncContext();
         }
 
-        private static TTask RunWithNew<TTask>(Workload<TTask> workload)
-            where TTask : Task
+        /// <summary>
+        /// Replaces the current context with a new context.
+        /// </summary>
+        /// <returns>An <see cref="IDisposable"/> object which will restore the replaced context when disposed.</returns>
+        public static IDisposable New()
         {
-            if (workload == null) throw new ArgumentNullException(nameof(workload));
+            var replaced = AsyncLocalContext.Value;
+            AsyncLocalContext.Value = new AsyncContext();
+            return new UsedContext(replaced);
+        }
 
-            var ec = ExecutionContext.Capture();
+        private class UsedContext : IDisposable
+        {
+            private readonly AsyncContext _replaced;
 
-            // may be null if execution flow has been suppressed - don't do it
-            if (ec == null) throw new InvalidOperationException("Cannot run without an ExecutionContext. Has execution flow been suspended?");
-
-            ExecutionContext.Run(ec, state =>
+            public UsedContext(AsyncContext replaced)
             {
-                RequireNew(); // require a new context
-                ((Workload) state).Start();
-            }, workload);
-
-            return workload.Task;
-        }
-
-        #region Task
-
-        /// <summary>
-        /// Starts an asynchronous task with a new <see cref="AsyncContext"/>.
-        /// </summary>
-        /// <param name="function">A function starting and returning an asynchronous task.</param>
-        /// <returns>The asynchronous task that was started.</returns>
-        public static Task RunWithNew(Func<Task> function)
-        {
-            if (function == null) throw new ArgumentNullException(nameof(function));
-            return RunWithNew(Workload.Create(function));
-        }
-
-        /// <summary>
-        /// Starts an asynchronous task with a new <see cref="AsyncContext"/>.
-        /// </summary>
-        /// <typeparam name="TState">The type of the state object.</typeparam>
-        /// <param name="function">A function starting and returning an asynchronous task.</param>
-        /// <param name="state">A state object that will be passed to the function.</param>
-        /// <returns>The asynchronous task that was started.</returns>
-        public static Task RunWithNew<TState>(Func<TState, Task> function, TState state)
-        {
-            if (function == null) throw new ArgumentNullException(nameof(function));
-            return RunWithNew(Workload.Create(function, state));
-        }
-
-        /// <summary>
-        /// Starts an asynchronous task with a new <see cref="AsyncContext"/>.
-        /// </summary>
-        /// <param name="function">A function starting and returning an asynchronous task.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>The asynchronous task that was started.</returns>
-        public static Task RunWithNew(Func<CancellationToken, Task> function, CancellationToken cancellationToken)
-        {
-            if (function == null) throw new ArgumentNullException(nameof(function));
-            return RunWithNew(Workload.Create(function, cancellationToken));
-        }
-
-        /// <summary>
-        /// Starts an asynchronous task with a new <see cref="AsyncContext"/>.
-        /// </summary>
-        /// <param name="function">A function starting and returning an asynchronous task.</param>
-        /// <param name="state">A state object that will be passed to the function.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>The asynchronous task that was started.</returns>
-        public static Task RunWithNew<TState>(Func<TState, CancellationToken, Task> function, TState state, CancellationToken cancellationToken)
-        {
-            if (function == null) throw new ArgumentNullException(nameof(function));
-            return RunWithNew(Workload.Create(function, state, cancellationToken));
-        }
-
-        #endregion
-
-        #region Task<TResult>
-
-        /// <summary>
-        /// Starts an asynchronous task with a new <see cref="AsyncContext"/>.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result produced by the task.</typeparam>
-        /// <param name="function">A function starting and returning an asynchronous task.</param>
-        /// <returns>The asynchronous task that was started.</returns>
-        public static Task<TResult> RunWithNew<TResult>(Func<Task<TResult>> function)
-        {
-            if (function == null) throw new ArgumentNullException(nameof(function));
-            return RunWithNew(Workload.Create(function));
-        }
-
-        /// <summary>
-        /// Starts an asynchronous task with a new <see cref="AsyncContext"/>.
-        /// </summary>
-        /// <typeparam name="TState">The type of the state object.</typeparam>
-        /// <typeparam name="TResult">The type of the result produced by the task.</typeparam>
-        /// <param name="function">A function starting and returning an asynchronous task.</param>
-        /// <param name="state">A state object that will be passed to the function.</param>
-        /// <returns>The asynchronous task that was started.</returns>
-        public static Task<TResult> RunWithNew<TState, TResult>(Func<TState, Task<TResult>> function, TState state)
-        {
-            if (function == null) throw new ArgumentNullException(nameof(function));
-            return RunWithNew(Workload.Create(function, state));
-        }
-
-        /// <summary>
-        /// Starts an asynchronous task with a new <see cref="AsyncContext"/>.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result produced by the task.</typeparam>
-        /// <param name="function">A function starting and returning an asynchronous task.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>The asynchronous task that was started.</returns>
-        public static Task<TResult> RunWithNew<TResult>(Func<CancellationToken, Task<TResult>> function, CancellationToken cancellationToken)
-        {
-            if (function == null) throw new ArgumentNullException(nameof(function));
-            return RunWithNew(Workload.Create(function, cancellationToken));
-        }
-
-        /// <summary>
-        /// Starts an asynchronous task with a new <see cref="AsyncContext"/>.
-        /// </summary>
-        /// <typeparam name="TState">The type of the state object.</typeparam>
-        /// <typeparam name="TResult">The type of the result produced by the task.</typeparam>
-        /// <param name="function">A function starting and returning an asynchronous task.</param>
-        /// <param name="state">A state object that will be passed to the function.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>The asynchronous task that was started.</returns>
-        public static Task<TResult> RunWithNew<TState, TResult>(Func<TState, CancellationToken, Task<TResult>> function, TState state, CancellationToken cancellationToken)
-        {
-            if (function == null) throw new ArgumentNullException(nameof(function));
-            return RunWithNew(Workload.Create(function, state, cancellationToken));
-        }
-
-        #endregion
-
-        #region Internals
-
-        private abstract class Workload
-        {
-            public static Workload<TTask> Create<TTask>(Func<TTask> function)
-                where TTask : Task
-                => new SimpleWorkload<TTask>(function);
-
-            public static Workload<TTask> Create<TState, TTask>(Func<TState, TTask> function, TState state)
-                where TTask : Task
-                => new SimpleWorkload<TState, TTask>(function, state);
-
-            public static Workload<TTask> Create<TTask>(Func<CancellationToken, TTask> function, CancellationToken cancellationToken)
-                where TTask : Task
-                => new CancellableWorkload<TTask>(function, cancellationToken);
-
-            public static Workload<TTask> Create<TState, TTask>(Func<TState, CancellationToken, TTask> function, TState state, CancellationToken cancellationToken)
-                where TTask : Task
-                => new CancellableWorkload<TState, TTask>(function, state, cancellationToken);
-
-            public abstract void Start();
-        }
-
-        #endregion
-
-        #region Task Workload
-
-        private abstract class Workload<TTask> : Workload
-            where TTask : Task
-        {
-            public TTask Task { get; protected set; }
-        }
-
-        private class SimpleWorkload<TTask> : Workload<TTask>
-            where TTask : Task
-        {
-            private readonly Func<TTask> _function;
-
-            public SimpleWorkload(Func<TTask> function)
-            {
-                _function = function;
+                _replaced = replaced;
             }
 
-            public override void Start() => Task = _function();
-        }
-
-        private class SimpleWorkload<TState, TTask> : Workload<TTask>
-            where TTask : Task
-        {
-            private readonly Func<TState, TTask> _function;
-            private readonly TState _state;
-
-            public SimpleWorkload(Func<TState, TTask> function, TState state)
+            public void Dispose()
             {
-                _function = function;
-                _state = state;
+                AsyncLocalContext.Value = _replaced;
             }
-
-            public override void Start() => Task = _function(_state);
         }
-
-        private class CancellableWorkload<TTask> : Workload<TTask>
-            where TTask : Task
-        {
-            private readonly Func<CancellationToken, TTask> _function;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancellableWorkload(Func<CancellationToken, TTask> function, CancellationToken cancellationToken)
-            {
-                _function = function;
-                _cancellationToken = cancellationToken;
-            }
-
-            public override void Start() => Task = _function(_cancellationToken);
-        }
-
-        private class CancellableWorkload<TState, TTask> : Workload<TTask>
-            where TTask : Task
-        {
-            private readonly Func<TState, CancellationToken, TTask> _function;
-            private readonly TState _state;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancellableWorkload(Func<TState, CancellationToken, TTask> function, TState state, CancellationToken cancellationToken)
-            {
-                _function = function;
-                _state = state;
-                _cancellationToken = cancellationToken;
-            }
-
-            public override void Start() => Task = _function(_state, _cancellationToken);
-        }
-
-        #endregion
     }
 }

--- a/src/Hazelcast.Net/Core/AsyncContext.cs
+++ b/src/Hazelcast.Net/Core/AsyncContext.cs
@@ -96,10 +96,9 @@ namespace Hazelcast.Core
         }
 
         /// <summary>
-        /// (internal for tests only)
-        /// Ensures that a context exists.
+        /// Requires a new context.
         /// </summary>
-        internal static void EnsureNew() // FIXME rename RequireNew() and make it public
+        public static void RequireNew()
         {
             Current.Value = new AsyncContext();
         }
@@ -116,7 +115,7 @@ namespace Hazelcast.Core
 
             ExecutionContext.Run(ec, state =>
             {
-                EnsureNew(); // force a new context
+                RequireNew(); // require a new context
                 ((Workload) state).Start();
             }, workload);
 

--- a/src/Hazelcast.Net/Core/AsyncContext.cs
+++ b/src/Hazelcast.Net/Core/AsyncContext.cs
@@ -99,7 +99,7 @@ namespace Hazelcast.Core
         /// (internal for tests only)
         /// Ensures that a context exists.
         /// </summary>
-        internal static void EnsureNew()
+        internal static void EnsureNew() // FIXME rename RequireNew() and make it public
         {
             Current.Value = new AsyncContext();
         }

--- a/src/Hazelcast.Net/DistributedObjects/DistributedObjectBase.cs
+++ b/src/Hazelcast.Net/DistributedObjects/DistributedObjectBase.cs
@@ -113,7 +113,7 @@ namespace Hazelcast.DistributedObjects
         /// identifier anymore - it is attached to the async context so it can flow with
         /// async operations.
         /// </remarks>
-        protected static long ContextId => AsyncContext.CurrentContext.Id;
+        protected static long ContextId => AsyncContext.Current.Id;
 
         /// <summary>
         /// Gets the serialization service.

--- a/src/Hazelcast.Net/Transactions/TransactionContext.cs
+++ b/src/Hazelcast.Net/Transactions/TransactionContext.cs
@@ -75,7 +75,7 @@ namespace Hazelcast.Transactions
         /// identifier anymore - it is attached to the async context so it can flow with
         /// async operations.
         /// </remarks>
-        private static long ContextId => AsyncContext.CurrentContext.Id;
+        private static long ContextId => AsyncContext.Current.Id;
 
         /// <summary>
         /// Gets or sets a value indicating whether the current asynchronous context is in a transaction.
@@ -89,8 +89,8 @@ namespace Hazelcast.Transactions
             // a confusion of concerns, and maybe a separate AsyncLocal would be more 'pure', but this is
             // simple enough.
 
-            get => AsyncContext.CurrentContext.InTransaction;
-            set => AsyncContext.CurrentContext.InTransaction = value;
+            get => AsyncContext.Current.InTransaction;
+            set => AsyncContext.Current.InTransaction = value;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes: #359 

Following discussions on the internal TDD this refactors the `AsyncContext` class with the following principles:

* code always executes within an implicit async context
* all locks are re-entrant by default, within that async context
* one can execute code in a new, isolated, async context by "using" a new context

For instance:

```csharp
using (AsyncContext.New())
{
    await DoSomethingAsync();
}
```
