### PR TITLE
Code Analysis and Quality

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -29,14 +29,14 @@
 
     <!-- non-Windows does not build for Framework and does not need this, Windows does -->
     <!-- version is detected by hz.ps1 automatically from this project file -->
-    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2020.2.3" Condition=" '$(OS)' == 'Windows_NT' ">
+    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2021.1.2" Condition=" '$(OS)' == 'Windows_NT' ">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- all platforms need this, but it is not compatible with net462, hence the condition -->
     <!-- BEWARE, version must align with Hazelcast.Net.Tests csproj! -->
-    <PackageReference Include="JetBrains.dotCover.DotNetCliTool" Version="2020.2.3" Condition=" '$(TargetFramework)' != 'net462' ">
+    <PackageReference Include="JetBrains.dotCover.DotNetCliTool" Version="2021.1.2" Condition=" '$(TargetFramework)' != 'net462' ">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Hazelcast.Net.Testing/Logging/TestingLogger.cs
+++ b/src/Hazelcast.Net.Testing/Logging/TestingLogger.cs
@@ -158,23 +158,17 @@ namespace Hazelcast.Testing.Logging
 
         private static string GetLogLevelString(LogLevel logLevel)
         {
-            switch (logLevel)
+            return logLevel switch
             {
-                case LogLevel.Trace:
-                    return "trce";
-                case LogLevel.Debug:
-                    return "dbug";
-                case LogLevel.Information:
-                    return "info";
-                case LogLevel.Warning:
-                    return "warn";
-                case LogLevel.Error:
-                    return "fail";
-                case LogLevel.Critical:
-                    return "crit";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(logLevel));
-            }
+                LogLevel.Trace => "trce",
+                LogLevel.Debug => "dbug",
+                LogLevel.Information => "info",
+                LogLevel.Warning => "warn",
+                LogLevel.Error => "fail",
+                LogLevel.Critical => "crit",
+                LogLevel.None => "----",
+                _ => throw new ArgumentOutOfRangeException(nameof(logLevel))
+            };
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/Clustering/MemberConnectionTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberConnectionTests.cs
@@ -105,8 +105,6 @@ namespace Hazelcast.Tests.Clustering
             // send async without a timeout uses the timeout in messagingOptions.RetryTimeoutSeconds
             // in order to determine whether to retry again and again
 
-            var token = new CancellationToken();
-
             var message = ClientPingServerCodec.EncodeRequest();
 
             // SendAsync prepares the message

--- a/src/Hazelcast.Net.Tests/Configuration/HazelcastOptionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Configuration/HazelcastOptionsTests.cs
@@ -17,7 +17,6 @@ using System.IO;
 using System.Linq;
 using System.Security.Authentication;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using ExpectedObjects;
 using Hazelcast.Clustering;
@@ -41,9 +40,8 @@ namespace Hazelcast.Tests.Configuration
         [Test]
         public void BuildExceptions()
         {
-            Action<IConfigurationBuilder> setup = null;
-            Assert.Throws<ArgumentNullException>(() => HazelcastOptions.Build(setup));
-            Assert.Throws<ArgumentNullException>(() => HazelcastOptions.Build(setup, null, "key"));
+            Assert.Throws<ArgumentNullException>(() => HazelcastOptions.Build((Action<IConfigurationBuilder>) null));
+            Assert.Throws<ArgumentNullException>(() => HazelcastOptions.Build(null, null, "key"));
         }
 
         [Test]
@@ -104,7 +102,7 @@ namespace Hazelcast.Tests.Configuration
         }
 
         [Test]
-        public async Task HazelcastOptionsRoot()
+        public void HazelcastOptionsRoot()
         {
             var options = ReadResource(Resources.HazelcastOptions);
 
@@ -183,8 +181,15 @@ namespace Hazelcast.Tests.Configuration
             Assert.AreEqual(SslProtocols.Tls11, sslOptions.Protocol);
             Console.WriteLine(sslOptions.ToString());
 
+#if NETCOREAPP
+#pragma warning disable CS0618 // Type or member is obsolete
+#endif
+            // testing obsolete Ssl2, Default protocols
             Assert.Throws<ConfigurationException>(() => sslOptions.Protocol = SslProtocols.Ssl2);
             Assert.Throws<ConfigurationException>(() => sslOptions.Protocol = SslProtocols.Default);
+#if NETCOREAPP
+#pragma warning restore CS0618
+#endif
 
             var cloudOptions = options.Cloud;
             Assert.IsTrue(cloudOptions.Enabled);

--- a/src/Hazelcast.Net.Tests/DotNet/DotNetTests.cs
+++ b/src/Hazelcast.Net.Tests/DotNet/DotNetTests.cs
@@ -25,5 +25,19 @@ namespace Hazelcast.Tests.DotNet
         {
             Assert.AreEqual(TimeSpan.Zero, default(TimeSpan));
         }
+
+        [Test]
+        public void ParamsArgs()
+        {
+            ParamsArgsMethod(false);
+            ParamsArgsMethod(false, "a", "b");
+            ParamsArgsMethod(false, (string)null);
+            ParamsArgsMethod(true, null);
+        }
+
+        private static void ParamsArgsMethod(bool isnull, params object[] objects)
+        {
+            Assert.That(objects, isnull ? Is.Null : Is.Not.Null);
+        }
     }
 }

--- a/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
+++ b/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <!-- BEWARE, version must align with build/build.proj! -->
-    <DotNetCliToolReference Include="JetBrains.dotCover.DotNetCliTool" Version="2020.2.3" />
+    <DotNetCliToolReference Include="JetBrains.dotCover.DotNetCliTool" Version="2021.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hazelcast.Net.Tests/Networking/SocketConnectionTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/SocketConnectionTests.cs
@@ -328,7 +328,6 @@ namespace Hazelcast.Tests.Networking
             //using var _ = EnableHConsoleForTest();
 
             var pipe = new MemoryPipe();
-            var count = 0L;
             var down = 0;
 
             var s = new TestSocketConnection(pipe.Stream1)
@@ -357,7 +356,6 @@ namespace Hazelcast.Tests.Networking
             //using var _ = EnableHConsoleForTest();
 
             var pipe = new MemoryPipe();
-            var count = 0L;
             var down = 0;
 
             TestSocketConnection s = null;

--- a/src/Hazelcast.Net.Tests/Serialization/PortableTest.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/PortableTest.cs
@@ -64,16 +64,14 @@ namespace Hazelcast.Tests.Serialization
 
         private class Child : IPortable
         {
-            private string name;
+            private string _name;
 
             public Child()
-            {
-
-            }
+            { }
 
             public Child(string name)
             {
-                this.name = name;
+                _name = name;
             }
 
             public int ClassId => 2;
@@ -82,43 +80,42 @@ namespace Hazelcast.Tests.Serialization
 
             public void ReadPortable(IPortableReader reader)
             {
-                name = reader.ReadString("name");
+                _name = reader.ReadString("name");
             }
 
             public void WritePortable(IPortableWriter writer)
             {
-                writer.WriteString("name", name);
+                writer.WriteString("name", _name);
             }
 
             public override bool Equals(object obj)
             {
-                if(ReferenceEquals(this, obj))
-                {
+                if (ReferenceEquals(this, obj))
                     return true;
-                }
 
-                if (obj == null || !GetType().Equals(obj.GetType()))
-                {
+                if (!(obj is Child child))
                     return false;
-                }
 
-                Child child = (Child)obj;
-                return name != null ? name.Equals(child.name) : child.name == null;
+                return _name == child._name;
+            }
+
+            public override int GetHashCode()
+            {
+                // ReSharper disable once NonReadonlyMemberInGetHashCode
+                return _name.GetHashCode();
             }
         }
 
         private class Parent : IPortable
         {
-            private Child child;
+            private Child _child;
 
             public Parent()
-            {
-
-            }
+            { }
 
             public Parent(Child child)
             {
-                this.child = child;
+                _child = child;
             }
 
             public int ClassId => 1;
@@ -127,25 +124,29 @@ namespace Hazelcast.Tests.Serialization
 
             public void ReadPortable(IPortableReader reader)
             {
-                child = reader.ReadPortable<Child>("child");
+                _child = reader.ReadPortable<Child>("child");
             }
 
             public void WritePortable(IPortableWriter writer)
             {
-                writer.WritePortable("child", child);
+                writer.WritePortable("child", _child);
             }
 
             public override bool Equals(object obj)
             {
-                if(ReferenceEquals(this, obj))
-                {
+                if (ReferenceEquals(this, obj))
                     return true;
-                }
-                if(obj == null || !GetType().Equals(obj.GetType())){
+
+                if (!(obj is Parent parent))
                     return false;
-                }
-                Parent parent = (Parent)obj;
-                return child != null ? child.Equals(parent.child) : parent.child == null;
+
+                return _child.Equals(parent._child);
+            }
+
+            public override int GetHashCode()
+            {
+                // ReSharper disable once NonReadonlyMemberInGetHashCode
+                return _child.GetHashCode();
             }
         }
     }

