### PR TITLE
Pws white space fix

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -555,6 +555,9 @@ function ensure-jar ( $jar, $repo, $artifact ) {
     $classpath = $script:options.classpath
     if (-not [System.String]::IsNullOrWhiteSpace($classpath)) { $classpath += $s }
     $classpath += "$tmpDir/lib/$jar"
+    # condiser to quote the path to escape from white space 
+    # where you call the $script:options.classpath
+    # ex: $quotedClassPath = '"{0}"' -f $script:options.classpath
     $script:options.classpath = $classpath
 }
 
@@ -1437,11 +1440,14 @@ function start-server() {
         $mainClass = "com.hazelcast.core.server.start-server" # 3.x
     }
 
+    $quotedClassPath = '"{0}"' -f $script:options.classpath
+    $quotedConfig = '"{0}"' -f $options.serverConfig
+
     # start the server
     $args = @(
         "-Dhazelcast.enterprise.license.key=$enterpriseKey",
-        "-cp", $script:options.classpath,
-        "-Dhazelcast.config=$($options.serverConfig)",
+        "-cp", $quotedClassPath,
+        "-Dhazelcast.config=$quotedConfig",
         "-server", "-Xms2g", "-Xmx2g", "-Dhazelcast.multicast.group=224.206.1.1", "-Djava.net.preferIPv4Stack=true",
         "$mainClass"
     )

--- a/hz.ps1
+++ b/hz.ps1
@@ -555,7 +555,7 @@ function ensure-jar ( $jar, $repo, $artifact ) {
     $classpath = $script:options.classpath
     if (-not [System.String]::IsNullOrWhiteSpace($classpath)) { $classpath += $s }
     $classpath += "$tmpDir/lib/$jar"
-    # condiser to quote the path to escape from white space 
+    # Be sure to quote the path to escape from white space 
     # where you call the $script:options.classpath
     # ex: $quotedClassPath = '"{0}"' -f $script:options.classpath
     $script:options.classpath = $classpath

--- a/hz.ps1
+++ b/hz.ps1
@@ -1386,10 +1386,12 @@ function start-remote-controller() {
     Write-Output "Starting Remote Controller..."
     Write-Output "ClassPath: $($script:options.classpath)"
 
+    $quotedClassPath = '"{0}"' -f $script:options.classpath
+
     # start the remote controller
     $args = @(
         "-Dhazelcast.enterprise.license.key=$script:enterpriseKey",
-        "-cp", "$($script:options.classpath)",
+        "-cp", $quotedClassPath,
         "com.hazelcast.remotecontroller.Main"
     )
 


### PR DESCRIPTION
I faced a problem when a java class path contains white spaces in it, controller and server doesn't work. Quoted the all usages of `$script:options.classpath`, and tested with run-server and test commands.