### PR TITLE
`ReadStringArray` Fixed and Tests Case Enlarged [API-1413]

### DIFF
--- a/src/Hazelcast.Net.Testing/TestUtils.cs
+++ b/src/Hazelcast.Net.Testing/TestUtils.cs
@@ -90,7 +90,8 @@ namespace Hazelcast.Testing
 
         public static string RandomStringWithLength(int length)
         {
-            return RandomString().Substring(0, length);
+            var str = RandomString();
+            return str.Substring(0, length < str.Length ? length : str.Length);
         }
     }
 }

--- a/src/Hazelcast.Net.Testing/TestUtils.cs
+++ b/src/Hazelcast.Net.Testing/TestUtils.cs
@@ -21,10 +21,15 @@ namespace Hazelcast.Testing
     {
         public static T[] RandomArray<T>(Func<T> randFunc, int size = 0)
         {
+            return RandomArray<T>(p => randFunc(), size);
+        }
+
+        public static T[] RandomArray<T>(Func<int, T> randFunc, int size = 0)
+        {
             var array = new T[size == 0 ? RandomProvider.Random.Next(5) + 1 : size];
             for (var i = 0; i < array.Length; i++)
             {
-                array[i] = randFunc();
+                array[i] = randFunc(i);
             }
             return array;
         }
@@ -36,7 +41,7 @@ namespace Hazelcast.Testing
 
         public static byte RandomByte()
         {
-            return (byte) RandomProvider.Random.Next();
+            return (byte)RandomProvider.Random.Next();
         }
 
         public static byte[] RandomBytes()
@@ -48,7 +53,7 @@ namespace Hazelcast.Testing
 
         public static char RandomChar()
         {
-            return (char) RandomProvider.Random.Next(0x1000); // but avoid surrogate pairs!
+            return (char)RandomProvider.Random.Next(0x1000); // but avoid surrogate pairs!
         }
 
         public static double RandomDouble()
@@ -58,7 +63,7 @@ namespace Hazelcast.Testing
 
         public static float RandomFloat()
         {
-            return (float) RandomProvider.Random.NextDouble();
+            return (float)RandomProvider.Random.NextDouble();
         }
 
         public static int RandomInt()
@@ -75,12 +80,17 @@ namespace Hazelcast.Testing
 
         public static short RandomShort()
         {
-            return (short) RandomProvider.Random.Next();
+            return (short)RandomProvider.Random.Next();
         }
 
         public static string RandomString()
         {
             return Guid.NewGuid().ToString();
+        }
+
+        public static string RandomStringWithLength(int length)
+        {
+            return RandomString().Substring(0, length);
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/Serialization/DataInputOutputTest.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/DataInputOutputTest.cs
@@ -23,20 +23,32 @@ namespace Hazelcast.Tests.Serialization
 {
     internal class DataInputOutputTest
     {
-        private static readonly Endianness[] Endiannesses =
+        private static readonly object[] Endiannesses =
         {
-            Endianness.BigEndian,
-            Endianness.LittleEndian,
+            new object[]{Endianness.BigEndian, 0 },
+            new object[]{Endianness.BigEndian, 1 },
+            new object[]{Endianness.BigEndian, 2 },
+            new object[]{Endianness.BigEndian, 3 },
+            new object[]{Endianness.BigEndian, 4 },
+            new object[]{Endianness.BigEndian, 10 },
+
+            new object[]{Endianness.LittleEndian, 0 },
+            new object[]{Endianness.LittleEndian, 1 },
+            new object[]{Endianness.LittleEndian, 2 },
+            new object[]{Endianness.LittleEndian, 3 },
+            new object[]{Endianness.LittleEndian, 4 },
+            new object[]{Endianness.LittleEndian, 10 }
+            
             //Endianness.NativeOrder()
         };
 
         [TestCaseSource(nameof(Endiannesses))]
-        public virtual void TestDataInputOutputWithPortable(Endianness endianness)
+        public virtual void TestDataInputOutputWithPortable(Endianness endianness, int arraySize)
         {
-            var portable = KitchenSinkPortable.Generate();
+            var portable = KitchenSinkPortable.Generate(arraySize);
 
             var config = new SerializationOptions();
-            config.AddPortableFactory(KitchenSinkPortableFactory.FactoryId, typeof (KitchenSinkPortableFactory));
+            config.AddPortableFactory(KitchenSinkPortableFactory.FactoryId, typeof(KitchenSinkPortableFactory));
 
             using var ss = new SerializationServiceBuilder(new NullLoggerFactory()).SetConfig(config)
                 .SetEndianness(endianness).Build();
@@ -52,12 +64,12 @@ namespace Hazelcast.Tests.Serialization
         }
 
         [TestCaseSource(nameof(Endiannesses))]
-        public virtual void TestInputOutputWithPortableReader(Endianness endianness)
+        public virtual void TestInputOutputWithPortableReader(Endianness endianness, int arraySize)
         {
-            var portable = KitchenSinkPortable.Generate();
+            var portable = KitchenSinkPortable.Generate(arraySize);
 
             var config = new SerializationOptions();
-            config.AddPortableFactory(KitchenSinkPortableFactory.FactoryId, typeof (KitchenSinkPortableFactory));
+            config.AddPortableFactory(KitchenSinkPortableFactory.FactoryId, typeof(KitchenSinkPortableFactory));
 
             using var ss = new SerializationServiceBuilder(new NullLoggerFactory()).SetConfig(config)
                 .SetEndianness(endianness).Build();
@@ -72,10 +84,10 @@ namespace Hazelcast.Tests.Serialization
         }
 
         [TestCaseSource(nameof(Endiannesses))]
-        public virtual void TestReadWrite(Endianness endianness)
+        public virtual void TestReadWrite(Endianness endianness, int arraySize)
         {
-            var obj = KitchenSinkDataSerializable.Generate();
-            obj.Serializable = KitchenSinkDataSerializable.Generate();
+            var obj = KitchenSinkDataSerializable.Generate(arraySize);
+            obj.Serializable = KitchenSinkDataSerializable.Generate(arraySize);
 
             using var ss = new SerializationServiceBuilder(new NullLoggerFactory())
                 .AddDataSerializableFactory(1, new ArrayDataSerializableFactory(new Func<IIdentifiedDataSerializable>[]
@@ -106,9 +118,9 @@ namespace Hazelcast.Tests.Serialization
         }
 
         [Test]
-		public void TestNullValue_When_ValueType()
-		{
-			Assert.Throws<SerializationException>(() =>
+        public void TestNullValue_When_ValueType()
+        {
+            Assert.Throws<SerializationException>(() =>
         {
             var ss = new SerializationServiceBuilder(new NullLoggerFactory())
                .Build();
@@ -118,7 +130,7 @@ namespace Hazelcast.Tests.Serialization
 
             var input = ss.CreateObjectDataInput(output.ToByteArray());
             ss.ReadObject<int>(input);
-			});
+        });
         }
 
         [Test]

--- a/src/Hazelcast.Net.Tests/Serialization/DataInputOutputTest.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/DataInputOutputTest.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Tests.Serialization
 {
     internal class DataInputOutputTest
     {
-        private static readonly object[] Endiannesses =
+        private static readonly object[] DataCases =
         {
             new object[]{Endianness.BigEndian, 0 },
             new object[]{Endianness.BigEndian, 1 },
@@ -42,7 +42,7 @@ namespace Hazelcast.Tests.Serialization
             //Endianness.NativeOrder()
         };
 
-        [TestCaseSource(nameof(Endiannesses))]
+        [TestCaseSource(nameof(DataCases))]
         public virtual void TestDataInputOutputWithPortable(Endianness endianness, int arraySize)
         {
             var portable = KitchenSinkPortable.Generate(arraySize);
@@ -63,7 +63,7 @@ namespace Hazelcast.Tests.Serialization
             Assert.AreEqual(portable, readObject);
         }
 
-        [TestCaseSource(nameof(Endiannesses))]
+        [TestCaseSource(nameof(DataCases))]
         public virtual void TestInputOutputWithPortableReader(Endianness endianness, int arraySize)
         {
             var portable = KitchenSinkPortable.Generate(arraySize);
@@ -83,7 +83,7 @@ namespace Hazelcast.Tests.Serialization
             Assert.AreEqual(portable, actual);
         }
 
-        [TestCaseSource(nameof(Endiannesses))]
+        [TestCaseSource(nameof(DataCases))]
         public virtual void TestReadWrite(Endianness endianness, int arraySize)
         {
             var obj = KitchenSinkDataSerializable.Generate(arraySize);

--- a/src/Hazelcast.Net.Tests/Serialization/Objects/KitchenSinkDataSerializable.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Objects/KitchenSinkDataSerializable.cs
@@ -115,39 +115,39 @@ namespace Hazelcast.Tests.Serialization.Objects
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((KitchenSinkDataSerializable) obj);
+            return Equals((KitchenSinkDataSerializable)obj);
         }
 
 
-        public static KitchenSinkDataSerializable Generate()
+        public static KitchenSinkDataSerializable Generate(int arraySize)
         {
             var truncatedDateTime = DateTime.Now;
             // truncate datetime to milliseconds
             truncatedDateTime =
-                new DateTime(truncatedDateTime.Ticks - (truncatedDateTime.Ticks%TimeSpan.TicksPerMillisecond));
+                new DateTime(truncatedDateTime.Ticks - (truncatedDateTime.Ticks % TimeSpan.TicksPerMillisecond));
 
             return new KitchenSinkDataSerializable
             {
                 Bool = TestUtils.RandomBool(),
-                BoolArray = TestUtils.RandomArray(TestUtils.RandomBool),
+                BoolArray = TestUtils.RandomArray(TestUtils.RandomBool, arraySize),
                 Byte = TestUtils.RandomByte(),
                 ByteArray = TestUtils.RandomBytes(),
                 Char = TestUtils.RandomChar(),
                 Double = TestUtils.RandomDouble(),
-                DoubleArray = TestUtils.RandomArray(TestUtils.RandomDouble),
+                DoubleArray = TestUtils.RandomArray(TestUtils.RandomDouble, arraySize),
                 Chars = TestUtils.RandomString(),
-                CharArray = TestUtils.RandomArray(TestUtils.RandomChar),
+                CharArray = TestUtils.RandomArray(TestUtils.RandomChar, arraySize),
                 DateTime = truncatedDateTime,
                 Float = TestUtils.RandomFloat(),
-                FloatArray = TestUtils.RandomArray(TestUtils.RandomFloat),
+                FloatArray = TestUtils.RandomArray(TestUtils.RandomFloat, arraySize),
                 Int = TestUtils.RandomInt(),
-                IntArray = TestUtils.RandomArray(TestUtils.RandomInt),
+                IntArray = TestUtils.RandomArray(TestUtils.RandomInt, arraySize),
                 Long = TestUtils.RandomLong(),
-                LongArray = TestUtils.RandomArray(TestUtils.RandomLong),
+                LongArray = TestUtils.RandomArray(TestUtils.RandomLong, arraySize),
                 Short = TestUtils.RandomShort(),
-                ShortArray = TestUtils.RandomArray(TestUtils.RandomShort),
+                ShortArray = TestUtils.RandomArray(TestUtils.RandomShort, arraySize),
                 String = TestUtils.RandomString(),
-                StringArray = TestUtils.RandomArray(TestUtils.RandomString)
+                StringArray = TestUtils.RandomArray(TestUtils.RandomString, arraySize)
             };
         }
 

--- a/src/Hazelcast.Net.Tests/Serialization/Objects/KitchenSinkPortable.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Objects/KitchenSinkPortable.cs
@@ -96,10 +96,17 @@ namespace Hazelcast.Tests.Serialization.Objects
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((KitchenSinkPortable) obj);
+            return Equals((KitchenSinkPortable)obj);
         }
-
-        public static KitchenSinkPortable Generate()
+             
+        /// <summary>
+        /// Generates a portable object with data. Also used to size strings in the string arrays.        
+        /// n(where 0<n<=len(randomstring)) length of string array will be like["x", "xx", "xxx", ....., "xxx..xxx"].         
+        /// It will allow to test deseriazliser with various size of strings.
+        /// </summary>
+        /// <param name="arraySize">arraySize">Size of for array type fields</param>
+        /// <returns></returns>
+        public static KitchenSinkPortable Generate(int arraySize = 5)
         {
             return new KitchenSinkPortable
             {
@@ -107,20 +114,20 @@ namespace Hazelcast.Tests.Serialization.Objects
                 BoolArray = TestUtils.RandomArray(TestUtils.RandomBool),
                 Byte = TestUtils.RandomByte(),
                 ByteArray = TestUtils.RandomBytes(),
-                Char = (char) Random.Next(),
+                Char = (char)Random.Next(),
                 Double = TestUtils.RandomDouble(),
-                DoubleArray = TestUtils.RandomArray(TestUtils.RandomDouble),
-                CharArray = TestUtils.RandomArray(TestUtils.RandomChar),
+                DoubleArray = TestUtils.RandomArray(TestUtils.RandomDouble, arraySize),
+                CharArray = TestUtils.RandomArray(TestUtils.RandomChar, arraySize),
                 Float = TestUtils.RandomFloat(),
-                FloatArray = TestUtils.RandomArray(TestUtils.RandomFloat),
+                FloatArray = TestUtils.RandomArray(TestUtils.RandomFloat, arraySize),
                 Int = TestUtils.RandomInt(),
-                IntArray = TestUtils.RandomArray(TestUtils.RandomInt),
+                IntArray = TestUtils.RandomArray(TestUtils.RandomInt, arraySize),
                 Long = TestUtils.RandomLong(),
-                LongArray = TestUtils.RandomArray(TestUtils.RandomLong),
+                LongArray = TestUtils.RandomArray(TestUtils.RandomLong, arraySize),
                 Short = TestUtils.RandomShort(),
-                ShortArray = TestUtils.RandomArray(TestUtils.RandomShort),
+                ShortArray = TestUtils.RandomArray(TestUtils.RandomShort, arraySize),
                 String = TestUtils.RandomString(),
-                StringArray = TestUtils.RandomArray(TestUtils.RandomString)
+                StringArray = TestUtils.RandomArray(TestUtils.RandomStringWithLength, arraySize)
             };
         }
 

--- a/src/Hazelcast.Net/Serialization/ObjectDataInput.api.cs
+++ b/src/Hazelcast.Net/Serialization/ObjectDataInput.api.cs
@@ -43,7 +43,7 @@ namespace Hazelcast.Serialization
             CheckAvailable(Position, BytesExtensions.SizeOfByte);
             var value = _buffer.ReadSByte(Position);
             Position += BytesExtensions.SizeOfByte;
-            return (sbyte) value;
+            return (sbyte)value;
         }
 
         public char ReadChar()
@@ -255,7 +255,8 @@ namespace Hazelcast.Serialization
             if (length == BytesExtensions.SizeOfNullArray) return null;
             if (length <= 0) return Array.Empty<string>();
 
-            CheckAvailable(Position, length * BytesExtensions.SizeOfDouble);
+            //A UTF8 string is at least 1 byte.
+            CheckAvailable(Position, length * BytesExtensions.SizeOfByte);
 
             var values = new string[length];
             for (var i = 0; i < length; i++)

--- a/src/Hazelcast.Net/Serialization/ObjectDataInput.api.cs
+++ b/src/Hazelcast.Net/Serialization/ObjectDataInput.api.cs
@@ -255,9 +255,6 @@ namespace Hazelcast.Serialization
             if (length == BytesExtensions.SizeOfNullArray) return null;
             if (length <= 0) return Array.Empty<string>();
 
-            //A UTF8 string is at least 1 byte.
-            CheckAvailable(Position, length * BytesExtensions.SizeOfByte);
-
             var values = new string[length];
             for (var i = 0; i < length; i++)
             {


### PR DESCRIPTION
**Problem:**
`ReadStringArray` was only reading if the total size of array is larger than 16 bytes which was not work for the strings that are shorter than 16 bytes. 

**Solution:**
Size of a UTF8 character could be 1 to 4 bytes, so I changed the size checking to 1 byte. Also, added various test cases. There are test cases that covers 0,1,2,3,4 and 10 length of arrays. Also, string arrays will be produced with different size of strings.

```
String arrays will be like;
["x"]
["x", "xx"]
["x", "xx", "xxx"]
["x", "xx", "xxx", "xxxx"]
["x", "xx", "xxx", "xxxx", ..., "xx....xxx"]
```