### PR TITLE
Delay failed members connections

### DIFF
--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -77,12 +77,12 @@ namespace Hazelcast.Clustering
                 // initialize the queue of members to connect
                 // and the handler to re-queue members that have failed, *if* they are still members
                 _memberConnectionQueue = new MemberConnectionQueue(clusterState.LoggerFactory);
-                _memberConnectionQueue.ConnectionFailed += (_, member) =>
+                _memberConnectionQueue.ConnectionFailed += (_, request) =>
                 {
                     lock (_mutex)
                     {
-                        if (_members.ContainsMember(member.Id))
-                            _memberConnectionQueue.Add(member);
+                        if (_members.ContainsMember(request.Member.Id))
+                            _memberConnectionQueue.AddAgain(request);
                     }
                 };
             }

--- a/src/Hazelcast.Net/Clustering/MemberConnectionQueue.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnectionQueue.cs
@@ -28,7 +28,7 @@ namespace Hazelcast.Clustering
     internal class MemberConnectionQueue : IAsyncEnumerable<MemberConnectionRequest>, IAsyncDisposable
     {
         private readonly AsyncQueue<MemberConnectionRequest> _requests = new AsyncQueue<MemberConnectionRequest>();
-        private readonly HashSet<MemberConnectionRequest> _delayed = new HashSet<MemberConnectionRequest>();
+        private readonly AsyncQueue<MemberConnectionRequest> _delayed = new AsyncQueue<MemberConnectionRequest>();
         private readonly CancellationTokenSource _cancel = new CancellationTokenSource();
 
         private readonly SemaphoreSlim _resume = new SemaphoreSlim(0); // blocks the queue when it is suspended
@@ -37,6 +37,7 @@ namespace Hazelcast.Clustering
         private readonly object _mutex = new object();
 
         private readonly ILogger _logger;
+        private readonly Task _delaying;
 
         private volatile bool _disposed;
         private MemberConnectionRequest _request;
@@ -50,6 +51,7 @@ namespace Hazelcast.Clustering
         {
             if (loggerFactory == null) throw new ArgumentNullException(nameof(loggerFactory));
             _logger = loggerFactory.CreateLogger<MemberConnectionQueue>();
+            _delaying = Delay();
 
             HConsole.Configure(x => x.Configure<MemberConnectionQueue>().SetPrefix("MBRQ"));
         }
@@ -96,8 +98,8 @@ namespace Hazelcast.Clustering
                 _logger.IfDebug()?.LogDebug("{DrainState} the members connection queue.", (drain ? "Drain and resume" : "Resume"));
                 if (drain)
                 {
-                    _requests.ForEach(request => request.Cancel());
-                    foreach (var request in _delayed) request.Cancel();
+                    _requests.ForEach(x => x.Cancel());
+                    _delayed.ForEach(x => x.Cancel());
                 }
                 _suspended = false;
                 _resume.Release();
@@ -134,33 +136,22 @@ namespace Hazelcast.Clustering
         {
             if (_disposed || request.Cancelled) return; // no need to add - no need to throw about it
 
-            _delayed.Add(request); // so it can be cancelled
-
-            Task.Run(async () =>
-            {
-                // for now, delay every failed request for 1s before queuing it again
-                // that is, more or less, what Java does (Java process all members every 1s)
-                // later on, that delay could depend on each request & have a wait strategy
-
-                await Task.Delay(1000, _cancel.Token).CfAwait(); 
-
-                lock (_mutex)
-                {
-                    _delayed.Remove(request);
-                    if (_disposed || request.Cancelled) return; // again
-
-                    if (!_requests.TryWrite(request))
-                    {
-                        // that should not happen, but log to be sure
-                        _logger.IfWarning()?.LogWarning("Failed to add again member ({MemberId}).", request.Member.Id.ToShortString());
-                    }
-                    else
-                    {
-                        _logger.IfDebug()?.LogDebug("Added again member {MemberId}", request.Member.Id.ToShortString());
-                    }
-                }
-            }).CfAwaitNoThrow(); // don't leak unobserved exceptions
+            _delayed.TryWrite(request);
         }
+
+        private async Task Delay()
+        {
+            const int minDelay = 1000; // milliseconds - but later on each request could have a retry strategy
+
+            await foreach (var request in _delayed.WithCancellation(_cancel.Token))
+            {
+                var elapsed = DateTime.UtcNow - request.CreateDate;
+                var delay = minDelay - (int)elapsed.TotalMilliseconds;
+                if (delay > 0) await Task.Delay(delay, _cancel.Token).CfAwait();
+                _requests.TryWrite(request);
+            }
+        }
+
 
         // when receiving members from the cluster... if a member is gone,
         // we need to remove it from the queue, no need to ever try to connect
@@ -177,14 +168,14 @@ namespace Hazelcast.Clustering
             // a member that we want to remove *may* end up being enumerated, and we're going to
             // to to connect to it, and either fail, or drop the connection - accepted tradeoff
             lock (_mutex) {
-                _requests.ForEach(m =>
+                _requests.ForEach(x =>
                 {
-                    if (m.Member.Id == memberId) m.Cancel();
+                    if (x.Member.Id == memberId) x.Cancel();
                 });
-                foreach (var request in _delayed)
+                _delayed.ForEach(x =>
                 {
-                    if (request.Member.Id == memberId) request.Cancel();
-                }
+                    if (x.Member.Id == memberId) x.Cancel();
+                });
             }
         }
 
