### PR TITLE
Get rid of FIXMEs in code and all warnings

### DIFF
--- a/src/Hazelcast.Net.Tests/Remote/ClientMapTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientMapTest.cs
@@ -616,8 +616,7 @@ namespace Hazelcast.Tests.Remote
             var m2 = await dictionary.GetAllAsync(ss);
             Assert.AreEqual(m2.Count, 2);
 
-            int gv;
-            m2.TryGetValue(1, out gv);
+            m2.TryGetValue(1, out var gv);
             Assert.AreEqual(gv, 1);
 
             m2.TryGetValue(3, out gv);
@@ -1017,7 +1016,7 @@ namespace Hazelcast.Tests.Remote
             await map.SetAsync("key1", "value1");
             await map.RemoveAsync("key1");
 
-            await AssertEx.SucceedsEventually(async () =>
+            await AssertEx.SucceedsEventually(() =>
             {
                 Assert.That(args, Is.Not.Null);
                 Assert.That(args.Key, Is.EqualTo("key1"));

--- a/src/Hazelcast.Net/Clustering/Heartbeat.cs
+++ b/src/Hazelcast.Net/Clustering/Heartbeat.cs
@@ -50,7 +50,7 @@ namespace Hazelcast.Clustering
             _terminateConnections = terminateConnections;
             if (options == null) throw new ArgumentNullException(nameof(options));
 
-            _logger = clusterState.LoggerFactory.CreateLogger<Heartbeat>(); // FIXME with client ID?
+            _logger = clusterState.LoggerFactory.CreateLogger<Heartbeat>();
             _period = TimeSpan.FromMilliseconds(options.PeriodMilliseconds);
             _timeout = TimeSpan.FromMilliseconds(options.TimeoutMilliseconds);
 
@@ -73,7 +73,7 @@ namespace Hazelcast.Clustering
                 _period.ToString("hh\\:mm\\:ss", CultureInfo.InvariantCulture),
                 _timeout.ToString("hh\\:mm\\:ss", CultureInfo.InvariantCulture));
 
-            HConsole.Configure(x => x.Configure<Heartbeat>().SetPrefix("HEARTBEAT")); // FIXME with client ID?
+            HConsole.Configure(x => x.Configure<Heartbeat>().SetPrefix("HEARTBEAT"));
 
             _cancel = new CancellationTokenSource();
             _heartbeating = BeatAsync(_cancel.Token);

--- a/src/Hazelcast.Net/Metrics/MetricUnit.cs
+++ b/src/Hazelcast.Net/Metrics/MetricUnit.cs
@@ -17,8 +17,8 @@ namespace Hazelcast.Metrics
     internal enum MetricUnit
     {
         // values must align with Java
-        Null = -1, // FIXME that should be the default?
-        Bytes = 0,
+        Null = -1,
+        Bytes = 0, // default
         Milliseconds = 1,
         Nanoseconds = 2,
         Percent = 3,

--- a/src/Hazelcast.Net/Metrics/MetricsCompressor.cs
+++ b/src/Hazelcast.Net/Metrics/MetricsCompressor.cs
@@ -232,7 +232,7 @@ namespace Hazelcast.Metrics
             var prevText = "";
 
             // sorted dictionary is ordered by natural order of its keys
-            // FIXME why would the order matter?!
+            // so that delta-processing is efficient
             foreach (var (stringText, stringId) in _strings)
             {
                 // this should have been checked earlier, this is a safety check

--- a/src/Hazelcast.Net/Metrics/MetricsPublisher.cs
+++ b/src/Hazelcast.Net/Metrics/MetricsPublisher.cs
@@ -97,7 +97,7 @@ namespace Hazelcast.Metrics
                 await foreach (var metric in metricSource.PublishMetrics())
                     metrics.Add(metric);
 
-            // TODO add NearCache manager as a metric source! - except, then, the souce can be async!
+            // TODO add NearCache manager as a metric source! - except, then, the source can be async!
             //await foreach (var nearCache in _nearCaches)
             //    metrics.AddRange(nearCache.Statistics.PublishMetrics());
 
@@ -110,7 +110,7 @@ namespace Hazelcast.Metrics
                 {
                     foreach (var metric in metrics)
                         compressor.Append(metric);
-                    bytes = compressor.GetBytesAndReset(); // FIXME should we, like, recycle it?
+                    bytes = compressor.GetBytesAndReset(); // TODO: consider re-using the compressor
                 }
 
                 if (cancellationToken.IsCancellationRequested) return;

--- a/src/Hazelcast.Net/Networking/SocketConnectionBase.cs
+++ b/src/Hazelcast.Net/Networking/SocketConnectionBase.cs
@@ -231,7 +231,6 @@ namespace Hazelcast.Networking
             _streamReadCancellationTokenSource.Cancel();
 
             // ensure everything is down by awaiting the other task
-            // FIXME why could this be null ?!
             var otherTask = task == _pipeReading ? _pipeWriting : _pipeReading;
             if (otherTask != null) await otherTask.CfAwait();
 

--- a/src/Hazelcast.Net/Partitioning/Strategies/StringPartitioningStrategy.cs
+++ b/src/Hazelcast.Net/Partitioning/Strategies/StringPartitioningStrategy.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace Hazelcast.Partitioning.Strategies
 {
     /// <summary>
@@ -32,7 +34,7 @@ namespace Hazelcast.Partitioning.Strategies
         {
             if (s == null) return null;
 
-            var pos = s.IndexOf('@');
+            var pos = s.IndexOf('@', StringComparison.Ordinal);
             return pos < 0 ? s : s[(pos + 1)..];
         }
     }


### PR DESCRIPTION
Just a small PR to get rid of all FIXMEs in the code and of all other warnings.