### PR TITLE
Fix build

### DIFF
--- a/build/certs.ps1
+++ b/build/certs.ps1
@@ -532,13 +532,35 @@ function install-root-ca-windows ( $filename, $add = $true ) {
     }
 
     try {
+        $existing = ($store.Certificates | where { $_.Subject -eq $cert.Subject -and $_.Thumbprint -ne $cert.Thumbprint })
+
+        if ($existing.Count -ne 0) {
+            write-output "CERTS: found one or more rogue root-ca cert already in Cert:\LocalMachine\Root, removing"
+            $existing | foreach-object { 
+                $store.Remove($_) 
+                write-output "CERTS: removed cert '$($_.Subject)' ($($_.Thumbprint)) from Cert:\LocalMachine\Root"
+            }
+        }
+
+        $existing = ($store.Certificates | where { $_.Subject -eq $cert.Subject })
+
         if ($add) {
-            $store.Add($cert)
-            write-output "CERTS: added cert '$($cert.Subject)' to Cert:\LocalMachine\Root"
+            if ($existing.Count -eq 0) {
+                $store.Add($cert)
+                write-output "CERTS: added cert '$($cert.Subject)' ($($cert.Thumbprint)) to Cert:\LocalMachine\Root"
+            }
+            else {
+                write-output "CERTS: found cert '$($cert.Subject)' ($($cert.Thumbprint)) already in Cert:\LocalMachine\Root"
+            }
         }
         else {
-            $store.Remove($cert)
-            write-output "CERTS: removed cert '$($cert.Subject)' from Cert:\LocalMachine\Root"
+            if ($existing.Count -eq 1) {
+                $store.Remove($cert)
+                write-output "CERTS: removed cert '$($cert.Subject)' ($($cert.Thumbprint)) from Cert:\LocalMachine\Root"
+            }
+            else {
+                write-output "CERTS: cert '$($cert.Subject)' ($($cert.Thumbprint)) not in Cert:\LocalMachine\Root"
+            }
         }
     }
     catch {
@@ -555,14 +577,26 @@ function install-root-ca-windows ( $filename, $add = $true ) {
 # same, but for Linux
 function install-root-ca-linux ( $filename, $add = $true ) {
     try {
+        $fileonly = [IO.Path]::GetFileName($filename)
         if ($add) {
-            cp $filename /usr/local/share/ca-certificates/
-            update-ca-certificates
+            if (-not (test-path "/usr/local/share/ca-certificates/$fileonly")) {
+                sudo cp $filename /usr/local/share/ca-certificates/
+                sudo update-ca-certificates
+                write-output "CERTS: added cert '$fileonly' to /usr/local/share/ca-certificates"
+            }
+            else {
+                write-output "CERTS: found cert '$fileonly' already in /usr/local/share/ca-certificates"
+            }
         }
         else {
-            $fileonly = [IO.Path]::GetFileName($filename)
-            rm /usr/local/share/ca-certificates/$fileonly
-            update-ca-certificates --fresh
+            if (test-path "/usr/local/share/ca-certificates/$fileonly") {
+                sudo rm /usr/local/share/ca-certificates/$fileonly
+                sudo update-ca-certificates --fresh
+                write-output "CERTS: removed cert '$fileonly' from /usr/local/share/ca-certificates"
+            }
+            else {
+                write-output "CERTS: cert '$fileonly' not in /usr/local/share/ca-certificates"
+            }
         }
         $global:CERTSEXITCODE = 0
     }
@@ -586,7 +620,7 @@ function install-root-ca ( $filename, $add = $true ) {
     }
 }
 
-function remove-root-ca ( $fiename ) {
+function remove-root-ca ( $filename ) {
     install-root-ca $filename $false
 }
 

--- a/hz.ps1
+++ b/hz.ps1
@@ -1109,6 +1109,7 @@ function ensure-certs {
         else {
             Write-Output "Missing $tmpDir/certs directory, generating"
             hz-generate-certs
+            hz-install-root-ca
         }
     }
 }

--- a/src/Hazelcast.Net.Testing/WaitHandleExtensions.cs
+++ b/src/Hazelcast.Net.Testing/WaitHandleExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hazelcast.Testing
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="WaitHandle"/> class.
+    /// </summary>
+    internal static class WaitHandleExtensions
+    {
+        public static async Task<bool> WaitOneAsync(this WaitHandle handle, int millisecondsTimeout = -1, CancellationToken cancellationToken = default)
+        {
+            RegisteredWaitHandle registeredHandle = null;
+            var tokenRegistration = default(CancellationTokenRegistration);
+            try
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                registeredHandle = ThreadPool.RegisterWaitForSingleObject(
+                    handle,
+                    (state, timedOut) => ((TaskCompletionSource<bool>)state).TrySetResult(!timedOut),
+                    tcs,
+                    millisecondsTimeout,
+                    true);
+                tokenRegistration = cancellationToken.Register(
+                    state => ((TaskCompletionSource<bool>)state).TrySetCanceled(),
+                    tcs);
+                return await tcs.Task;
+            }
+            finally
+            {
+                registeredHandle?.Unregister(null);
+                tokenRegistration.Dispose();
+            }
+        }
+    }
+}

