### PR TITLE
Cleanup load-balancing

### DIFF
--- a/src/Hazelcast.Net.Tests/Clustering/LoadBalancingTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/LoadBalancingTests.cs
@@ -33,7 +33,7 @@ namespace Hazelcast.Tests.Clustering
                 Assert.That(lb.GetMember(), Is.EqualTo(memberId));
 
             // no effect
-            lb.NotifyMembers(new[] { Guid.NewGuid() });
+            lb.SetMembers(new[] { Guid.NewGuid() });
 
             Assert.That(lb.Count, Is.EqualTo(1));
             for (var i = 0; i < 4; i++)
@@ -57,7 +57,7 @@ namespace Hazelcast.Tests.Clustering
             Assert.That(lb.Count, Is.EqualTo(0));
             Assert.Throws<InvalidOperationException>(() => lb.GetMember());
 
-            lb.NotifyMembers(memberIds);
+            lb.SetMembers(memberIds);
             Assert.That(lb.Count, Is.EqualTo(3));
 
             var seen = Guid.Empty;
@@ -75,7 +75,7 @@ namespace Hazelcast.Tests.Clustering
 
             memberIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
 
-            lb.NotifyMembers(memberIds);
+            lb.SetMembers(memberIds);
             Assert.That(lb.Count, Is.EqualTo(2));
 
             for (var i = 0; i < 10; i++)
@@ -84,7 +84,7 @@ namespace Hazelcast.Tests.Clustering
                 Assert.That(memberIds, Does.Contain(memberId));
             }
 
-            lb.NotifyMembers(new Guid[0]);
+            lb.SetMembers(new Guid[0]);
             Assert.That(lb.Count, Is.EqualTo(0));
             Assert.Throws<InvalidOperationException>(() => lb.GetMember());
         }
@@ -98,7 +98,7 @@ namespace Hazelcast.Tests.Clustering
             Assert.That(lb.Count, Is.EqualTo(0));
             Assert.Throws<InvalidOperationException>(() => lb.GetMember());
 
-            lb.NotifyMembers(memberIds);
+            lb.SetMembers(memberIds);
             Assert.That(lb.Count, Is.EqualTo(3));
 
             Assert.That(lb.GetMember(), Is.EqualTo(memberIds[1]));
@@ -110,7 +110,7 @@ namespace Hazelcast.Tests.Clustering
 
             memberIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
 
-            lb.NotifyMembers(memberIds);
+            lb.SetMembers(memberIds);
             Assert.That(lb.Count, Is.EqualTo(2));
 
             Assert.That(lb.GetMember(), Is.EqualTo(memberIds[1]));
@@ -118,7 +118,7 @@ namespace Hazelcast.Tests.Clustering
             Assert.That(lb.GetMember(), Is.EqualTo(memberIds[1]));
             Assert.That(lb.GetMember(), Is.EqualTo(memberIds[0]));
 
-            lb.NotifyMembers(new Guid[0]);
+            lb.SetMembers(new Guid[0]);
             Assert.That(lb.Count, Is.EqualTo(0));
             Assert.Throws<InvalidOperationException>(() => lb.GetMember());
         }
@@ -126,7 +126,7 @@ namespace Hazelcast.Tests.Clustering
         [Test]
         public void ArgumentExceptions()
         {
-            Assert.Throws<ArgumentNullException>(() => new RoundRobinLoadBalancer().NotifyMembers(null));
+            Assert.Throws<ArgumentNullException>(() => new RoundRobinLoadBalancer().SetMembers(null));
         }
     }
 }

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -158,7 +158,7 @@ namespace Hazelcast.Clustering
             _memberTable = table;
 
             // notify the load balancer of the new list of members
-            _loadBalancer.NotifyMembers(members.Select(x => x.Id));
+            _loadBalancer.SetMembers(members.Select(x => x.Id));
 
             // signal once
             if (Interlocked.CompareExchange(ref _firstMembersViewed, 1, 0) == 0)