--- a/src/Hazelcast.Net/Clustering/Authenticator.cs
+++ b/src/Hazelcast.Net/Clustering/Authenticator.cs
@@ -127,7 +127,7 @@ namespace Hazelcast.Clustering
             cancellationToken.ThrowIfCancellationRequested();
 
             HConsole.WriteLine(this, "Send auth request");
-            var responseMessage = await client.SendAsync(requestMessage, cancellationToken).CfAwait();
+            var responseMessage = await client.SendAsync(requestMessage).CfAwait();
             HConsole.WriteLine(this, "Rcvd auth response");
             var response = ClientAuthenticationCodec.DecodeResponse(responseMessage);
             HConsole.WriteLine(this, "Auth response is: " + (AuthenticationStatus) response.Status);

--- a/src/Hazelcast.Net/Clustering/Cluster.cs
+++ b/src/Hazelcast.Net/Clustering/Cluster.cs
@@ -179,12 +179,12 @@ namespace Hazelcast.Clustering
         public async Task ConnectAsync(CancellationToken cancellationToken)
         {
             // change state to Starting if it is zero aka New
-            var changed = await State.ChangeStateAndWait(ClientState.Starting, 0 /* ClientState.New */);
+            var changed = await State.ChangeStateAndWait(ClientState.Starting, 0 /* ClientState.New */).CfAwait();
             if (!changed)
                 throw new ConnectionException("Failed to connected (aborted).");
 
             // connect
-            await Connections.ConnectAsync(cancellationToken);
+            await Connections.ConnectAsync(cancellationToken).CfAwait();
         }
 
         /// <inheritdoc />

--- a/src/Hazelcast.Net/Clustering/ClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterEvents.cs
@@ -361,7 +361,7 @@ namespace Hazelcast.Clustering
 
                 // remove from the server
                 // and, if it fails, enqueue for collection
-                if (await RemoveSubscriptionAsync(memberSubscription, cancellationToken))
+                if (await RemoveSubscriptionAsync(memberSubscription, cancellationToken).CfAwait())
                     subscription.Remove(memberSubscription);
                 else
                     CollectSubscription(memberSubscription);
@@ -765,7 +765,12 @@ namespace Hazelcast.Clustering
         /// <summary>
         /// Handles a connection being opened.
         /// </summary>
+#pragma warning disable IDE0060 // Remove unused parameters
+#pragma warning disable CA1801 // Review unused parameters
+        // unused parameters are required, this is an event handler
         public ValueTask OnConnectionOpened(MemberConnection connection, bool isFirstEver, bool isFirst, bool isNewCluster)
+#pragma warning restore CA1801
+#pragma warning restore IDE0060
         {
             // atomically add the connection and capture known subscriptions
             List<ClusterSubscription> subscriptions;

--- a/src/Hazelcast.Net/Clustering/ClusterInstrumentation.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterInstrumentation.cs
@@ -30,9 +30,9 @@ namespace Hazelcast.Clustering
 
         public int ExceptionsInEventHandlersCount => _exceptionsInEventHandlersCount;
 
-// work-in-progress, not using all parameters for now
-#pragma warning disable CA1801 // Review unused parameters
+        // work-in-progress, not using all parameters for now
 #pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable CA1801 // Review unused parameters
 
         internal void CountMissedEvent(ClientMessage message)
             => Interlocked.Increment(ref _missedEventsCount);

--- a/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
@@ -207,9 +207,9 @@ namespace Hazelcast.Clustering
             message.Flags |= ClientMessageFlags.BeginFragment | ClientMessageFlags.EndFragment;
 
             // create the invocation
-            using var invocation = connection != null ? new Invocation(message, _clusterState.Options.Messaging, connection) :
-                                   targetPartitionId >= 0 ? new Invocation(message, _clusterState.Options.Messaging, targetPartitionId) :
-                                   targetMemberId != default ? new Invocation(message, _clusterState.Options.Messaging, targetMemberId) :
+            var invocation = connection != null ? new Invocation(message, _clusterState.Options.Messaging, connection) :
+                             targetPartitionId >= 0 ? new Invocation(message, _clusterState.Options.Messaging, targetPartitionId) :
+                             targetMemberId != default ? new Invocation(message, _clusterState.Options.Messaging, targetMemberId) :
                                    new Invocation(message, _clusterState.Options.Messaging);
 
             return await SendAsyncInternal(invocation, cancellationToken).CfAwait();

--- a/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
+++ b/src/Hazelcast.Net/Clustering/DistributedEventScheduler.cs
@@ -183,7 +183,7 @@ namespace Hazelcast.Clustering
                     }
                 }
 
-                await Handle(eventData); // does not throw
+                await Handle(eventData).CfAwait(); // does not throw
             }
         }
 

--- a/src/Hazelcast.Net/Clustering/Invocation.cs
+++ b/src/Hazelcast.Net/Clustering/Invocation.cs
@@ -28,7 +28,7 @@ namespace Hazelcast.Clustering
     /// <summary>
     /// Represents an ongoing server invocation.
     /// </summary>
-    internal class Invocation : IDisposable
+    internal class Invocation
     {
         private readonly MessagingOptions _messagingOptions;
 
@@ -254,9 +254,5 @@ namespace Hazelcast.Clustering
             // with messages
             _completionSource = new TaskCompletionSource<ClientMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
-
-        /// <inheritdoc />
-        public void Dispose()
-        { }
     }
 }

--- a/src/Hazelcast.Net/Clustering/LoadBalancing/LoadBalancerBase.cs
+++ b/src/Hazelcast.Net/Clustering/LoadBalancing/LoadBalancerBase.cs
@@ -25,7 +25,10 @@ namespace Hazelcast.Clustering.LoadBalancing
         /// <summary>
         /// Gets the members.
         /// </summary>
+        // TODO: this should be a ReadOnlyCollection<Guid> (breaking)
+#pragma warning disable CA1002 // Do not expose generic lists
         protected List<Guid> Members { get; private set; }
+#pragma warning restore CA1002
 
         /// <inheritdoc />
         public virtual int Count => Members?.Count ?? 0;

--- a/src/Hazelcast.Net/Clustering/LoadBalancing/RandomLoadBalancer.cs
+++ b/src/Hazelcast.Net/Clustering/LoadBalancing/RandomLoadBalancer.cs
@@ -36,7 +36,7 @@ namespace Hazelcast.Clustering.LoadBalancing
         {
             var members = Members;
             if (members == null || members.Count == 0) return default;
-            return members[RandomProvider.Random.Next(members.Count)];
+            return members[RandomProvider.Next(members.Count)];
         }
     }
 }

--- a/src/Hazelcast.Net/Clustering/RetryStrategy.cs
+++ b/src/Hazelcast.Net/Clustering/RetryStrategy.cs
@@ -67,7 +67,9 @@ namespace Hazelcast.Clustering
         public RetryStrategy(string action, int initialBackOffMilliseconds, int maxBackOffMilliseconds, double multiplier, long timeoutMilliseconds, double jitter, ILoggerFactory loggerFactory)
         {
             if (string.IsNullOrWhiteSpace(action)) throw new ArgumentException(ExceptionMessages.NullOrEmpty, nameof(action));
+#pragma warning disable CA1308 // Normalize strings to uppercase - not normalizing, just lower-casing for display
             _action = action.ToLowerInvariant();
+#pragma warning restore CA1308
             _initialBackOffMilliseconds = initialBackOffMilliseconds;
             _maxBackOffMilliseconds = maxBackOffMilliseconds;
             _multiplier = multiplier;
@@ -94,7 +96,7 @@ namespace Hazelcast.Clustering
                 return false;
             }
 
-            var delay = (int) (_currentBackOffMilliseconds * (1 - _jitter * (1 - RandomProvider.Random.NextDouble())));
+            var delay = (int) (_currentBackOffMilliseconds * (1 - _jitter * (1 - RandomProvider.NextDouble())));
             delay = Math.Min(delay, Math.Max(0, (int) (_timeoutMilliseconds - elapsed)));
 
             _logger.LogDebug($"Unable to {_action} after {_attempts} attempts and {elapsed}ms, will retry in {delay}ms");