@@ -276,19 +267,22 @@ namespace Hazelcast.Clustering
         }
 
         /// <inheritdoc />
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             // note: DisposeAsync should not throw (CA1065)
 
             lock (_mutex)
             {
-                if (_disposed) return default;
+                if (_disposed) return;
                 _disposed = true;
             }
 
             _requests.Complete();
+            _delayed.Complete();
             _cancel.Cancel();
             _cancel.Dispose();
+
+            await _delaying.CfAwaitNoThrow();
 
             // cannot wait until enumeration (if any) is complete,
             // because that depends on the caller calling MoveNext,
@@ -297,8 +291,6 @@ namespace Hazelcast.Clustering
 
             _resume.Dispose();
             _enumerate.Dispose();
-
-            return default;
         }
     }
 }

--- a/src/Hazelcast.Net/Clustering/MemberConnectionQueue.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnectionQueue.cs
@@ -59,6 +59,16 @@ namespace Hazelcast.Clustering
         public event EventHandler<MemberConnectionRequest> ConnectionFailed;
 
         /// <summary>
+        /// (internals for tests only) Gets the count of requests in the queue.
+        /// </summary>
+        internal int RequestsCount => _requests.Count;
+
+        /// <summary>
+        /// (internals for tests only) Gets the count of delayed requests in the queue.
+        /// </summary>
+        internal int DelayedRequestsCount => _delayed.Count;
+
+        /// <summary>
         /// Suspends the queue.
         /// </summary>
         /// <returns>A <see cref="ValueTask"/> that will be completed when the queue is suspended.</returns>
@@ -151,7 +161,6 @@ namespace Hazelcast.Clustering
                 _requests.TryWrite(request);
             }
         }
-
 
         // when receiving members from the cluster... if a member is gone,
         // we need to remove it from the queue, no need to ever try to connect

--- a/src/Hazelcast.Net/Clustering/MemberConnectionQueue.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnectionQueue.cs
@@ -28,6 +28,7 @@ namespace Hazelcast.Clustering
     internal class MemberConnectionQueue : IAsyncEnumerable<MemberConnectionRequest>, IAsyncDisposable
     {
         private readonly AsyncQueue<MemberConnectionRequest> _requests = new AsyncQueue<MemberConnectionRequest>();
+        private readonly HashSet<MemberConnectionRequest> _delayed = new HashSet<MemberConnectionRequest>();
         private readonly CancellationTokenSource _cancel = new CancellationTokenSource();
 
         private readonly SemaphoreSlim _resume = new SemaphoreSlim(0); // blocks the queue when it is suspended
@@ -53,7 +54,7 @@ namespace Hazelcast.Clustering
             HConsole.Configure(x => x.Configure<MemberConnectionQueue>().SetPrefix("MBRQ"));
         }
 
-        public event EventHandler<MemberInfo> ConnectionFailed;
+        public event EventHandler<MemberConnectionRequest> ConnectionFailed;
 
         /// <summary>
         /// Suspends the queue.
@@ -93,7 +94,11 @@ namespace Hazelcast.Clustering
                 if (_disposed) return; // nothing to resume - but no need to throw about it
                 if (!_suspended) throw new InvalidOperationException("Not suspended.");
                 _logger.IfDebug()?.LogDebug("{DrainState} the members connection queue.", (drain ? "Drain and resume" : "Resume"));
-                if (drain) _requests.ForEach(request => request.Cancel());
+                if (drain)
+                {
+                    _requests.ForEach(request => request.Cancel());
+                    foreach (var request in _delayed) request.Cancel();
+                }
                 _suspended = false;
                 _resume.Release();
             }
@@ -121,6 +126,42 @@ namespace Hazelcast.Clustering
             }
         }
 
