### PR TITLE
Update hz.ps1

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -1386,10 +1386,12 @@ function start-remote-controller() {
     Write-Output "Starting Remote Controller..."
     Write-Output "ClassPath: $($script:options.classpath)"
 
+    $quotedClassPath = '"{0}"' -f $script:options.classpath
+
     # start the remote controller
     $args = @(
         "-Dhazelcast.enterprise.license.key=$script:enterpriseKey",
-        "-cp", "$($script:options.classpath)",
+        "-cp", $quotedClassPath,
         "com.hazelcast.remotecontroller.Main"
     )
 


### PR DESCRIPTION
Java classpaths are quoted to escape from white spaces in the path.