--- a/src/Hazelcast.Net/Clustering/LoadBalancing/ILoadBalancer.cs
+++ b/src/Hazelcast.Net/Clustering/LoadBalancing/ILoadBalancer.cs
@@ -30,16 +30,16 @@ namespace Hazelcast.Clustering.LoadBalancing
         /// <summary>
         /// Selects a member.
         /// </summary>
-        /// <returns>The unique identifier of the selected member.</returns>
+        /// <returns>The unique identifier of the selected member, if any; otherwise <c>Guid.Empty</c>.</returns>
         Guid GetMember();
 
         /// <summary>
-        /// Notifies the load balancer of a new set of members.
+        /// Sets the members.
         /// </summary>
         /// <param name="memberIds">The identifiers of the members.</param>
         /// <remarks>
-        /// <para>The new set of members fully replace existing members.</para>
+        /// <para>The set of members that fully replaces the existing members.</para>
         /// </remarks>
-        void NotifyMembers(IEnumerable<Guid> memberIds);
+        void SetMembers(IEnumerable<Guid> memberIds);
     }
 }

--- a/src/Hazelcast.Net/Clustering/LoadBalancing/LoadBalancerBase.cs
+++ b/src/Hazelcast.Net/Clustering/LoadBalancing/LoadBalancerBase.cs
@@ -34,7 +34,7 @@ namespace Hazelcast.Clustering.LoadBalancing
         public abstract Guid GetMember();
 
         /// <inheritdoc />
-        public virtual void NotifyMembers(IEnumerable<Guid> memberIds)
+        public virtual void SetMembers(IEnumerable<Guid> memberIds)
         {
             if (memberIds == null) throw new ArgumentNullException(nameof(memberIds));
 
@@ -44,19 +44,6 @@ namespace Hazelcast.Clustering.LoadBalancing
                 if (distinct.Add(memberId))
                     members.Add(memberId);
             Members = members; // atomic reference
-        }
-
-        /// <summary>
-        /// Gets a non-empty (else throws) snapshot of members.
-        /// </summary>
-        protected List<Guid> GetMembersNonEmptySnapshot()
-        {
-            var members = Members; // capture
-
-            if ((members?.Count ?? 0) == 0)
-                throw new InvalidOperationException("The load balancer does not have members.");
-
-            return members;
         }
     }
 }

--- a/src/Hazelcast.Net/Clustering/LoadBalancing/RandomLoadBalancer.cs
+++ b/src/Hazelcast.Net/Clustering/LoadBalancing/RandomLoadBalancer.cs
@@ -34,7 +34,8 @@ namespace Hazelcast.Clustering.LoadBalancing
         /// <inheritdoc />
         public override Guid GetMember()
         {
-            var members = GetMembersNonEmptySnapshot();
+            var members = Members;
+            if (members == null || members.Count == 0) return default;
             return members[RandomProvider.Random.Next(members.Count)];
         }
     }

--- a/src/Hazelcast.Net/Clustering/LoadBalancing/RoundRobinLoadBalancer.cs
+++ b/src/Hazelcast.Net/Clustering/LoadBalancing/RoundRobinLoadBalancer.cs
@@ -36,7 +36,8 @@ namespace Hazelcast.Clustering.LoadBalancing
         /// <inheritdoc />
         public override Guid GetMember()
         {
-            var members = GetMembersNonEmptySnapshot();
+            var members = Members;
+            if (members == null || members.Count == 0) return default;
             var index = Interlocked.Increment(ref _index);
             return members[index % members.Count];
         }

--- a/src/Hazelcast.Net/Clustering/LoadBalancing/StaticLoadBalancer.cs
+++ b/src/Hazelcast.Net/Clustering/LoadBalancing/StaticLoadBalancer.cs
@@ -54,7 +54,7 @@ namespace Hazelcast.Clustering.LoadBalancing
             => _memberId;
 
         /// <inheritdoc />
-        public override void NotifyMembers(IEnumerable<Guid> memberIds)
+        public override void SetMembers(IEnumerable<Guid> memberIds)
         { }
     }
 }


### PR DESCRIPTION
After: #448
Misc. cleanup of the load-balancing code. Only internals, no functional changes.