+        /// <summary>
+        /// Adds a request again.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        public void AddAgain(MemberConnectionRequest request)
+        {
+            if (_disposed || request.Cancelled) return; // no need to add - no need to throw about it
+
+            _delayed.Add(request); // so it can be cancelled
+
+            Task.Run(async () =>
+            {
+                // for now, delay every failed request for 1s before queuing it again
+                // that is, more or less, what Java does (Java process all members every 1s)
+                // later on, that delay could depend on each request & have a wait strategy
+
+                await Task.Delay(1000, _cancel.Token).CfAwait(); 
+
+                lock (_mutex)
+                {
+                    _delayed.Remove(request);
+                    if (_disposed || request.Cancelled) return; // again
+
+                    if (!_requests.TryWrite(request))
+                    {
+                        // that should not happen, but log to be sure
+                        _logger.IfWarning()?.LogWarning("Failed to add again member ({MemberId}).", request.Member.Id.ToShortString());
+                    }
+                    else
+                    {
+                        _logger.IfDebug()?.LogDebug("Added again member {MemberId}", request.Member.Id.ToShortString());
+                    }
+                }
+            }).CfAwaitNoThrow(); // don't leak unobserved exceptions
+        }
+
         // when receiving members from the cluster... if a member is gone,
         // we need to remove it from the queue, no need to ever try to connect
         // to it again - so it remains in the _members async queue, but we
@@ -135,10 +176,16 @@ namespace Hazelcast.Clustering
             // cancel all corresponding requests - see notes in AsyncQueue, this is best-effort,
             // a member that we want to remove *may* end up being enumerated, and we're going to
             // to to connect to it, and either fail, or drop the connection - accepted tradeoff
-            lock (_mutex) _requests.ForEach(m =>
-            {
-                if (m.Member.Id == memberId) m.Cancel();
-            });
+            lock (_mutex) {
+                _requests.ForEach(m =>
+                {
+                    if (m.Member.Id == memberId) m.Cancel();
+                });
+                foreach (var request in _delayed)
+                {
+                    if (request.Member.Id == memberId) request.Cancel();
+                }
+            }
         }
 
         /// <inheritdoc />
@@ -198,7 +245,7 @@ namespace Hazelcast.Clustering
                             {
                                 var request = _queueRequestsEnumerator.Current;
                                 if (request.Member == null || request.Cancelled) break; // that request is to be skipped
-                                request.Failed += (r, _) => _queue.ConnectionFailed?.Invoke(_queue, ((MemberConnectionRequest)r).Member);
+                                request.Failed += (r, _) => _queue.ConnectionFailed?.Invoke(_queue, (MemberConnectionRequest)r);
                                 _queue._request = request;
                                 return true;
                             }

--- a/src/Hazelcast.Net/Clustering/MemberConnectionRequest.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnectionRequest.cs
@@ -33,6 +33,8 @@ namespace Hazelcast.Clustering
 
         public MemberInfo Member { get; }
 
+        public DateTime CreateDate { get; } = DateTime.UtcNow;
+
         public event EventHandler Failed;
 
         public bool Cancelled { get; private set; }

--- a/src/Hazelcast.Net/Clustering/MemberConnectionRequest.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnectionRequest.cs
@@ -50,7 +50,11 @@ namespace Hazelcast.Clustering
         {
             // trigger before completing
             // (completing can unlock a suspend wait)
-            if (!success) Failed?.Invoke(this, default);
+            if (!success)
+            {
+                Failed?.Invoke(this, default);
+                Failed = null;
+            }
 
             lock (_mutex)
             {

--- a/src/Hazelcast.Net/Core/AsyncQueue.cs
+++ b/src/Hazelcast.Net/Core/AsyncQueue.cs
@@ -35,6 +35,11 @@ namespace Hazelcast.Core
         private bool _completed;
 
         /// <summary>
+        /// (internals for tests only) Gets the count of items in the queue.
+        /// </summary>
+        internal int Count => _items.Count;
+
+        /// <summary>
         /// Tries to write an item to the queue.
         /// </summary>
         /// <param name="item">The item.</param>


### PR DESCRIPTION
During wrapping up of `release/5.1.0` we realized that the Java code in `TcpClientConnectionManager` is testing all clients once every second (see line 340) which means that a member that fails to connect will be retried 1s later. In our own code, the `MemberConnectionQueue` requeues failed members immediately, meaning that if there is only 1 member and it's constantly failing, we'll retry as fast as we can.

This PR adds a special case for failed requests which are "added again". Basically we fire a background task that adds the request back after 1s. That task is cancelled if the whole queue is completed (when the client shuts down) so it's not blocking things. And, the request is put in a special set so that it is canceled if needed.