--- a/src/Hazelcast.Net/Clustering/StateChangeQueue.cs
+++ b/src/Hazelcast.Net/Clustering/StateChangeQueue.cs
@@ -93,7 +93,7 @@ namespace Hazelcast.Clustering
             var completion = new TaskCompletionSource<object>();
             do
             {
-                marker = -RandomProvider.Random.Next();
+                marker = -RandomProvider.Next();
             } while (marker < 0 && !_markers.TryAdd(marker, completion));
 
             // queue the state
@@ -162,6 +162,8 @@ namespace Hazelcast.Clustering
 
             // wait until the events queue is drained
             await _raising.CfAwait();
+
+            await _states.DisposeAsync().CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/Clustering/TerminateConnections.cs
+++ b/src/Hazelcast.Net/Clustering/TerminateConnections.cs
@@ -88,6 +88,8 @@ namespace Hazelcast.Clustering
             _cancel.Cancel();
             await _terminating.CfAwaitCanceled();
             _cancel.Dispose();
+
+            await _connections.DisposeAsync().CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/CodeAnalysisSuppressions.cs
+++ b/src/Hazelcast.Net/CodeAnalysisSuppressions.cs
@@ -14,11 +14,14 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-#if CODE_ANALYSIS
-
-// this file contains assembly-level SuppressMessage attributes for NDepend,
+// this file contains assembly-level suppression directives for NDepend,
 // they will be compiled into the assembly only if CODE_ANALYSIS is defined
 // and should not be compiled into the final Release version that ships.
+//
+// this file also contains assembly-level suppression directives for the
+// compiler (to deal with some warnings) that are always compiled.
+
+#if CODE_ANALYSIS
 
 // scope can be: deep module namespace type method field
 // and also: namespaceAndDescendants
@@ -58,7 +61,7 @@ using System.Diagnostics.CodeAnalysis;
 // Unfortunately, NDepend uses e.g. 'method' scope which is not OK
 #pragma warning disable IDE0076 // Invalid global 'SuppressMessageAttribute'
 
-#region General
+#region NDepend / General
 
 // NDepend complains about 'public' methods in an 'internal' class
 // but even NDepend documentation mentions that not everyone agrees
@@ -70,7 +73,7 @@ using System.Diagnostics.CodeAnalysis;
 
 #endregion
 
-#region Accepted Checks
+#region NDepend / Accepted Checks
 
 // We use System.Random in our RandomProvider and don't expect it
 // to be used for anything security-related, so, suppress
@@ -115,7 +118,7 @@ using System.Diagnostics.CodeAnalysis;
 
 #endregion
 
-#region Codecs
+#region NDepend / Codecs
 
 // TODO: we should use all codecs, or mark them individually
 // and so, we should not mark them all as "not dead code"
@@ -136,7 +139,7 @@ using System.Diagnostics.CodeAnalysis;
 
 #endregion
 
-#region Types Not Dead
+#region NDepend / Types Not Dead
 
 [assembly: SuppressMessage(NDepend.Category, NDepend.Check.PotentiallyDeadTypes,
     Target = "Hazelcast.AssemblySigning",
@@ -144,7 +147,7 @@ using System.Diagnostics.CodeAnalysis;
 
 #endregion
 
-#region System
+#region NDepend / System
 
 // suppress issues with our System.* extensions for dealing with netstandard versions
 // each namespace needs its rule
@@ -173,7 +176,7 @@ using System.Diagnostics.CodeAnalysis;
     Target = /*~N:*/ "System.Diagnostics.CodeAnalysis",
     Scope = "namespaceAndDescendants",
     Justification = NDepend.Justification.Accepted)]
-[assembly:SuppressMessage(NDepend.Category, "",
+[assembly: SuppressMessage(NDepend.Category, "",
     Target = /*~N:*/ "System.Runtime.CompilerServices",
     Scope = "namespaceAndDescendants",
     Justification = "Imported code.")]
@@ -190,6 +193,115 @@ using System.Diagnostics.CodeAnalysis;
 #endif
 
 #endregion
+
+#endif
+
+#region Accepted Checks
+
+[assembly: SuppressMessage("Security", "CA5394:Do not use insecure randomness",
+    //Scope = "all",
+    Justification = "Not used for security purposes.")]
+
+// TODO: all our event args should inherit from EventArgs (breaking)
+// (and, Target cannot contain wildcards)
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.Events.DistributedObjectCreatedEventArgs",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.Events.DistributedObjectDestroyedEventArgs",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.Events.MembersUpdatedEventArgs",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.Events.PartitionLostEventArgs",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.Events.DistributedObjectLifecycleEventArgs",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.CollectionItemEventArgs`1",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapClearedEventArgs",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEvictedEventArgs",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEntryEvictedEventArgs`2",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEntryAddedEventArgs`2",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEntryExpiredEventArgs`2",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEntryInvalidatedEventArgs`2",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEntryLoadedEventArgs`2",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEntryMergedEventArgs`2",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEntryRemovedEventArgs`2",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.MapEntryUpdatedEventArgs`2",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.TopicMessageEventArgs`1",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.StateChangedEventArgs",
+    Justification = Analysis.Justification.CA1711_EventArgs)]
+
+// nothing we can do about these
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.ITopicEventHandler`1",
+    Justification = Analysis.Justification.CA1711_EventHandler)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.IMapEventHandler`3",
+    Justification = Analysis.Justification.CA1711_EventHandler)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.IMapEntryEventHandler`3",
+    Justification = Analysis.Justification.CA1711_EventHandler)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.DistributedObjects.ICollectionItemEventHandler`1",
+    Justification = Analysis.Justification.CA1711_EventHandler)]
+[assembly: SuppressMessage(Analysis.Naming, Analysis.CA1711, Scope = Analysis.Scope.Type,
+    Target = "~T:Hazelcast.IHazelcastClientEventHandler",
+    Justification = Analysis.Justification.CA1711_EventHandler)]
+
+#endregion
+
+// ReSharper disable once CheckNamespace
+internal static class Analysis
+{
+    public const string Naming = "Naming";
+    public const string Style = "Style";
+
+    // ReSharper disable InconsistentNaming
+    public const string CA1711 = "CA1711:Identifiers should not have incorrect suffix";
+    public const string IDE0066 = "IDE0066:Convert switch statement to expression";
+    // ReSharper restore InconsistentNaming
+
+    public static class Scope
+    {
+        public const string Type = "type";
+    }
+
+    public static class Justification
+    {
+        // ReSharper disable InconsistentNaming
+        public const string CA1711_EventArgs = "Our event args should inherit from System.EventArgs but this is a breaking change";
+        public const string CA1711_EventHandler = "Our event handlers cannot be true event-handler delegates.";
+        // ReSharper restore InconsistentNaming
+    }
+}
 
 // ReSharper disable once CheckNamespace
 internal static class NDepend
@@ -221,5 +333,3 @@ internal static class NDepend
         public const string TypeNotDead = "Not dead.";
     }
 }
-
-#endif

--- a/src/Hazelcast.Net/Core/Attempt.cs
+++ b/src/Hazelcast.Net/Core/Attempt.cs
@@ -21,9 +21,7 @@ namespace Hazelcast.Core
     /// <summary>
     /// Creates instances of the <see cref="Attempt{TResult}"/> struct.
     /// </summary>
-#pragma warning disable CA1815 // Override equals and operator equals on value types - not meant to be compared
     internal readonly struct Attempt
-#pragma warning disable CA1815
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Attempt"/> struct.

--- a/src/Hazelcast.Net/Core/EnumerableExtensions.cs
+++ b/src/Hazelcast.Net/Core/EnumerableExtensions.cs
@@ -30,7 +30,7 @@ namespace Hazelcast.Core
         /// <param name="source">The original enumerable.</param>
         /// <returns>The original enumerable items, in random order.</returns>
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
-            => source.OrderBy(x => RandomProvider.Random.Next());
+            => source.OrderBy(x => RandomProvider.Next());
 
         /// <summary>
         /// Combine multiple <see cref="IEnumerable{T}"/> instances.

--- a/src/Hazelcast.Net/Core/HConsoleOptions.cs
+++ b/src/Hazelcast.Net/Core/HConsoleOptions.cs
@@ -13,7 +13,13 @@
 // limitations under the License.
 
 using System;
+
+#if HZ_CONSOLE
 using System.Collections.Generic;
+#else
+// ReSharper disable UnusedTypeParameter
+#pragma warning disable CA1801 // Review unused parameters
+#endif
 
 namespace Hazelcast.Core
 {
@@ -199,3 +205,5 @@ namespace Hazelcast.Core
 #endif
     }
 }
+
+#pragma warning restore CA1801 // Review unused parameters

