### PR TITLE
Adjustments to Jira workflow

### DIFF
--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -1,7 +1,7 @@
 name: Create Jira issue
 
 # runs: whenever a label is added to an issue
-# if: the issue title does not yet contain '[API-' and
+# if: the issue title does not yet contain 'API-' and
 #     the label is 'to-jira' or 'Jira'
 # does: create corresponding Jira issue and link the two issues
 
@@ -13,7 +13,7 @@ jobs:
   jira:
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.issue.title, '[API-') &&
+      !contains(github.event.issue.title, 'API-') &&
       (
         github.event.label.name == 'to-jira' ||
         github.event.label.name == 'Jira'

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -1,13 +1,23 @@
 name: Create Jira issue
 
+# runs: whenever a label is added to an issue
+# if: the issue title does not yet contain '[API-' and
+#     the label is 'to-jira' or 'Jira'
+# does: create corresponding Jira issue and link the two issues
+
 on:
   issues:
     types: labeled
 
 jobs:
   jira:
-    if: ${{ github.event.label.name == 'to-jira' }}
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.issue.title, '[API-') &&
+      (
+        github.event.label.name == 'to-jira' ||
+        github.event.label.name == 'Jira'
+      )
     steps:
       - name: Call composite action
         uses: hazelcast/github-jira-tool-action@v3

--- a/Hazelcast.Net.sln
+++ b/Hazelcast.Net.sln
@@ -57,6 +57,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build-branch.yml = .github\workflows\build-branch.yml
 		.github\workflows\build-pr.yml = .github\workflows\build-pr.yml
 		.github\workflows\build-release.yml = .github\workflows\build-release.yml
+		.github\workflows\jira-label.yml = .github\workflows\jira-label.yml
 		.github\workflows\report-pr.yml = .github\workflows\report-pr.yml
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Proposing changes for the Jira workflow:
- Rename the label workflow file to `jira-label.yml`
- Get it to trigger on the `Jira` label too, so we can rename the label
- Does not trigger if the issue title already contains `[API-`

That last one condition is added so that we can add the `Jira` label to an issue or PR that we have already manually linked to Jira, and prevent the workflow from triggering. Or, should we remove the label by accident, we can add it back without the workflow triggering. Yes, happened to me, and I ended up with duplicates in Jira.

Note: if/when the PR is merged, the `to-jira` label can (should) be renamed to `Jira`.