--- a/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.Clustering;
 using Hazelcast.Core;
@@ -271,9 +272,11 @@ namespace Hazelcast.Tests.Clustering
         [TestCase(false, 1)]
         public async Task TestClientCanFailoverFirstClusterNotUp(bool smartRouting, int memberCount)
         {
-            var _ = HConsoleForTest();
+            //using var _ = HConsoleForTest();
 
             var numberOfStateChanged = 0;
+            var waitConnected = new AutoResetEvent(false);
+            var waitDisconnected = new AutoResetEvent(false);
 
             var failoverOptions = new HazelcastFailoverOptionsBuilder()
                 .With(fo =>
@@ -296,6 +299,15 @@ namespace Hazelcast.Tests.Clustering
                                 {
                                     HConsole.WriteLine(this, $"State Changed:{arg.State}");
                                     numberOfStateChanged++;
+                                    switch (arg.State)
+                                    {
+                                        case ClientState.Connected:
+                                            waitConnected.Set();
+                                            break;
+                                        case ClientState.Disconnected:
+                                            waitDisconnected.Set();
+                                            break;
+                                    }
                                 }));
                         })
                         .Build());
@@ -325,7 +337,7 @@ namespace Hazelcast.Tests.Clustering
             Assert.IsNotNull(map);
 
             // first cluster should be B, A is not up
-            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 60_000, 500);
+            Assert.That(await waitConnected.WaitOneAsync(90_000)); // get connected before timeout
             await AssertClusterB(map, client.ClusterName);
 
             //Start A before switch
@@ -337,8 +349,9 @@ namespace Hazelcast.Tests.Clustering
             await KillMembersAsync(RcClusterAlternative, membersB);
 
             //We should be at A
-            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 60_000, 500);
-            await AssertClusterA(map, client.ClusterName);
+            Assert.That(await waitDisconnected.WaitOneAsync(90_000)); // get disconnected before timeout
+            Assert.That(await waitConnected.WaitOneAsync(90_000)); // get reconnected before timeout
+            await AssertClusterA(map, client.ClusterName); // to the right cluster
 
             // Start cluster B again
             HConsole.WriteLine(this, $"START: Members of Cluster B :{RcClusterAlternative.Id}");
@@ -349,8 +362,9 @@ namespace Hazelcast.Tests.Clustering
             await KillMembersAsync(RcClusterPrimary, membersA);
 
             //Now, we should failover to cluster B