--- a/src/Hazelcast.Net/Core/HConsoleTargetOptions.cs
+++ b/src/Hazelcast.Net/Core/HConsoleTargetOptions.cs
@@ -265,7 +265,7 @@ namespace Hazelcast.Core
             get
             {
 #if HZ_CONSOLE
-                var timestamp = TimeStampEnabled ? (DateTime.Now - TimeStampOrigin).ToString("hhmmss\\.fff\\ ") : "";
+                var timestamp = TimeStampEnabled ? (DateTime.Now - TimeStampOrigin).ToString("hhmmss\\.fff\\ ", CultureInfo.InvariantCulture) : "";
                 return $"{timestamp}{new string(' ', Indent)}[{Thread.CurrentThread.ManagedThreadId:00}] {Prefix}: ";
 #else
                 return "";

--- a/src/Hazelcast.Net/Core/RandomProvider.cs
+++ b/src/Hazelcast.Net/Core/RandomProvider.cs
@@ -35,6 +35,7 @@ namespace Hazelcast.Core
         private static readonly object GlobalLock = new object();
         private static readonly ThreadLocal<Random> ThreadRandom = new ThreadLocal<Random>(NewRandom);
 
+
         /// <summary>
         /// Creates a new random for a thread.
         /// </summary>
@@ -43,7 +44,9 @@ namespace Hazelcast.Core
         {
             // use GlobalRandom to get a random seed, using GlobalLock
             // because the Random class is not thread safe
+#pragma warning disable CA5394 // Do not use insecure randomness
             lock (GlobalLock) return new Random(GlobalRandom.Next());
+#pragma warning restore CA5394
         }
 
         /// <summary>
@@ -55,5 +58,56 @@ namespace Hazelcast.Core
         /// retrieve it each time it is required.</para>
         /// </remarks>
         public static Random Random => ThreadRandom.Value;
+
+        /// <summary>
+        /// Returns a non-negative random integer number (thread-safe, not appropriate for security purposes).
+        /// </summary>
+        /// <returns>A 32-bit signed integer that is greater than or equal to 0 and less than <see cref="int.MaxValue"/>.</returns>
+        /// <remarks>
+        /// <para>Using this method will not trigger a CA5394 "Do not use insecure randomness" warning,
+        /// yet this method should NOT be used for anything related to security.</para>
+        /// </remarks>
+#pragma warning disable CA5394 // Do not use insecure randomness
+        public static int Next() => Random.Next();
+#pragma warning restore CA5394
+
+        /// <summary>
+        /// Returns a non-negative random integer number that is less than the specified maximum (thread-safe, not appropriate for security purposes).
+        /// </summary>
+        /// <param name="maxValue">The exclusive upper bound of the random number to be generated.</param>
+        /// <returns>A 32-bit signed integer that is greater than or equal to 0 and less than <paramref name="maxValue"/>.</returns>
+        /// <remarks>
+        /// <para>Using this method will not trigger a CA5394 "Do not use insecure randomness" warning,
+        /// yet this method should NOT be used for anything related to security.</para>
+        /// </remarks>
+#pragma warning disable CA5394 // Do not use insecure randomness
+        public static int Next(int maxValue) => Random.Next(maxValue);
+#pragma warning restore CA5394
+
+        /// <summary>
+        /// Returns a non-negative random integer number that is within the specified range (thread-safe, not appropriate for security purposes).
+        /// </summary>
+        /// <param name="minValue">The non-negative, inclusive lower bound of the random number to be generated.</param>
+        /// <param name="maxValue">The exclusive upper bound of the random number to be generated.</param>
+        /// <returns>A 32-bit signed integer that is greater than or equal to <paramref name="minValue"/> and less than <paramref name="maxValue"/>.</returns>
+        /// <remarks>
+        /// <para>Using this method will not trigger a CA5394 "Do not use insecure randomness" warning,
+        /// yet this method should NOT be used for anything related to security.</para>
+        /// </remarks>
+#pragma warning disable CA5394 // Do not use insecure randomness
+        public static int Next(int minValue, int maxValue) => Random.Next(minValue, maxValue);
+#pragma warning restore CA5394
+
+        /// <summary>
+        /// Returns a random floating-point number that is greater than or equal to 0.0, and less than 1.0 (thread-safe, not appropriate for security purposes).
+        /// </summary>
+        /// <returns>A double-precision floating-point number that is greater than or equal to 0.0, and less than 1.0.</returns>
+        /// <remarks>
+        /// <para>Using this method will not trigger a CA5394 "Do not use insecure randomness" warning,
+        /// yet this method should NOT be used for anything related to security.</para>
+        /// </remarks>
+#pragma warning disable CA5394 // Do not use insecure randomness
+        public static double NextDouble() => Random.NextDouble();
+#pragma warning restore CA5394
     }
 }

