### PR TITLE
Fix RetryStrategy delay

### DIFF
--- a/src/Hazelcast.Net.Tests/Clustering/RetryStrategyTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/RetryStrategyTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Hazelcast.Clustering;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Hazelcast.Tests.Clustering
+{
+    [TestFixture]
+    public class RetryStrategyTests
+    {
+        [Test]
+        public void TestDelayWithTimeout()
+        {
+            var retry = new RetryStrategy("test", 1_000, 30_000, 1, 60_000, 0, new NullLoggerFactory());
+
+            Assert.That(retry.GetDelay(1_000), Is.EqualTo(1_000));
+            Assert.That(retry.GetDelay(2_000), Is.EqualTo(1_000));
+
+            Assert.That(retry.GetDelay(59_000), Is.EqualTo(1_000));
+            Assert.That(retry.GetDelay(59_500), Is.EqualTo(500)); // almost timeout
+            Assert.That(retry.GetDelay(60_000), Is.EqualTo(0)); // timeout
+
+            // elapsed cannot be > timeout - but just in case
+            Assert.That(retry.GetDelay(80_000), Is.EqualTo(0)); 
+        }
+
+        [Test]
+        public void TestDelayInfiniteTimeout()
+        {
+            var retry = new RetryStrategy("test", 1_000, 30_000, 1, -1, 0, new NullLoggerFactory());
+
+            Assert.That(retry.GetDelay(1_000), Is.EqualTo(1_000));
+            Assert.That(retry.GetDelay(2_000), Is.EqualTo(1_000));
+
+            Assert.That(retry.GetDelay(int.MaxValue), Is.EqualTo(1_000)); // no timeout
+        }
+
+        [Test]
+        public void TestDelayJitter()
+        {
+            var retry0 = new RetryStrategy("test", 1_000, 30_000, 1, 60_000, 0, new NullLoggerFactory());
+            Assert.That(retry0.GetDelay(1_000), Is.EqualTo(1_000));
+
+            var retry1 = new RetryStrategy("test", 1_000, 30_000, 1, 60_000, 1, new NullLoggerFactory());
+            const int count = 10;
+            var total = 0;
+            for (var i = 0; i < count; i++) total += retry1.GetDelay(1_000);
+            Assert.That(total, Is.LessThan(1_000 * count));
+        }
+
+        [TestCase(1_000, 1, 1_000)]
+        [TestCase(1_000, 2, 2_000)]
+        [TestCase(8_000, 2, 16_000)]
+        [TestCase(16_000, 2, 30_000)] // max!
+        public void TestBackoff(int initial, int multiplier, int expected)
+        {
+            var retry = new RetryStrategy("test", initial, 30_000, multiplier, 60_000, 0, new NullLoggerFactory());
+
+            Assert.That(retry.GetNewBackoff(), Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/Hazelcast.Net.Tests/Clustering/RetryStrategyTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/RetryStrategyTests.cs
@@ -55,10 +55,17 @@ namespace Hazelcast.Tests.Clustering
             Assert.That(retry0.GetDelay(1_000), Is.EqualTo(1_000));
 
             var retry1 = new RetryStrategy("test", 1_000, 30_000, 1, 60_000, 1, new NullLoggerFactory());
-            const int count = 10;
-            var total = 0;
-            for (var i = 0; i < count; i++) total += retry1.GetDelay(1_000);
-            Assert.That(total, Is.LessThan(1_000 * count));
+            const int count = 100;
+            var min = int.MaxValue;
+            var max = int.MinValue;
+            for (var i = 0; i < count; i++)
+            {
+                var delay = retry1.GetDelay(1_000);
+                if (min > delay) min = delay;
+                if (max < delay) max = delay;
+            }
+            Assert.That(min, Is.LessThan(1_000)); // some values were lower than initial
+            Assert.That(max, Is.GreaterThan(1_000)); // some values were greater than initial
         }
 
         [TestCase(1_000, 1, 1_000)]

--- a/src/Hazelcast.Net/Clustering/RetryStrategy.cs
+++ b/src/Hazelcast.Net/Clustering/RetryStrategy.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Hazelcast.Configuration;
 using Hazelcast.Core;
 using Hazelcast.Exceptions;
 using Microsoft.Extensions.Logging;
@@ -29,11 +30,11 @@ namespace Hazelcast.Clustering
         private readonly string _action;
         private readonly ILogger _logger;
 
-        private int _initialBackoffMilliseconds { get; }
-        private int _maxBackoffMilliseconds { get; }
-        private double _multiplier { get; }
-        private long _timeoutMilliseconds { get; }
-        private double _jitter { get; }
+        private readonly int _initialBackoffMilliseconds;
+        private readonly int _maxBackoffMilliseconds;
+        private readonly double _multiplier;
+        private readonly long _timeoutMilliseconds;
+        private readonly double _jitter;
         private int _currentBackOffMilliseconds;
         private int _attempts;
         private DateTime _begin;
@@ -71,17 +72,37 @@ namespace Hazelcast.Clustering
             _action = action.ToLowerInvariant();
 #pragma warning restore CA1308
 
-
+            if (initialBackOffMilliseconds < 0) throw new ConfigurationException("Initial back-off must be greater than or equal to zero.");
             _initialBackoffMilliseconds = initialBackOffMilliseconds;
+            if (maxBackOffMilliseconds < 0) throw new ConfigurationException("Maximum back-off must be greater than or equal to zero.");
             _maxBackoffMilliseconds = maxBackOffMilliseconds;
+            if (multiplier <= 0) throw new ConfigurationException("Multiplier must be greater than zero.");
             _multiplier = multiplier;
             _timeoutMilliseconds = timeoutMilliseconds;
+            if (jitter < 0 || jitter > 1) throw new ConfigurationException("Jitter must be between zero and one, inclusive.");
             _jitter = jitter;
-            _currentBackOffMilliseconds = initialBackOffMilliseconds;
 
             _logger = loggerFactory?.CreateLogger<RetryStrategy>() ?? throw new ArgumentNullException(nameof(loggerFactory));
 
             Restart();
+        }
+
+        /// <summary>
+        /// (internal for tests only) Gets the delay.
+        /// </summary>
+        internal int GetDelay(int elapsed)
+        {
+            var delay = (int)(_currentBackOffMilliseconds * (1 - _jitter * (1 - RandomProvider.NextDouble())));
+            if (_timeoutMilliseconds >= 0) delay = Math.Min(delay, Math.Max(0, (int)(_timeoutMilliseconds - elapsed)));
+            return delay;
+        }
+
+        /// <summary>
+        /// (internal for tests only) Gets the new back-off.
+        /// </summary>
+        internal int GetNewBackoff()
+        {
+            return (int)Math.Min(_currentBackOffMilliseconds * _multiplier, _maxBackoffMilliseconds);
         }
 
         /// <inheritdoc />
@@ -102,8 +123,7 @@ namespace Hazelcast.Clustering
                 return false;
             }
 
-            var delay = (int)(_currentBackOffMilliseconds * (1 - _jitter * (1 - RandomProvider.NextDouble())));
-            delay = Math.Min(delay, Math.Max(0, (int)(_timeoutMilliseconds - elapsed)));
+            var delay = GetDelay(elapsed);
 
             _logger.IfDebug()?.LogDebug("Unable to {Action} after {Attempts} attempts and {Elapsed}ms, will retry in {Delay}ms", _action, _attempts, elapsed, delay);
 
@@ -122,7 +142,7 @@ namespace Hazelcast.Clustering
                 return false;
             }
 
