### PR TITLE
Jar downloading script is updated for 5.0 jar names

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -570,14 +570,22 @@ function ensure-server-files {
     ensure-jar "hazelcast-${hzVersion}-tests.jar" $mvnOssRepo "com.hazelcast:hazelcast:${hzVersion}:jar:tests"
 
     if ($options.enterprise) {
-
-        # ensure we have the hazelcast enterprise server + test jar
-        ensure-jar "hazelcast-enterprise-all-${hzVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise-all:${hzVersion}"
+		# ensure we have the hazelcast enterprise server + test jar
+		if(${hzVersion} -lt "5.0"){
+			ensure-jar "hazelcast-enterprise-all-${hzVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise-all:${hzVersion}"
+		}
+		else {
+			ensure-jar "hazelcast-enterprise-${hzVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${hzVersion}"
+		}		
         ensure-jar "hazelcast-enterprise-${hzVersion}-tests.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${hzVersion}:jar:tests"
     } else {
-
         # ensure we have the hazelcast server jar
-        ensure-jar "hazelcast-all-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-all:${hzVersion}"
+		if(${hzVersion} -lt "5.0"){
+			ensure-jar "hazelcast-all-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-all:${hzVersion}"
+		}
+		else {
+			ensure-jar "hazelcast-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast:${hzVersion}"
+		}        
     }
 
     if (-not [string]::IsNullOrWhiteSpace($options.serverConfig)) {

--- a/hz.ps1
+++ b/hz.ps1
@@ -570,22 +570,23 @@ function ensure-server-files {
     ensure-jar "hazelcast-${hzVersion}-tests.jar" $mvnOssRepo "com.hazelcast:hazelcast:${hzVersion}:jar:tests"
 
     if ($options.enterprise) {
-		# ensure we have the hazelcast enterprise server + test jar
-		if(${hzVersion} -lt "5.0"){
-			ensure-jar "hazelcast-enterprise-all-${hzVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise-all:${hzVersion}"
-		}
-		else {
-			ensure-jar "hazelcast-enterprise-${hzVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${hzVersion}"
-		}		
+	# ensure we have the hazelcast enterprise server + test jar
+	if(${hzVersion} -lt "5.0"){
+	    ensure-jar "hazelcast-enterprise-all-${hzVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise-all:${hzVersion}"
+	}
+	else {
+	    ensure-jar "hazelcast-enterprise-${hzVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${hzVersion}"
+	}		
         ensure-jar "hazelcast-enterprise-${hzVersion}-tests.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${hzVersion}:jar:tests"
-    } else {
+    } 
+    else {
         # ensure we have the hazelcast server jar
-		if(${hzVersion} -lt "5.0"){
-			ensure-jar "hazelcast-all-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-all:${hzVersion}"
-		}
-		else {
-			ensure-jar "hazelcast-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast:${hzVersion}"
-		}        
+	if(${hzVersion} -lt "5.0"){
+	    ensure-jar "hazelcast-all-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-all:${hzVersion}"
+	}
+	else {
+	    ensure-jar "hazelcast-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast:${hzVersion}"
+	}        
     }
 
     if (-not [string]::IsNullOrWhiteSpace($options.serverConfig)) {

--- a/hz.ps1
+++ b/hz.ps1
@@ -576,6 +576,7 @@ function ensure-server-files {
 	}
 	else {
 	    ensure-jar "hazelcast-enterprise-${hzVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${hzVersion}"
+	    ensure-jar "hazelcast-sql-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-sql:${hzVersion}"
 	}		
         ensure-jar "hazelcast-enterprise-${hzVersion}-tests.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${hzVersion}:jar:tests"
     } 
@@ -586,6 +587,7 @@ function ensure-server-files {
 	}
 	else {
 	    ensure-jar "hazelcast-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast:${hzVersion}"
+	    ensure-jar "hazelcast-sql-${hzVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-sql:${hzVersion}"
 	}        
     }
 


### PR DESCRIPTION
hazelcast-all naming is not used anymore after hazelcast 5.0, this PR is modifiying the jar downloading part of the build script to be compatible for the new jar names