-            await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Connected, client.State); }, 60_000, 500);
-            await AssertClusterB(map, client.ClusterName);
+            Assert.That(await waitDisconnected.WaitOneAsync(90_000)); // get disconnected before timeout
+            Assert.That(await waitConnected.WaitOneAsync(90_000)); // get reconnected before timeout
+            await AssertClusterB(map, client.ClusterName); // to the right cluster
 
             Assert.GreaterOrEqual(numberOfStateChanged, 8);
             /*

--- a/src/Hazelcast.Net.Tests/DotNet/TypeTests.cs
+++ b/src/Hazelcast.Net.Tests/DotNet/TypeTests.cs
@@ -85,11 +85,17 @@ namespace Hazelcast.Tests.DotNet
         // is in the currently executing assembly or in mscorlib.dll/System.Private.CoreLib.dll, it is sufficient
         // to supply the type name qualified by its namespace."
 
+#if NETFRAMEWORK && ASSEMBLY_SIGNING
+        private static string PublicKeyToken = AssemblySigning.PublicKeyToken;
+#else
+        private static string PublicKeyToken = "null";
+#endif
+
         private static readonly (string, Type, bool)[] CreateTypeSource =
         {
             // works with type.AssemblyQualifiedName
-            ($"Hazelcast.Tests.DotNet.TypeTests+Thing, Hazelcast.Net.Tests, Version={OurVersion}, Culture=neutral, PublicKeyToken=null", typeof(Thing), true),
-            ($"Hazelcast.Tests.DotNet.TypeTests+Thing`1[[System.Int32, {IntAssembly}, {IntDetails}]], Hazelcast.Net.Tests, Version={OurVersion}, Culture=neutral, PublicKeyToken=null", typeof(Thing<int>), true),
+            ($"Hazelcast.Tests.DotNet.TypeTests+Thing, Hazelcast.Net.Tests, Version={OurVersion}, Culture=neutral, PublicKeyToken={PublicKeyToken}", typeof(Thing), true),
+            ($"Hazelcast.Tests.DotNet.TypeTests+Thing`1[[System.Int32, {IntAssembly}, {IntDetails}]], Hazelcast.Net.Tests, Version={OurVersion}, Culture=neutral, PublicKeyToken={PublicKeyToken}", typeof(Thing<int>), true),
 
             // missing namespace = cannot work
             ("Thing", typeof(Thing), false),
@@ -110,8 +116,14 @@ namespace Hazelcast.Tests.DotNet
 
             // different version... random public key... does not matter
             // regardless of whether the assemblies are signed or not - Type.GetType does not care
+#if NETFRAMEWORK && ASSEMBLY_SIGNING
+            // except when signing with net framework of course
+            ($"Hazelcast.Tests.DotNet.TypeTests+Thing, Hazelcast.Net.Tests, Version=2.0.0.0", typeof(Thing), false),
+            ($"Hazelcast.Tests.DotNet.TypeTests+Thing, Hazelcast.Net.Tests, Version=99.0.0.0", typeof(Thing), false),
+#else
             ("Hazelcast.Tests.DotNet.TypeTests+Thing, Hazelcast.Net.Tests, Version=2.0.0.0", typeof(Thing), true),
             ("Hazelcast.Tests.DotNet.TypeTests+Thing, Hazelcast.Net.Tests, Version=99.0.0.0", typeof(Thing), true),
+#endif
 
             // except, .NET Framework wants the public key token to make sense & match
             ($"Hazelcast.Tests.DotNet.TypeTests+Thing, Hazelcast.Net.Tests, Version={OurVersion}, Culture=neutral, PublicKeyToken=7caaaaaabea7798e", typeof(Thing), !IsFramework),

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
@@ -64,7 +64,7 @@
 // definition.
 
 #if !SSLCERTS_JAVA && !SSLCERTS_MIXED && !SSLCERTS_CUSTOM
-#define SSLCERTS_MIXED
+#define SSLCERTS_CUSTOM
 #endif
 
 using System;


### PR DESCRIPTION
This PR ports the changes made to the `release/5.1.0` branch in order to fix its build which was broken by:
* An expired SSL certificate & a general confusion around test certs renewal - we now generate all our certs locall - that may not be the long-term solution but it works, now
* Some .NET type tests that failed for .NET Framework and signed code (PRs builds are not signed)
* Some failover tests that depended too much on timing and failed on GitHub