-            _currentBackOffMilliseconds = (int)Math.Min(_currentBackOffMilliseconds * _multiplier, _maxBackoffMilliseconds);
+            _currentBackOffMilliseconds = GetNewBackoff();
             return true;
         }
 
@@ -133,7 +153,5 @@ namespace Hazelcast.Clustering
             _currentBackOffMilliseconds = Math.Min(_maxBackoffMilliseconds, _initialBackoffMilliseconds);
             _begin = DateTime.UtcNow;
         }
-
-
     }
 }

--- a/src/Hazelcast.Net/Clustering/RetryStrategy.cs
+++ b/src/Hazelcast.Net/Clustering/RetryStrategy.cs
@@ -92,7 +92,14 @@ namespace Hazelcast.Clustering
         /// </summary>
         internal int GetDelay(int elapsed)
         {
-            var delay = (int)(_currentBackOffMilliseconds * (1 - _jitter * (1 - RandomProvider.NextDouble())));
+            // java:
+            // long actualSleepTime = (long) (currentBackoffMillis +currentBackoffMillis * jitter * (2.0 * random.nextDouble() - 1.0));
+            //
+            // delay is _currentBackOffMilliseconds + _currentBackOffMilliseconds * jitter * random
+            // where random is between -1 and +1 and _jitter is between 0 and 1
+
+            var rand = 2.0 * RandomProvider.NextDouble() - 1.0; // -1 to +1
+            var delay = (int)(_currentBackOffMilliseconds * (1 + _jitter * rand));
             if (_timeoutMilliseconds >= 0) delay = Math.Min(delay, Math.Max(0, (int)(_timeoutMilliseconds - elapsed)));
             return delay;
         }


### PR DESCRIPTION
As exposed by the Cloud tests during release validation, we have a bug in our RetryStrategy where, if the timeout is set to -1 (i.e. infinite timeout), the delay is consistently zero. This fixes the issue + adds tests.