### PR TITLE
Adjustments for 4.2 server compatibility

### DIFF
--- a/src/Hazelcast.Net.Tests/Remote/ClientMapTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientMapTest.cs
@@ -23,7 +23,9 @@ using Hazelcast.Exceptions;
 using Hazelcast.Query;
 using Hazelcast.Serialization;
 using Hazelcast.Testing;
+using Hazelcast.Testing.Conditions;
 using Hazelcast.Tests.TestObjects;
+using NuGet.Versioning;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Remote
@@ -598,7 +600,14 @@ namespace Hazelcast.Tests.Remote
 
             var entryStats = await dictionary.GetEntryViewAsync("item1");
 
-            Assert.AreEqual(0, entryStats.Hits);
+            // prior to 4.2, hits is zero
+            // starting with 4.2, hits is -1
+            var serverVersion = ServerVersion.GetVersion();
+            var expectedHits = serverVersion < new NuGetVersion(4, 2, 0)
+                ? 0
+                : -1;
+
+            Assert.AreEqual(expectedHits, entryStats.Hits);
 
             Assert.AreEqual("item1", entryStats.Key);
             Assert.AreEqual("value1", entryStats.Value);
@@ -1143,7 +1152,7 @@ namespace Hazelcast.Tests.Remote
             await using var _ = DestroyAndDispose(dictionary);
 
             Assert.AreEqual(0, await dictionary.GetSizeAsync());
-            await dictionary.PutTransientAsync("key1", "value1", TimeSpan.FromMilliseconds(100));
+            await dictionary.PutTransientAsync("key1", "value1", TimeSpan.FromMilliseconds(1000));
             Assert.AreEqual("value1", await dictionary.GetAsync("key1"));
 
             await AssertEx.SucceedsEventually(async () =>
@@ -1158,7 +1167,7 @@ namespace Hazelcast.Tests.Remote
             var dictionary = await Client.GetMapAsync<string, string>(CreateUniqueName());
             await using var _ = DestroyAndDispose(dictionary);
 
-            await dictionary.SetAsync("key1", "value1", TimeSpan.FromMilliseconds(100));
+            await dictionary.SetAsync("key1", "value1", TimeSpan.FromMilliseconds(1000));
             Assert.IsNotNull(await dictionary.GetAsync("key1"));
 
             await AssertEx.SucceedsEventually(async () =>
@@ -1248,7 +1257,7 @@ namespace Hazelcast.Tests.Remote
             Assert.AreEqual("value1", await dictionary.GetAsync("key1"));
             await dictionary.SetAsync("key1", "value2");
             Assert.AreEqual("value2", await dictionary.GetAsync("key1"));
-            await dictionary.SetAsync("key1", "value3", TimeSpan.FromMilliseconds(100));
+            await dictionary.SetAsync("key1", "value3", TimeSpan.FromMilliseconds(1000));
             Assert.AreEqual("value3", await dictionary.GetAsync("key1"));
 
             await AssertEx.SucceedsEventually(async () =>

--- a/src/Hazelcast.Net.Tests/Remote/ClientTxnMapTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientTxnMapTest.cs
@@ -135,7 +135,7 @@ namespace Hazelcast.Tests.Remote
 
             await using var context = await Client.BeginTransactionAsync();
             var txDictionary = await context.GetMapAsync<string, string>(dictionary.Name);
-            var ttlMillis = 100;
+            var ttlMillis = 1000;
             Assert.That(await txDictionary.PutAsync("key1", "value1", TimeSpan.FromMilliseconds(ttlMillis)), Is.Null);
             Assert.That(await txDictionary.GetAsync("key1"), Is.EqualTo("value1"));
 

--- a/src/Hazelcast.Net.Tests/Remote/MapTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/MapTests.cs
@@ -299,7 +299,7 @@ namespace Hazelcast.Tests.Remote
             var value = await map.GetAsync("key").CfAwait();
             Assert.AreEqual(42, value);
 
-            await Task.Delay(1000); // wait for 1 second
+            await Task.Delay(1500); // wait for 1.5 second
 
             Assert.That(await map.GetAsync("key"), Is.Zero);
 


### PR DESCRIPTION
Some adjustments to tests required for 4.2 server compatibility - especially,
* 4.2 throws `TransactionTimeoutException` in case of a transaction timeout and not `TransactionException` anymore
* 4.2 map entry stats have slightly changed