### PR TITLE
Fix to unsigned assembly reference

### DIFF
--- a/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
@@ -28,7 +28,7 @@ using Hazelcast.Configuration;
 namespace Hazelcast.Tests.Clustering
 {
     [Category("enterprise")]
-    [Timeout(120_000)]
+    [Timeout(150_000)]
     internal class FailoverTests : MultipleClusterRemoteTestBase
     {
         private IDisposable HConsoleForTest()
@@ -324,7 +324,7 @@ namespace Hazelcast.Tests.Clustering
             Assert.IsNotNull(map);
 
             // first cluster should be B, A is not up
-            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 60_000, 500);
+            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 90_000, 500);
             await AssertClusterB(map, client.ClusterName);
 
             //Start A before switch
@@ -336,7 +336,7 @@ namespace Hazelcast.Tests.Clustering
             await KillMembersAsync(RcClusterAlternative, membersB);
 
             //We should be at A
-            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 60_000, 500);
+            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 90_000, 500);
             await AssertClusterA(map, client.ClusterName);
 
             // Start cluster B again
@@ -348,7 +348,7 @@ namespace Hazelcast.Tests.Clustering
             await KillMembersAsync(RcClusterPrimary, membersA);
 
             //Now, we should failover to cluster B
-            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 60_000, 500);
+            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 90_000, 500);
             await AssertClusterB(map, client.ClusterName);
 
             Assert.GreaterOrEqual(numberOfStateChanged, 8);

--- a/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
@@ -21,7 +21,6 @@ using Hazelcast.Partitioning;
 using Hazelcast.Testing;
 using Hazelcast.Testing.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using NUnit.Framework;
 using Hazelcast.Exceptions;
 using Hazelcast.Configuration;
@@ -53,7 +52,7 @@ namespace Hazelcast.Tests.Clustering
 
         private static ClusterState MockClusterState(HazelcastOptions options)
         {
-            return new ClusterState(options, "clusterName", "clientName", Mock.Of<Partitioner>(), new NullLoggerFactory());
+            return new ClusterState(options, "clusterName", "clientName", new Partitioner(), new NullLoggerFactory());
         }
 
         [Test]

--- a/src/Hazelcast.Net/Properties/AssemblyInfo.cs
+++ b/src/Hazelcast.Net/Properties/AssemblyInfo.cs
@@ -33,7 +33,6 @@ using Hazelcast;
 [assembly: InternalsVisibleTo("Hazelcast.Net.Testing")]
 [assembly: InternalsVisibleTo("hb")]
 [assembly: InternalsVisibleTo("Hazelcast.Net.DependencyInjection")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]//test mocks
 
 #endif
 


### PR DESCRIPTION
Moq fails while working with signed assemblies. Now, removed the Moq usage and the reference.