--- a/src/Hazelcast.Net/Core/ServiceFactory.cs
+++ b/src/Hazelcast.Net/Core/ServiceFactory.cs
@@ -47,7 +47,10 @@ namespace Hazelcast.Core
         /// </remarks>
         public static T CreateInstance<T>(IDictionary<string, string> stringArgs = null, params object[] paramArgs)
         {
+#pragma warning disable CA1508 // Avoid dead conditional code
+            // false-positive, https://github.com/dotnet/roslyn-analyzers/issues/3845
             if (paramArgs == null) throw new ArgumentNullException(nameof(paramArgs));
+#pragma warning restore CA1508
 
             try
             {
@@ -76,7 +79,10 @@ namespace Hazelcast.Core
         public static T CreateInstance<T>(Type type, IDictionary<string, string> stringArgs = null, params object[] paramArgs)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
+#pragma warning disable CA1508 // Avoid dead conditional code
+            // false-positive, https://github.com/dotnet/roslyn-analyzers/issues/3845
             if (paramArgs == null) throw new ArgumentNullException(nameof(paramArgs));
+#pragma warning restore CA1508
 
             try
             {
@@ -105,7 +111,10 @@ namespace Hazelcast.Core
         public static T CreateInstance<T>(string typeName, IDictionary<string, string> stringArgs = null, params object[] paramArgs)
         {
             if (string.IsNullOrWhiteSpace(typeName)) throw new ArgumentException(ExceptionMessages.NullOrEmpty, nameof(typeName));
+#pragma warning disable CA1508 // Avoid dead conditional code
+            // false-positive, https://github.com/dotnet/roslyn-analyzers/issues/3845
             if (paramArgs == null) throw new ArgumentNullException(nameof(paramArgs));
+#pragma warning restore CA1508
 
             try
             {
@@ -133,7 +142,10 @@ namespace Hazelcast.Core
         public static object CreateInstance(Type type, IDictionary<string, string> stringArgs = null, params object[] paramArgs)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
+#pragma warning disable CA1508 // Avoid dead conditional code
+            // false-positive, https://github.com/dotnet/roslyn-analyzers/issues/3845
             if (paramArgs == null) throw new ArgumentNullException(nameof(paramArgs));
+#pragma warning restore CA1508
 
             try
             {
@@ -161,7 +173,10 @@ namespace Hazelcast.Core
         public static object CreateInstance(string typeName, IDictionary<string, string> stringArgs = null, params object[] paramArgs)
         {
             if (string.IsNullOrWhiteSpace(typeName)) throw new ArgumentException(ExceptionMessages.NullOrEmpty, nameof(typeName));
+#pragma warning disable CA1508 // Avoid dead conditional code
+            // false-positive, https://github.com/dotnet/roslyn-analyzers/issues/3845
             if (paramArgs == null) throw new ArgumentNullException(nameof(paramArgs));
+#pragma warning restore CA1508
 
             try
             {
@@ -173,22 +188,19 @@ namespace Hazelcast.Core
             }
         }
 
+
         /// <summary>
         /// (internal for tests only)
         /// Casts an object.
         /// </summary>
         internal static T As<T>(object o)
         {
-            // this would be nicer with a switch expression but dotCover (as of 2020.2.3) does no cover them
-            switch (o)
+            return o switch
             {
-                case T t:
-                    return t;
-                case null:
-                    throw new ArgumentNullException(nameof(o));
-                default:
-                    throw new InvalidCastException($"Failed to cast object of type {o.GetType()} to {typeof (T)}.");
-            }
+                T t => t,
+                null => throw new ArgumentNullException(nameof(o)),
+                _ => throw new InvalidCastException($"Failed to cast object of type {o.GetType()} to {typeof (T)}.")
+            };
         }
 
         private static Type GetType(string typeName)
@@ -206,9 +218,12 @@ namespace Hazelcast.Core
         internal static object CreateInstanceInternal(Type type, IDictionary<string, string> stringArgs, params object[] paramArgs)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
+#pragma warning disable CA1508 // Avoid dead conditional code
+            // false-positive, https://github.com/dotnet/roslyn-analyzers/issues/3845
             if (paramArgs == null) throw new ArgumentNullException(nameof(paramArgs));
+#pragma warning restore CA1508
 
-            // fast: use the empty ctor if no args (will throw if it does not exist)
+                // fast: use the empty ctor if no args (will throw if it does not exist)
             if ((stringArgs == null || stringArgs.Count == 0) && paramArgs.Length == 0)
                 return Activator.CreateInstance(type);
 

--- a/src/Hazelcast.Net/Core/TaskCoreExtensions.cs
+++ b/src/Hazelcast.Net/Core/TaskCoreExtensions.cs
@@ -238,7 +238,7 @@ namespace Hazelcast.Core
         {
             if (timeoutMilliseconds < 0)
             {
-                await task;
+                await task.ConfigureAwait(false);
                 return;
             }
 
@@ -277,7 +277,7 @@ namespace Hazelcast.Core
         {
             if (timeoutMilliseconds < 0)
             {
-                return await task;
+                return await task.ConfigureAwait(false);
             }
 
             using var delayCancel = new CancellationTokenSource();
@@ -317,8 +317,10 @@ namespace Hazelcast.Core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ObserveException([NotNull] this Task task)
 #pragma warning disable CS4014 // Because this call is not awaited...
+#pragma warning disable CA2012 // Use ValueTasks correctly - no we don't
             => ObserveExceptionInternal(task);
 #pragma warning restore CS4014
+#pragma warning restore CA2012
 
         // this indirect method will end up inlined, and exists only to
         // prevent CS4014 to pop on the code calling ObserveException

--- a/src/Hazelcast.Net/Core/TypeExtensions.cs
+++ b/src/Hazelcast.Net/Core/TypeExtensions.cs
@@ -65,7 +65,7 @@ namespace Hazelcast.Core
             if (!fqn)
             {
                 var pos = name.LastIndexOf('.');
-                if (pos >= 0) name = name.Substring(pos + 1);
+                if (pos >= 0) name = name[(pos + 1)..];
             }
             return name.Replace('+', '.');
         }

--- a/src/Hazelcast.Net/DistributedObjects/CollectionItemEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/CollectionItemEventArgs.cs
@@ -21,7 +21,9 @@ namespace Hazelcast.DistributedObjects
     /// Represents event data for the <see cref="CollectionItemEventTypes"/> events.
     /// </summary>
     /// <typeparam name="T">The topic object type.</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class CollectionItemEventArgs<T> : EventArgsBase
+#pragma warning restore CA1711 
     {
         private readonly Lazy<T> _item;
 

--- a/src/Hazelcast.Net/DistributedObjects/ICollectionItemEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/ICollectionItemEventHandler.cs
@@ -22,7 +22,9 @@ namespace Hazelcast.DistributedObjects
     /// Specifies a collection item event handler.
     /// </summary>
     /// <typeparam name="T">The collection items type.</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public interface ICollectionItemEventHandler<T>
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Gets the handled event type.

--- a/src/Hazelcast.Net/DistributedObjects/IHCollection.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHCollection.cs
@@ -28,7 +28,9 @@ namespace Hazelcast.DistributedObjects
     /// </para>
     /// </remarks>
     /// <typeparam name="T">The type of the items in the collection</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - that *is* a collection
     public interface IHCollection<T> : IDistributedObject, IAsyncEnumerable<T>
+#pragma warning restore CA1711
     {
         //setting
 

--- a/src/Hazelcast.Net/DistributedObjects/IHList.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHList.cs
@@ -64,7 +64,9 @@ namespace Hazelcast.DistributedObjects
         /// <param name="index">index index of the element to replace</param>
         /// <param name="item">element to be stored at the specified position</param>
         /// <returns>The element previously at the specified position</returns>
+#pragma warning disable CA1716 // Identifiers should not match keywords - here, yes
         Task<T> Set(int index, T item);
+#pragma warning restore CA1716
 
         //Getting
 

--- a/src/Hazelcast.Net/DistributedObjects/IHQueue.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHQueue.cs
@@ -28,7 +28,9 @@ namespace Hazelcast.DistributedObjects
     /// will not scale by adding more members to the cluster.
     /// </para>
     /// </remarks>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - that *is* a queue
     public interface IHQueue<T> : IHCollection<T>
+#pragma warning restore CA1711
     {
         // setting
 

--- a/src/Hazelcast.Net/DistributedObjects/IHTxQueue.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IHTxQueue.cs
@@ -18,7 +18,9 @@ using System.Threading.Tasks;
 namespace Hazelcast.DistributedObjects
 {
     /// <summary>Transactional implementation of Queue</summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - that *is* a queue
     public interface IHTxQueue<TItem> : ITransactionalObject
+#pragma warning restore CA1711
     {
         Task<bool> OfferAsync(TItem item);
 

--- a/src/Hazelcast.Net/DistributedObjects/IMapEntryEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IMapEntryEventHandler.cs
@@ -24,7 +24,9 @@ namespace Hazelcast.DistributedObjects
     /// <typeparam name="TKey">The type of the keys.</typeparam>
     /// <typeparam name="TValue">The type of the values.</typeparam>
     /// <typeparam name="TSender">The type of the sender.</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public interface IMapEntryEventHandler<TKey, TValue, in TSender> : IMapEventHandlerBase
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Handles an event.

--- a/src/Hazelcast.Net/DistributedObjects/IMapEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/IMapEventHandler.cs
@@ -23,7 +23,9 @@ namespace Hazelcast.DistributedObjects
     /// <typeparam name="TKey">The type of the keys.</typeparam>
     /// <typeparam name="TValue">The type of the values.</typeparam>
     /// <typeparam name="TSender">The type of the sender.</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public interface IMapEventHandler<TKey, TValue, in TSender> : IMapEventHandlerBase
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Handles an event.

--- a/src/Hazelcast.Net/DistributedObjects/ITopicEventHandler.cs
+++ b/src/Hazelcast.Net/DistributedObjects/ITopicEventHandler.cs
@@ -21,7 +21,9 @@ namespace Hazelcast.DistributedObjects
     /// Specifies a topic event handler.
     /// </summary>
     /// <typeparam name="T">The topic objects type.</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public interface ITopicEventHandler<T>
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Handles an event.

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Getting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Getting.cs
@@ -370,7 +370,14 @@ namespace Hazelcast.DistributedObjects.Impl
         }
 
         private static PagingPredicate UnwrapPagingPredicate(IPredicate predicate)
-            => predicate as PagingPredicate ?? (predicate as PartitionPredicate)?.Target as PagingPredicate;
+        {
+            return predicate switch
+            {
+                PagingPredicate paging => paging,
+                PartitionPredicate partition => partition.Target as PagingPredicate,
+                _ => null
+            };
+        }
 
         public async IAsyncEnumerator<KeyValuePair<TKey, TValue>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {

--- a/src/Hazelcast.Net/DistributedObjects/MapClearedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapClearedEventArgs.cs
@@ -16,7 +16,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapClearedEventArgs : MapEventArgsBase
+#pragma warning restore CA1711
     {
         public MapClearedEventArgs(MemberInfo member, int numberOfAffectedEntries, object state)
             : base(member, numberOfAffectedEntries, state)

--- a/src/Hazelcast.Net/DistributedObjects/MapEntryAddedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEntryAddedEventArgs.cs
@@ -17,7 +17,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEntryAddedEventArgs<TKey, TValue> : MapEntryEventArgsBase<TKey>
+#pragma warning restore CA1711
     {
         private readonly Lazy<TValue> _value;
 

--- a/src/Hazelcast.Net/DistributedObjects/MapEntryEvictedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEntryEvictedEventArgs.cs
@@ -17,7 +17,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEntryEvictedEventArgs<TKey, TValue> : MapEntryEventArgsBase<TKey>
+#pragma warning restore CA1711
     {
         private readonly Lazy<TValue> _oldValue;
 

--- a/src/Hazelcast.Net/DistributedObjects/MapEntryExpiredEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEntryExpiredEventArgs.cs
@@ -17,7 +17,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEntryExpiredEventArgs<TKey, TValue> : MapEntryEventArgsBase<TKey>
+#pragma warning restore CA1711
     {
         private readonly Lazy<TValue> _oldValue;
 

--- a/src/Hazelcast.Net/DistributedObjects/MapEntryInvalidatedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEntryInvalidatedEventArgs.cs
@@ -17,7 +17,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEntryInvalidatedEventArgs<TKey, TValue> : MapEntryEventArgsBase<TKey>
+#pragma warning restore CA1711
     {
         public MapEntryInvalidatedEventArgs(MemberInfo member, Lazy<TKey> key, object state)
             : base(member, key, state)

--- a/src/Hazelcast.Net/DistributedObjects/MapEntryLoadedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEntryLoadedEventArgs.cs
@@ -17,7 +17,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEntryLoadedEventArgs<TKey, TValue> : MapEntryEventArgsBase<TKey>
+#pragma warning restore CA1711
     {
         private readonly Lazy<TValue> _value;
         private readonly Lazy<TValue> _oldValue;

--- a/src/Hazelcast.Net/DistributedObjects/MapEntryMergedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEntryMergedEventArgs.cs
@@ -17,7 +17,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEntryMergedEventArgs<TKey, TValue> : MapEntryEventArgsBase<TKey>
+#pragma warning restore CA1711
     {
         private readonly Lazy<TValue> _value;
         private readonly Lazy<TValue> _oldValue;

--- a/src/Hazelcast.Net/DistributedObjects/MapEntryRemovedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEntryRemovedEventArgs.cs
@@ -17,7 +17,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEntryRemovedEventArgs<TKey, TValue> : MapEntryEventArgsBase<TKey>
+#pragma warning restore CA1711
     {
         private readonly Lazy<TValue> _oldValue;
 

--- a/src/Hazelcast.Net/DistributedObjects/MapEntryUpdatedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEntryUpdatedEventArgs.cs
@@ -17,7 +17,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEntryUpdatedEventArgs<TKey, TValue> : MapEntryEventArgsBase<TKey>
+#pragma warning restore CA1711
     {
         private readonly Lazy<TValue> _oldValue;
         private readonly Lazy<TValue> _value;

--- a/src/Hazelcast.Net/DistributedObjects/MapEvictedEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/MapEvictedEventArgs.cs
@@ -16,7 +16,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.DistributedObjects
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class MapEvictedEventArgs : MapEventArgsBase
+#pragma warning restore CA1711
     {
         public MapEvictedEventArgs(MemberInfo member, int numberOfAffectedEntries, object state)
             : base(member, numberOfAffectedEntries, state)

--- a/src/Hazelcast.Net/DistributedObjects/TopicMessageEventArgs.cs
+++ b/src/Hazelcast.Net/DistributedObjects/TopicMessageEventArgs.cs
@@ -20,7 +20,9 @@ namespace Hazelcast.DistributedObjects
     /// Represents event data for the <see cref="TopicEventTypes.Message"/> event.
     /// </summary>
     /// <typeparam name="T">The topic object type.</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class TopicMessageEventArgs<T> : EventArgsBase
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TopicMessageEventArgs{T}"/> class.

--- a/src/Hazelcast.Net/Events/DistributedObjectCreatedEventArgs.cs
+++ b/src/Hazelcast.Net/Events/DistributedObjectCreatedEventArgs.cs
@@ -19,7 +19,9 @@ namespace Hazelcast.Events
     /// <summary>
     /// Represents event data for a cluster object created event.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class DistributedObjectCreatedEventArgs : DistributedObjectLifecycleEventArgs
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DistributedObjectCreatedEventArgs"/> class.

--- a/src/Hazelcast.Net/Events/DistributedObjectDestroyedEventArgs.cs
+++ b/src/Hazelcast.Net/Events/DistributedObjectDestroyedEventArgs.cs
@@ -19,7 +19,9 @@ namespace Hazelcast.Events
     /// <summary>
     /// Represents event data for a cluster object destroyed event.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public sealed class DistributedObjectDestroyedEventArgs : DistributedObjectLifecycleEventArgs
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DistributedObjectDestroyedEventArgs"/> class.

--- a/src/Hazelcast.Net/Events/DistributedObjectLifecycleEventArgs.cs
+++ b/src/Hazelcast.Net/Events/DistributedObjectLifecycleEventArgs.cs
@@ -19,7 +19,9 @@ namespace Hazelcast.Events
     /// <summary>
     /// Provides a base class for cluster object lifecycle events data.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public abstract class DistributedObjectLifecycleEventArgs
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DistributedObjectLifecycleEventArgs"/> class.

--- a/src/Hazelcast.Net/Events/MembersUpdatedEventArgs.cs
+++ b/src/Hazelcast.Net/Events/MembersUpdatedEventArgs.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using Hazelcast.Clustering;
 using Hazelcast.Models;
 
 namespace Hazelcast.Events
@@ -21,7 +20,9 @@ namespace Hazelcast.Events
     /// <summary>
     /// Represents event data for the members updated event.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public class MembersUpdatedEventArgs
+#pragma warning restore CA1711
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MembersUpdatedEventArgs"/> class.

--- a/src/Hazelcast.Net/Events/PartitionLostEventArgs.cs
+++ b/src/Hazelcast.Net/Events/PartitionLostEventArgs.cs
@@ -16,7 +16,9 @@ using Hazelcast.Models;
 
 namespace Hazelcast.Events
 {
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public class PartitionLostEventArgs
+#pragma warning restore CA1711
     {
         public PartitionLostEventArgs(int partitionId, int lostBackupCount, bool isAllReplicasInPartitionLost, MemberInfo member)
         {

--- a/src/Hazelcast.Net/Exceptions/ClientOfflineException.cs
+++ b/src/Hazelcast.Net/Exceptions/ClientOfflineException.cs
@@ -57,7 +57,7 @@ namespace Hazelcast.Exceptions
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         [ExcludeFromCodeCoverage]
-        private ClientOfflineException(string message)
+        public ClientOfflineException(string message)
             : base(message)
         {
             State = 0; // unknown
@@ -80,7 +80,7 @@ namespace Hazelcast.Exceptions
         /// </summary>
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
         [ExcludeFromCodeCoverage]
-        private ClientOfflineException(Exception innerException)
+        public ClientOfflineException(Exception innerException)
             : base(ExceptionMessages.ClientNotConnectedException, innerException)
         {
             State = 0; // unknown
@@ -105,7 +105,7 @@ namespace Hazelcast.Exceptions
         /// <param name="message">The message that describes the error.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
         [ExcludeFromCodeCoverage]
-        private ClientOfflineException(string message, Exception innerException)
+        public ClientOfflineException(string message, Exception innerException)
             : base(message, innerException)
         {
             State = 0; // unknown

--- a/src/Hazelcast.Net/Hazelcast.Net.csproj
+++ b/src/Hazelcast.Net/Hazelcast.Net.csproj
@@ -66,10 +66,22 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="ZpqrtBnk.CommentsBuildAnalyzer" Version="1.0.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Hazelcast.Net.JetBrainsAnnotations\Hazelcast.Net.JetBrainsAnnotations.csproj" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)'=='Debug'">
+      <EditorConfigFiles Include="debug.editorconfig" Link=".editorconfig" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)'=='Release'">
+      <EditorConfigFiles Include="release.editorconfig" Link=".editorconfig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hazelcast.Net/IHazelcastClientEventHandler.cs
+++ b/src/Hazelcast.Net/IHazelcastClientEventHandler.cs
@@ -17,6 +17,8 @@ namespace Hazelcast
     /// <summary>
     /// Defines a Hazelcast client event handler.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public interface IHazelcastClientEventHandler
+#pragma warning restore CA1711
     { }
 }

--- a/src/Hazelcast.Net/Messaging/MessageTypeConstants.cs
+++ b/src/Hazelcast.Net/Messaging/MessageTypeConstants.cs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if DEBUG
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+#endif
 
 namespace Hazelcast.Messaging
 {
@@ -67,7 +69,11 @@ namespace Hazelcast.Messaging
         }
 #endif
 
+#if !DEBUG
+#pragma warning disable CA1801 // Review unused parameters - not going to use type if !DEBUG
+#endif
         public static string GetMessageTypeName(int type)
+#pragma warning restore CA1801
         {
 #if DEBUG
             return MessageNames.TryGetValue(type, out var name) ? name : "(unknown)";

--- a/src/Hazelcast.Net/NetStandard/HashCode.cs
+++ b/src/Hazelcast.Net/NetStandard/HashCode.cs
@@ -95,9 +95,18 @@ namespace System
 
         private static uint GenerateGlobalSeed()
         {
-            // code above is from net core 3.1, probably excellent
-            // but we don't have GetRandomBytes etc... this will be enough
+            // netcore 3.1 does:
+            //    uint result;
+            //    Interop.GetRandomBytes((byte*)&result, sizeof(uint));
+            //    return result;
+            //
+            // but that requires the unsafe flag, and we don't have GetRandomBytes,
+            // etc - enough to use the Random class (and probably ends up using
+            // the same code anyways) - we're not doing security here
+
+#pragma warning disable CA5394 // Do not use insecure randomness
             return Convert.ToUInt32(new Random().Next());
+#pragma warning restore CA5394
         }
 
         public static int Combine<T1>(T1 value1)

--- a/src/Hazelcast.Net/Networking/SslOptions.cs
+++ b/src/Hazelcast.Net/Networking/SslOptions.cs
@@ -23,7 +23,8 @@ namespace Hazelcast.Networking
     /// </summary>
     public class SslOptions
     {
-        private SslProtocols _sslProtocol = SslProtocols.Tls12;
+        // default is none, to let the system select the best option
+        private SslProtocols _sslProtocol = SslProtocols.None;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SslOptions"/> class.
@@ -94,19 +95,21 @@ namespace Hazelcast.Networking
             get => _sslProtocol;
             set
             {
-                // this would be nicer with a switch expression but dotCover (as of 2020.2.3) does no cover them
-                switch (value)
+#pragma warning disable IDE0072
+                // ReSharper disable once SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
+                _sslProtocol = value switch
                 {
-#pragma warning disable CA5397 // Do not use deprecated SslProtocols values - TODO: consider removing them?
-                    case SslProtocols.Tls:
-                    case SslProtocols.Tls11:
+                    SslProtocols.None => value,
+#pragma warning disable CA5397 // Do not use deprecated SslProtocols values - but, we still support them
+                    SslProtocols.Tls => value,
+                    SslProtocols.Tls11 => value,
 #pragma warning restore CA5397
-                    case SslProtocols.Tls12:
-                        _sslProtocol = value;
-                        break;
-                    default:
-                        throw new ConfigurationException("Invalid value. Value must be Tls, Tls11 or Tls12.");
-                }
+#pragma warning disable CA5398 // Avoid hardcoded SslProtocols values - well, here, yes
+                    SslProtocols.Tls12 => value,
+#pragma warning restore CA5398
+                    _ => throw new ConfigurationException("Invalid value. Value must be None, Tls, Tls11 or Tls12.")
+                };
+#pragma warning restore IDE0072
             }
         }
 

--- a/src/Hazelcast.Net/Partitioning/Partitioner.cs
+++ b/src/Hazelcast.Net/Partitioning/Partitioner.cs
@@ -84,7 +84,7 @@ namespace Hazelcast.Partitioning
         /// <returns>A random partition identifier.</returns>
         public int GetRandomPartitionId()
         {
-            return RandomProvider.Random.Next(Count);
+            return RandomProvider.Next(Count);
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/Projection/MultiAttributeProjection.cs
+++ b/src/Hazelcast.Net/Projection/MultiAttributeProjection.cs
@@ -40,7 +40,11 @@ namespace Hazelcast.Projection
             {
                 if (string.IsNullOrWhiteSpace(attributePath))
                     throw new ArgumentException("No attribute path can be null nor empty.", nameof(attributePaths));
+#if NETSTANDARD2_1
+                if (attributePath.Contains("[any]", StringComparison.OrdinalIgnoreCase))
+#else
                 if (attributePath.Contains("[any]"))
+#endif
                     throw new ArgumentException("No attribute path can contain the '[any]' operator.", nameof(attributePaths));
             }
 

--- a/src/Hazelcast.Net/Properties/AssemblyInfo.cs
+++ b/src/Hazelcast.Net/Properties/AssemblyInfo.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 // NOTE: do NOT make this assembly visible to Hazelcast.Net.Examples, as
@@ -50,3 +51,6 @@ using Hazelcast;
 //
 // TODO: write for instance VB+F# examples just to be sure
 //[assembly: CLSCompliant(true)]
+
+[assembly: SuppressMessage("Microsoft.Design", "CA1014:MarkAssembliesWithClsCompliant", Justification="Intentional")]
+

--- a/src/Hazelcast.Net/Protocol/BuiltInCodecs/ListMultiFrameCodec.cs
+++ b/src/Hazelcast.Net/Protocol/BuiltInCodecs/ListMultiFrameCodec.cs
@@ -38,7 +38,9 @@ namespace Hazelcast.Protocol.BuiltInCodecs
 
             foreach (var item in collection)
             {
+#pragma warning disable CA1508 // Avoid dead conditional code - false positive, yes it can be null
                 if (item == null)
+#pragma warning restore CA1508
                 {
                     clientMessage.Append(Frame.CreateNull());
                 }

--- a/src/Hazelcast.Net/Query/InPredicate.cs
+++ b/src/Hazelcast.Net/Query/InPredicate.cs
@@ -30,7 +30,10 @@ namespace Hazelcast.Query
         public InPredicate(string attributeName, params object[] values)
         {
             _attributeName = attributeName;
+#pragma warning disable CA1508 // Avoid dead conditional code
+            // false-positive, https://github.com/dotnet/roslyn-analyzers/issues/3845
             _values = values ?? throw new ArgumentNullException(nameof(values));
+#pragma warning restore CA1508 // Avoid dead conditional code
         }
 
         public void ReadData(IObjectDataInput input)

--- a/src/Hazelcast.Net/Query/PredicateBuilder.cs
+++ b/src/Hazelcast.Net/Query/PredicateBuilder.cs
@@ -22,7 +22,7 @@ namespace Hazelcast.Query
     /// </summary>
     public class PredicateBuilder
     {
-        protected readonly string _name;
+        private readonly string _name;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PredicateBuilder"/> class.

--- a/src/Hazelcast.Net/Serialization/JavaClass.cs
+++ b/src/Hazelcast.Net/Serialization/JavaClass.cs
@@ -28,10 +28,10 @@ namespace Hazelcast.Serialization
 
         public string Name { get; }
 
-        public override bool Equals(object other)
+        public override bool Equals(object obj)
         {
-            if (ReferenceEquals(this, other)) return true;
-            return other is JavaClass thing && EqualsN(this, thing);
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is JavaClass thing && EqualsN(this, thing);
         }
 
         protected bool Equals(JavaClass other)

--- a/src/Hazelcast.Net/Serialization/PortableContext.cs
+++ b/src/Hazelcast.Net/Serialization/PortableContext.cs
@@ -47,23 +47,18 @@ namespace Hazelcast.Serialization
             return GetClassDefContext(factoryId).Lookup(classId, version);
         }
 
-        /// <exception cref="System.IO.IOException" />
         public IClassDefinition LookupClassDefinition(IData data)
         {
-            if (!data.IsPortable)
-            {
-                throw new ArgumentException("Data is not Portable!");
-            }
-            var @in = _serializationService.CreateObjectDataInput(data);
-            var factoryId = @in.ReadInt();
-            var classId = @in.ReadInt();
-            var version = @in.ReadInt();
-            var classDefinition = LookupClassDefinition(factoryId, classId, version);
-            if (classDefinition == null)
-            {
-                classDefinition = ReadClassDefinition(@in, factoryId, classId, version);
-            }
-            return classDefinition;
+            if (!data.IsPortable)throw new ArgumentException("Data is not Portable.", nameof(data));
+
+            using var input = _serializationService.CreateObjectDataInput(data);
+
+            var factoryId = input.ReadInt();
+            var classId = input.ReadInt();
+            var version = input.ReadInt();
+
+            return LookupClassDefinition(factoryId, classId, version) ??
+                   ReadClassDefinition(input, factoryId, classId, version);
         }
 
         public IClassDefinition RegisterClassDefinition(IClassDefinition cd)

--- a/src/Hazelcast.Net/Serialization/SerializableSerializer.cs
+++ b/src/Hazelcast.Net/Serialization/SerializableSerializer.cs
@@ -17,6 +17,17 @@ using System.Runtime.Serialization.Formatters.Binary;
 
 namespace Hazelcast.Serialization
 {
+    // note
+    //
+    // "The BinaryFormatter type is dangerous and is not recommended for data processing. Applications
+    // should stop using BinaryFormatter as soon as possible, even if they believe the data they're
+    // processing to be trustworthy. BinaryFormatter is insecure and can't be made secure."
+    //
+    // see: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+    // see: https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide
+    //
+    // TODO: replace BinaryFormatter with something else (breaking?)
+
     /// <summary>
     /// Serialize using default .NET serialization
     /// </summary>
@@ -28,7 +39,11 @@ namespace Hazelcast.Serialization
         {
             var formatter = new BinaryFormatter();
             using var stream = new MemoryStream(input.ReadByteArray());
+#pragma warning disable CA2300 // Do not use insecure deserializer BinaryFormatter - see note above
+#pragma warning disable CA2301
             return formatter.Deserialize(stream);
+#pragma warning restore CA2300
+#pragma warning restore CA2301
         }
 
         public override void Write(IObjectDataOutput output, object obj)

--- a/src/Hazelcast.Net/Serialization/SerializationService.cs
+++ b/src/Hazelcast.Net/Serialization/SerializationService.cs
@@ -98,7 +98,9 @@ namespace Hazelcast.Serialization
             RegisterClassDefinitions(classDefinitions, checkClassDefErrors);
         }
 
+#pragma warning disable CA1822 // Mark members as static - might not remain constant forever
         public byte GetVersion() => SerializerVersion;
+#pragma warning restore CA1822
 
         public virtual IPortableContext GetPortableContext() => _portableContext;
 
@@ -112,7 +114,7 @@ namespace Hazelcast.Serialization
             return CreateObjectDataOutput();
         }
 
-        private void ReturnDataOutput(ObjectDataOutput output)
+        private static void ReturnDataOutput(ObjectDataOutput output)
         {
             //TODO pooling
             output.Dispose();
@@ -124,7 +126,7 @@ namespace Hazelcast.Serialization
             return new ObjectDataInput(data.ToByteArray(), this, Endianness, HeapData.DataOffset);
         }
 
-        private void ReturnDataInput(ObjectDataInput input)
+        private static void ReturnDataInput(ObjectDataInput input)
         {
             //TODO pooling
             input.Dispose();
@@ -215,6 +217,22 @@ namespace Hazelcast.Serialization
             }
         }
 
+        private static bool CanBeNull<T>()
+        {
+            var typeOfT = typeof(T);
+
+            var isValueType = typeOfT.IsValueType;
+            if (!isValueType) return true;
+
+#pragma warning disable CA1508 // Avoid dead conditional code
+            // false positive, https://github.com/dotnet/roslyn-analyzers/issues/4763
+            var isNullableType = typeOfT.IsNullableType();
+#pragma warning restore CA1508
+            if (isNullableType) return true;
+
+            return false;
+        }
+
         public T ReadObject<T>(IObjectDataInput input)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
@@ -227,15 +245,14 @@ namespace Hazelcast.Serialization
                     ThrowMissingSerializer(typeId);
 
                 var o = serializer.Read(input);
-                if (o is null)
+                if (o is T ot) return ot;
+
+                if (o is null) 
                 {
-                    var typeOfT = typeof(T);
-                    if (typeOfT.IsValueType && !typeOfT.IsNullableType())
-                        throw new SerializationException($"Deserialized null value cannot be of value type {typeof(T)}.");
-                    return default;
+                    if (CanBeNull<T>()) return default;
+                    throw new SerializationException($"Deserialized null value cannot be of value type {typeof(T)}.");
                 }
 
-                if (o is T ot) return ot;
                 throw new InvalidCastException($"Deserialized object is of type {o.GetType()}, not {typeof(T)}.");
             }
             catch (Exception e) when (!(e is OutOfMemoryException) && !(e is SerializationException))
@@ -552,8 +569,22 @@ namespace Hazelcast.Serialization
                 throw new ArgumentException("Given data is not Portable! -> " + data.TypeId);
             }
 
-            var input = CreateObjectDataInput(data);
-            return _portableSerializer.CreateReader(input);
+            ObjectDataInput input = null;
+            IPortableReader reader;
+            try
+            {
+                input = CreateObjectDataInput(data);
+                reader = _portableSerializer.CreateReader(input);
+                input = null;
+            }
+            finally
+            {
+#pragma warning disable CA1508 // Avoid dead conditional code - false positive
+                input?.Dispose();
+#pragma warning restore CA1508
+            }
+
+            return reader;
         }
 
         public virtual void Dispose()
@@ -567,6 +598,13 @@ namespace Hazelcast.Serialization
             _idMap.Clear();
             Interlocked.Exchange(ref _global, null);
             _constantTypesMap.Clear();
+
+            _portableSerializer.Dispose();
+
+            _nullSerializerAdapter.Dispose();
+            _portableSerializerAdapter.Dispose();
+            _dataSerializerAdapter.Dispose();
+            _serializableSerializerAdapter.Dispose();
         }
 
         protected internal int CalculatePartitionHash(object obj, IPartitioningStrategy strategy)

--- a/src/Hazelcast.Net/StateChangedEventArgs.cs
+++ b/src/Hazelcast.Net/StateChangedEventArgs.cs
@@ -17,7 +17,9 @@ namespace Hazelcast
     /// <summary>
     /// Represents event data for the state changed event.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - here it is correct
     public class StateChangedEventArgs
+#pragma warning restore CA1711 
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="StateChangedEventArgs"/> class.

--- a/src/Hazelcast.Net/Transactions/TransactionContext.cs
+++ b/src/Hazelcast.Net/Transactions/TransactionContext.cs
@@ -32,9 +32,12 @@ namespace Hazelcast.Transactions
         private readonly object _inTransactionMutex = new object();
 
         private long _threadId; // the "threadId", i.e. async context, which owns the transaction
-        private long _startTime; // the start time of the transaction
-        private MemberConnection _connection; // the client supporting the transaction
+        //private long _startTime; // the start time of the transaction
         private bool _completed; // whether the transaction has been completed
+
+#pragma warning disable CA2213 // Disposable fields should be disposed - well, no
+        private MemberConnection _connection; // the client supporting the transaction
+#pragma warning restore CA2213
 
         // TODO transactions need some TLC
         // how is two-phases commit supposed to work? is it all server-side (and then, why
@@ -102,7 +105,7 @@ namespace Hazelcast.Transactions
             if (_connection == null) throw _cluster.State.ThrowClientOfflineException();
 
             _threadId = ContextId;
-            _startTime = Clock.Milliseconds;
+            //_startTime = Clock.Milliseconds;
 
             HConsole.WriteLine(this, $"Begin transaction on context #{ContextId}");
 
@@ -120,7 +123,7 @@ namespace Hazelcast.Transactions
             {
                 lock (_inTransactionMutex) asyncContext.InTransaction = false;
                 _threadId = 0;
-                _startTime = 0;
+                //_startTime = 0;
                 TransactionId = default;
                 State = TransactionState.None;
                 throw;

--- a/src/Hazelcast.Net/Transactions/TransactionOptions.cs
+++ b/src/Hazelcast.Net/Transactions/TransactionOptions.cs
@@ -21,7 +21,9 @@ namespace Hazelcast.Transactions
     {
         private int _durability = 1;
 
+#pragma warning disable CA1008 // Enums should have zero value - no, "default" is not a valid value
         public enum TransactionType
+#pragma warning restore CA1008
         {
             /// <summary>
             /// Commits the transaction in two distinct phases.

--- a/src/Hazelcast.Net/debug.editorconfig
+++ b/src/Hazelcast.Net/debug.editorconfig
@@ -9,7 +9,6 @@ indent_style = space
 [*.xml]
 indent_size = 2
 
-
 # C# files analysis
 [*.cs]
 #dotnet_code_quality.CA2000.excluded_symbol_names = T:Hazelcast.DistributedObjects.Implementation.Queue.Queue`1
@@ -21,5 +20,6 @@ dotnet_diagnostic.CA1031.severity = none # Do not catch general exception types
 dotnet_diagnostic.CA1040.severity = none # Avoid empty interfaces
 dotnet_diagnostic.CA2225.severity = none # Operator overloads have named alternates
 
+dotnet_diagnostic.ZB1002.severity = warning # FIXME!
 
 #

--- a/src/Hazelcast.Net/release.editorconfig
+++ b/src/Hazelcast.Net/release.editorconfig
@@ -1,0 +1,25 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+root = true
+
+# All files
+[*]
+indent_style = space
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# C# files analysis
+[*.cs]
+#dotnet_code_quality.CA2000.excluded_symbol_names = T:Hazelcast.DistributedObjects.Implementation.Queue.Queue`1
+#dotnet_code_quality.CA2000.excluded_symbol_names = M:Hazelcast.DistributedObjects.Implementation.Queue.Queue`1.WithTimeout``
+#dotnet_code_quality.CA2000.severity = none
+
+dotnet_diagnostic.CA1303.severity = none # Do not pass literals as localized parameters
+dotnet_diagnostic.CA1031.severity = none # Do not catch general exception types
+dotnet_diagnostic.CA1040.severity = none # Avoid empty interfaces
+dotnet_diagnostic.CA2225.severity = none # Operator overloads have named alternates
+
+dotnet_diagnostic.ZB1002.severity = error # FIXME!
+
+#


### PR DESCRIPTION
This is a code analysis / quality PR - it should *_not_* change anything, functionally, but only adjust things to get rid of most of the warnings that we get when building code. The goal being to have zero warning, zero message when we build.

It also upgrades `dotCover` (that we use for code coverage) to its latest version, which brings improvements such as properly supporting `switch` expressions.

It also adds a special Roslyn analyzer that converts comments containing the `FIXME` keyword into build-time warnings or errors. This is because I like putting `FIXME` comments in places where I know that we _*must_* come back and fix something, before we ship, but then I lose track of them.