### PR TITLE
Build and publish Hazelcast.Net.Win32 NuGet package

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -286,6 +286,8 @@ foreach ($t in $commands) {
             Write-Output "  -classPath <classpath> : define an additional classpath (alias: cp)."
             Write-Output "        The classpath is appended to the RC or server classpath."
             Write-Output ""
+            Write-Output "  -reproducible : mark the build as reproducible (alias: repro)"
+            Write-Output ""
             Write-Output ""
             exit 0
 		}

--- a/hz.ps1
+++ b/hz.ps1
@@ -1596,6 +1596,7 @@ if ($doNuget) {
     # https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack
 
     packNuGet("Hazelcast.Net")
+    packNuGet("Hazelcast.Net.Win32")
 }
 
 if ($doNupush -and -not $testsSuccess) {
@@ -1609,6 +1610,7 @@ if ($doNupush) {
     Write-Output "Push NuGet packages..."
 
     &$nuget push "$tmpDir\output\Hazelcast.Net.$version.nupkg" -ApiKey $nugetApiKey -Source "https://api.nuget.org/v3/index.json"
+    &$nuget push "$tmpDir\output\Hazelcast.Net.Win32.$version.nupkg" -ApiKey $nugetApiKey -Source "https://api.nuget.org/v3/index.json"
 }
 
 Write-Output ""

--- a/src/Hazelcast.Net.Win32/Hazelcast.Net.Win32.csproj
+++ b/src/Hazelcast.Net.Win32/Hazelcast.Net.Win32.csproj
@@ -5,6 +5,14 @@
     <RootNamespace>Hazelcast</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>Open-source Win32 / Kerberos extensions for Hazelcast, the open-source in-memory distributed computing platform.</Description>
+    <PackageProjectUrl>https://hazelcast.github.io/hazelcast-csharp-client/</PackageProjectUrl>
+    <PackageTags>hazelcast cache clustering scalabilty distributed caching win32 kerberos</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageIcon>nuget-logo.png</PackageIcon>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(ASSEMBLY_SIGNING)'=='true'">
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
@@ -13,12 +21,41 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- repository -->
+    <RepositoryType>Git</RepositoryType>
+    <RepositoryUrl>https://github.com/hazelcast/hazelcast-csharp-client</RepositoryUrl>
+
+    <!-- repository url can be published to nuspec -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- specify the remote name, in case git config contains multiple remotes -->
+    <GitRepositoryRemoteName>hazelcast</GitRepositoryRemoteName>
+
+    <!-- build symbol package (snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <!-- embed source files that are not trakced by git -->
+    <!-- building generates some *.AssemblyInfo.cs files that we want to embed -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- ContinuousIntegrationBuild is set via a dotnet pack option -->
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Hazelcast.Net\Hazelcast.Net.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\nuget-logo.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Hazelcast.Net.Win32/Security/Win32/AuthIdentity.cs
+++ b/src/Hazelcast.Net.Win32/Security/Win32/AuthIdentity.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 namespace Hazelcast.Security.Win32
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct AuthIdentity
+    internal struct AuthIdentity
     {
         [MarshalAs(UnmanagedType.LPWStr)]
         public string User;

--- a/src/Hazelcast.Net.Win32/Security/Win32/CredentialHandle.cs
+++ b/src/Hazelcast.Net.Win32/Security/Win32/CredentialHandle.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 
 namespace Hazelcast.Security.Win32
 {
-    public abstract class Credential
+    internal abstract class Credential
     {
         protected const int SEC_WINNT_AUTH_IDENTITY_VERSION_2 = 0x201;
 

--- a/src/Hazelcast.Net.Win32/Security/Win32/Enums.cs
+++ b/src/Hazelcast.Net.Win32/Security/Win32/Enums.cs
@@ -23,7 +23,7 @@ using System;
 
 namespace Hazelcast.Security.Win32
 {
-    public enum ContextStatus
+    internal enum ContextStatus
     {
         RequiresContinuation,
         Accepted,
@@ -57,7 +57,7 @@ namespace Hazelcast.Security.Win32
         UnverifiedTargetName = 0x20000000
     }
 
-    public enum SecStatus : uint
+    internal enum SecStatus : uint
     {
         SEC_E_OK = 0x0,
         SEC_E_ERROR = 0x80000000,
@@ -86,7 +86,7 @@ namespace Hazelcast.Security.Win32
         SEC_I_RENEGOTIATE = 0x00090321
     }
 
-    public enum SecurityContextAttribute
+    internal enum SecurityContextAttribute
     {
         SECPKG_ATTR_SIZES = 0,
         SECPKG_ATTR_NAMES = 1,

--- a/src/Hazelcast.Net.Win32/Security/Win32/SspiContext.cs
+++ b/src/Hazelcast.Net.Win32/Security/Win32/SspiContext.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 
 namespace Hazelcast.Security.Win32
 {
-    public class SspiContext : IDisposable
+    internal class SspiContext : IDisposable
     {
         private readonly string spn;
 

--- a/src/Hazelcast.Net.Win32/Security/Win32/SuppliedCredential.cs
+++ b/src/Hazelcast.Net.Win32/Security/Win32/SuppliedCredential.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 
 namespace Hazelcast.Security.Win32
 {
-    public class SuppliedCredential : Credential
+    internal class SuppliedCredential : Credential
     {
         private readonly AuthIdentity _auth;
 


### PR DESCRIPTION
As part of the main build, now build and publish the Hazelcast.Net.Win32 NuGet package.
This package is required for people to use Kerberos with our client, without building the DLL themselves.