### PR TITLE
Fix hz script with UseBasicParsing

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -499,6 +499,12 @@ function invokeWebRequest($url, $dest) {
         $args.OutFile = $dest
         $args.PassThru = $true
     }
+    
+    # "Indicates that the cmdlet uses the response object for HTML content without Document
+    # Object Model (DOM) parsing. This parameter is required when Internet Explorer is not
+    # installed on the computers, such as on a Server Core installation of a Windows Server
+    # operating system."
+    $args.UseBasicParsing = $true
 
     $pp = $progressPreference
     $progressPreference = 'SilentlyContinue'

--- a/hz.ps1
+++ b/hz.ps1
@@ -504,7 +504,12 @@ function invokeWebRequest($url, $dest) {
     # Object Model (DOM) parsing. This parameter is required when Internet Explorer is not
     # installed on the computers, such as on a Server Core installation of a Windows Server
     # operating system."
-    $args.UseBasicParsing = $true
+    #
+    # "This parameter has been deprecated. Beginning with PowerShell 6.0.0, all Web requests
+    # use basic parsing only. This parameter is included for backwards compatibility only 
+    # and any use of it has no effect on the operation of the cmdlet."
+    #
+    $args.UseBasicParsing = $true # PS 5 requires this
 
     $pp = $progressPreference
     $progressPreference = 'SilentlyContinue'


### PR DESCRIPTION
Web requests initiated by the hz script should use the `UseBasicParsing` as per [this documentation page](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest) - the parameter is obsolete for PS 7+, but required for PS 5 in some environments where IE is not available. Otherwise, the build may fail in these environments.