### PR TITLE
Backport Fixes of Known Issues on 5.0.3 [API-1449]

### DIFF
--- a/src/Hazelcast.Net.Testing/MultiMembersRemoteTestBase.cs
+++ b/src/Hazelcast.Net.Testing/MultiMembersRemoteTestBase.cs
@@ -60,6 +60,20 @@ namespace Hazelcast.Testing
         }
 
         /// <summary>
+        /// Shutdowns a member from the cluster.
+        /// </summary>
+        /// <param name="memberId">The identifier of the member to remove.</param>
+        /// <returns>A task that will complete when the member has been shutdown.</returns>
+        protected async Task ShutdownMember(Guid memberId)
+        {
+            if (RcMembers.TryRemove(memberId, out var member))
+            {
+                await RcClient.ShutdownMemberAsync(RcCluster.Id, member.Uuid);
+            }
+        }
+
+
+        /// <summary>
         /// Gets the remote members.
         /// </summary>
         protected ConcurrentDictionary<Guid, Member> RcMembers { get; } = new ConcurrentDictionary<Guid, Member>();

--- a/src/Hazelcast.Net.Tests/Clustering/RetryStrategyTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/RetryStrategyTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Hazelcast.Clustering;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Hazelcast.Tests.Clustering
+{
+    [TestFixture]
+    public class RetryStrategyTests
+    {
+        [Test]
+        public void TestDelayWithTimeout()
+        {
+            var retry = new RetryStrategy("test", 1_000, 30_000, 1, 60_000, 0, new NullLoggerFactory());
+
+            Assert.That(retry.GetDelay(1_000), Is.EqualTo(1_000));
+            Assert.That(retry.GetDelay(2_000), Is.EqualTo(1_000));
+
+            Assert.That(retry.GetDelay(59_000), Is.EqualTo(1_000));
+            Assert.That(retry.GetDelay(59_500), Is.EqualTo(500)); // almost timeout
+            Assert.That(retry.GetDelay(60_000), Is.EqualTo(0)); // timeout
+
+            // elapsed cannot be > timeout - but just in case
+            Assert.That(retry.GetDelay(80_000), Is.EqualTo(0)); 
+        }
+
+        [Test]
+        public void TestDelayInfiniteTimeout()
+        {
+            var retry = new RetryStrategy("test", 1_000, 30_000, 1, -1, 0, new NullLoggerFactory());
+
+            Assert.That(retry.GetDelay(1_000), Is.EqualTo(1_000));
+            Assert.That(retry.GetDelay(2_000), Is.EqualTo(1_000));
+
+            Assert.That(retry.GetDelay(int.MaxValue), Is.EqualTo(1_000)); // no timeout
+        }
+
+        [Test]
+        public void TestDelayJitter()
+        {
+            var retry0 = new RetryStrategy("test", 1_000, 30_000, 1, 60_000, 0, new NullLoggerFactory());
+            Assert.That(retry0.GetDelay(1_000), Is.EqualTo(1_000));
+
+            var retry1 = new RetryStrategy("test", 1_000, 30_000, 1, 60_000, 1, new NullLoggerFactory());
+            const int count = 100;
+            var min = int.MaxValue;
+            var max = int.MinValue;
+            for (var i = 0; i < count; i++)
+            {
+                var delay = retry1.GetDelay(1_000);
+                if (min > delay) min = delay;
+                if (max < delay) max = delay;
+            }
+            Assert.That(min, Is.LessThan(1_000)); // some values were lower than initial
+            Assert.That(max, Is.GreaterThan(1_000)); // some values were greater than initial
+        }
+
+        [TestCase(1_000, 1, 1_000)]
+        [TestCase(1_000, 2, 2_000)]
+        [TestCase(8_000, 2, 16_000)]
+        [TestCase(16_000, 2, 30_000)] // max!
+        public void TestBackoff(int initial, int multiplier, int expected)
+        {
+            var retry = new RetryStrategy("test", initial, 30_000, multiplier, 60_000, 0, new NullLoggerFactory());
+
+            Assert.That(retry.GetNewBackoff(), Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/Hazelcast.Net.Tests/Remote/UnisocketTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/UnisocketTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hazelcast.Core;
+using Hazelcast.Testing;
+using NUnit.Framework;
+
+namespace Hazelcast.Tests.Remote
+{
+    public class UnisocketTests : MultiMembersRemoteTestBase
+    {
+        [TearDown]
+        public async Task RemoveAllMembers()
+        {
+            foreach (var member in RcMembers)
+            {
+                await ShutdownMember(member.Key);
+            }
+        }
+        /// <summary>
+        /// Port of testClientListener_withDummyClient
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task TestEventsWithDummyClient()
+        {
+            var memberA = await AddMember();
+            int eventCount = 0;
+
+            var client = await CreateAndStartClientAsync(opt =>
+             {
+                 opt.Networking.SmartRouting = false;
+                 opt.AddSubscriber(events => events.StateChanged((sender, args) =>
+                 {
+                     HConsole.WriteLine(this, args.State);
+                     if (args.State == ClientState.Connected || args.State == ClientState.Shutdown)
+                         eventCount++;
+                 }));
+             });
+
+            await client.DisposeAsync();
+
+            Assert.AreEqual(2, eventCount);
+        }
+
+        [Test]
+        public async Task TestDistributedObjectEventsWithDummyClient()
+        {
+            var memberA = await AddMember();
+            var memberB = await AddMember();
+
+            int eventCount = 0;
+
+            var client = await CreateAndStartClientAsync(opt =>
+            {
+                opt.Networking.SmartRouting = false;
+            });
+
+            var map = await client.GetMapAsync<int, int>("myMap");
+            await map.SubscribeAsync(events => events.EntryAdded((sender, args) => { eventCount++; }));
+
+            await ShutdownMember(Guid.Parse(memberA.Uuid));
+            memberA = await AddMember();
+
+            await AssertEx.SucceedsEventually(async () =>
+            {
+                var script = "instance_0.getMap(\"myMap\").put(1,1)";
+                var response = await RcClient.ExecuteOnControllerAsync(RcCluster.Id, script, Hazelcast.Testing.Remote.Lang.JAVASCRIPT);
+                Assert.GreaterOrEqual(1, eventCount);
+            }, 10_000, 500);
+        }
+
+        /// <summary>
+        /// Port of testMemberConnectionOrder
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task TestClientConnectsToOneMember()
+        {
+            var memberA = await AddMember();
+            var memberB = await AddMember();
+
+            var client = await CreateAndStartClientAsync(opt =>
+            {
+                opt.Networking.SmartRouting = false;
+                opt.Networking.ShuffleAddresses = false;
+                opt.Networking.Addresses.Clear();
+                opt.Networking.Addresses.Add(memberA.Host + ":" + memberA.Port);
+                opt.Networking.Addresses.Add(memberB.Host + ":" + memberB.Port);
+            });
+
+            var map = await client.GetMapAsync<int, int>("oneMemberMap");
+            for (int i = 0; i < 100; i++)
+            {
+                await map.PutAsync(i, i);
+            }
+
+            var script = "result = instance_1.getClientService().getConnectedClients().size().toString();";
+            var response = await RcClient.ExecuteOnControllerAsync(RcCluster.Id, script, Hazelcast.Testing.Remote.Lang.JAVASCRIPT);
+
+            var countOfClients = int.Parse(Encoding.UTF8.GetString(response.Result));
+
+            // instance1 shouldn't have any clients due to unisocket mode
+            script = "result = instance_0.getClientService().getConnectedClients().size().toString();";
+            response = await RcClient.ExecuteOnControllerAsync(RcCluster.Id, script, Hazelcast.Testing.Remote.Lang.JAVASCRIPT);
+            countOfClients += int.Parse(Encoding.UTF8.GetString(response.Result));
+
+            //sum should be 1 since don't know which member is connected to
+            Assert.AreEqual(1, countOfClients);
+        }
+
+    }
+}

--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -287,7 +287,7 @@ namespace Hazelcast.Clustering
         /// <param name="connection">The connection.</param>
         private async ValueTask OnConnectionClosed(MemberConnection connection)
         {
-            _logger.IfDebug()?.LogDebug($"Connection {connection.Id.ToShortString()} to member {connection.MemberId.ToShortString()} at {connection.Address} closed.");
+            _logger.If(LogLevel.Information)?.LogInformation("Connection {ConnectionId} to member {MemberId} at {Address} closed.", connection.Id.ToShortString(), connection.MemberId.ToShortString(), connection.Address);
 
             TaskCompletionSource<object> connectCompletion;
             lock (_mutex)

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -262,7 +262,6 @@ namespace Hazelcast.Clustering
                 if (!disconnecting)
                 {
                     _logger.IfDebug()?.LogDebug($"Removed connection {connection.Id.ToShortString()} to member {connection.MemberId.ToShortString()}, remain {(_connected ? "" : "dis")}connected.");
-
                     // if we are connected,
                     // and the disconnected member is still a member, queue it for reconnection
                     if (_connected && _members.TryGetMember(connection.MemberId, out var member))
@@ -323,6 +322,7 @@ namespace Hazelcast.Clustering
 
         private void LogDiffs(MemberTable table, Dictionary<MemberInfo, int> diff)
         {
+            var countOfUnchanged = 0;
             var msg = new StringBuilder();
             msg.Append("Members [");
             msg.Append(table.Count);
@@ -331,20 +331,33 @@ namespace Hazelcast.Clustering
             {
                 msg.Append("    ");
                 msg.Append(m.ToShortString(true));
-                var status = d switch
+                string status;
+                switch (d)
                 {
-                    1 => "Removing",
-                    2 => "Adding",
-                    3 => "Unchanged",
-                    _ => ""
-                };
+                    case 1:
+                        status = "Removing";
+                        break;
+                    case 2:
+                        status = "Adding";
+                        break;
+                    case 3:
+                        status = "Unchanged";
+                        countOfUnchanged++;
+                        break;
+                    default:
+                        status = "";
+                        break;
+                }
+
                 msg.Append(' ');
                 msg.Append(status);
                 msg.AppendLine();
             }
             msg.Append('}');
 
-            _logger.LogInformation(msg.ToString());
+            //Print only if there is a change
+            if (countOfUnchanged != diff.Count)
+                _logger.LogInformation(msg.ToString());
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -89,9 +89,49 @@ namespace Hazelcast.Clustering
         }
 
         // NOTES
-        // we cannot have two connections to the same member ID at the same time, but a member IP may change,
-        // so having a connection to a member ID does not mean that the member is connected, and we may have
-        // to switch a member's connection over to a new IP
+        //
+        // - we cannot have two connections to the same member ID at the same time, the AddConnection
+        //   method makes sure that a second connection to the same member ID is either rejected, or
+        //   replaces the existing one (depending on conditions).
+        //
+        // - a member can be associated with 3 addresses:
+        //  - the address that we connected to
+        //  - the address that was reported by the member when we connected to it
+        //  - the address that was associated with the member in the members list
+        //
+        // we have always ignored the second address (as Java does) - we used to ignore the third
+        // address too (as Java does) BUT this means that if we connect to a cluster via a load-
+        // balancer, as is proposed in some k8s examples, traffic keeps going through the load-
+        // balancer - and this is not ideal - so we implemented the following logic:
+        //
+        // - each member exposes a ConnectAddress which derives from the members list, and is the
+        //   address that we assume the member wants us to connect to
+        // - when we connect to a member at an address, and then later on receive a member list
+        //   proposing a *different* address for the member, we terminate the original connection,
+        //   triggering the reconnection mechanism to the member's ConnectAddress
+        //
+        // however, this breaks non-smart routing, as the reconnection mechanism does NOT activate
+        // when routing is not smart : when the original connection is terminated, the client remains
+        // disconnected.
+        //
+        // a general discussion is needed as to which address to use for members, in all clients.
+        // however, in the short term, we need to fix non-smart routing, with two possible choices:
+        // - run the reconnection mechanism for non-smart routing
+        // - make the address-switching logic optional & disabled for non-smart routing
+        //
+        // the first option may have unintended consequences, whereas the second "just" brings back
+        // the old logic for non-smart routing -> we choose the second option and implement a
+        // switch feature in MatchMemberAddress
+
+        // see notes above, determines whether to match members addresses
+        // - we want to match for smart routing
+        // - and also for Cloud?
+        private bool MatchMemberAddress
+            => _clusterState.Options.Networking.SmartRouting || _clusterState.Options.Networking.Cloud.Enabled;
+
+        // see notes above, if matching then addresses must match, else anything matches
+        private bool IsMemberAddress(MemberInfo member, NetworkAddress address)
+            => !MatchMemberAddress || member.ConnectAddress == address;
 
         // determines whether a member is connected.
         private bool IsMemberConnected(MemberInfo member)
@@ -108,8 +148,8 @@ namespace Hazelcast.Clustering
         }
 
         private bool HasConnectionForMemberLocked(MemberInfo member)
-            => _connections.TryGetValue(member.Id, out var connection) &&
-               connection.Address == member.ConnectAddress;
+            => _connections.TryGetValue(member.Id, out var connection) && 
+               IsMemberAddress(member, connection.Address);
 
         // determines whether we have a connection for a member
         private bool HasConnectionForMember(MemberInfo member)
@@ -144,7 +184,7 @@ namespace Hazelcast.Clustering
 
                 if (contains)
                 {
-                    if (existingConnection.Address != connection.Address)
+                    if (MatchMemberAddress && existingConnection.Address != connection.Address)
                     {
                         _terminateConnections.Add(existingConnection);
                     }
@@ -170,7 +210,7 @@ namespace Hazelcast.Clustering
                 }
 
                 // if this is a true member connection
-                if (_members.TryGetMember(connection.MemberId, out var member) && member.ConnectAddress == connection.Address)
+                if (_members.TryGetMember(connection.MemberId, out var member) && IsMemberAddress(member, connection.Address))
                 {
                     // if this is the first connection to an actual member, change state & trigger event
                     if (!_connected)
@@ -221,7 +261,7 @@ namespace Hazelcast.Clustering
                 // if we are not disconnecting, we can return - we are done
                 if (!disconnecting)
                 {
-                    _logger.LogDebug($"Removed connection {connection.Id.ToShortString()} to member {connection.MemberId.ToShortString()}, remain {(_connected?"":"dis")}connected.");
+                    _logger.IfDebug()?.LogDebug($"Removed connection {connection.Id.ToShortString()} to member {connection.MemberId.ToShortString()}, remain {(_connected ? "" : "dis")}connected.");
 
                     // if we are connected,
                     // and the disconnected member is still a member, queue it for reconnection
@@ -436,7 +476,7 @@ namespace Hazelcast.Clustering
                 List<MemberConnection> toRemove = null;
                 foreach (var c in _connections.Values)
                 {
-                    if (!d.TryGetValue(c.MemberId, out var m) || m.ConnectAddress != c.Address)
+                    if (!d.TryGetValue(c.MemberId, out var m) || !IsMemberAddress(m, c.Address))
                         (toRemove ??= new List<MemberConnection>()).Add(c);
                 }
 
@@ -757,7 +797,9 @@ namespace Hazelcast.Clustering
         /// <inheritdoc />
         public async ValueTask DisposeAsync()
         {
-            await _memberConnectionQueue.DisposeAsync().CfAwait();
+            // no connection queue is assigned in unisocket mode
+            if (_memberConnectionQueue != null)
+                await _memberConnectionQueue.DisposeAsync().CfAwait();
         }
     }
 }

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -77,12 +77,12 @@ namespace Hazelcast.Clustering
                 // initialize the queue of members to connect
                 // and the handler to re-queue members that have failed, *if* they are still members
                 _memberConnectionQueue = new MemberConnectionQueue(clusterState.LoggerFactory);
-                _memberConnectionQueue.ConnectionFailed += (_, member) =>
+                _memberConnectionQueue.ConnectionFailed += (_, request) =>
                 {
                     lock (_mutex)
                     {
-                        if (_members.ContainsMember(member.Id))
-                            _memberConnectionQueue.Add(member);
+                        if (_members.ContainsMember(request.Member.Id))
+                            _memberConnectionQueue.AddAgain(request);
                     }
                 };
             }

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -85,6 +85,7 @@ namespace Hazelcast.Clustering
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = loggerFactory.CreateLogger<MemberConnection>();
 
+            MemberAddress = address; // may change after connection is established.
             HConsole.Configure(x => x.Configure<MemberConnection>().SetIndent(4).SetPrefix("MBR.CONN"));
         }
 
@@ -144,6 +145,11 @@ namespace Hazelcast.Clustering
         /// Gets the network address the client is connected to.
         /// </summary>
         public NetworkAddress Address { get; }
+
+        /// <summary>
+        /// Gets the network address reported by the member.
+        /// </summary>
+        public NetworkAddress MemberAddress { get; private set; }
 
         /// <summary>
         /// Gets the local endpoint of the socket connection.
@@ -219,6 +225,7 @@ namespace Hazelcast.Clustering
             ClusterId = result.ClusterId;
             ConnectTime = DateTimeOffset.Now;
             Principal = result.Principal;
+            MemberAddress = result.MemberAddress;
 
             bool disposed;
             lock (_mutex)

--- a/src/Hazelcast.Net/Clustering/MemberConnectionRequest.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnectionRequest.cs
@@ -22,18 +22,17 @@ namespace Hazelcast.Clustering
     {
         private readonly object _mutex = new object();
         private TaskCompletionSource<object> _completionSource;
+        private DateTime _requestDate;
 
         public MemberConnectionRequest(MemberInfo member)
         {
             Member = member;
-            Cancelled = false;
-            Completed = false;
-            _completionSource = null;
+            Reset();
         }
 
         public MemberInfo Member { get; }
 
-        public DateTime CreateDate { get; } = DateTime.UtcNow;
+        public TimeSpan Elapsed => DateTime.UtcNow - _requestDate;
 
         public event EventHandler Failed;
 
@@ -53,7 +52,6 @@ namespace Hazelcast.Clustering
             if (!success)
             {
                 Failed?.Invoke(this, default);
-                Failed = null;
             }
 
             lock (_mutex)
@@ -74,6 +72,15 @@ namespace Hazelcast.Clustering
                 }
                 return new ValueTask(_completionSource.Task);
             }
+        }
+
+        public void Reset()
+        {
+            Cancelled = false;
+            Completed = false;
+            Failed = null;
+            _completionSource = null;
+            _requestDate = DateTime.UtcNow;
         }
 
         /// <inheritdoc />

--- a/src/Hazelcast.Net/Clustering/MemberConnectionRequest.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnectionRequest.cs
@@ -33,6 +33,8 @@ namespace Hazelcast.Clustering
 
         public MemberInfo Member { get; }
 
+        public DateTime CreateDate { get; } = DateTime.UtcNow;
+
         public event EventHandler Failed;
 
         public bool Cancelled { get; private set; }
@@ -48,7 +50,11 @@ namespace Hazelcast.Clustering
         {
             // trigger before completing
             // (completing can unlock a suspend wait)
-            if (!success) Failed?.Invoke(this, default);
+            if (!success)
+            {
+                Failed?.Invoke(this, default);
+                Failed = null;
+            }
 
             lock (_mutex)
             {

--- a/src/Hazelcast.Net/Clustering/RetryStrategy.cs
+++ b/src/Hazelcast.Net/Clustering/RetryStrategy.cs
@@ -34,9 +34,7 @@ namespace Hazelcast.Clustering
         private readonly double _jitter;
         private readonly string _action;
         private readonly ILogger _logger;
-
-        private readonly int _initialBackoffMilliseconds;
-        private readonly int _maxBackoffMilliseconds;
+        
         private int _currentBackOffMilliseconds;
         private int _attempts;
         private DateTime _begin;
@@ -75,9 +73,9 @@ namespace Hazelcast.Clustering
 #pragma warning restore CA1308
 
             if (initialBackOffMilliseconds < 0) throw new ConfigurationException("Initial back-off must be greater than or equal to zero.");
-            _initialBackoffMilliseconds = initialBackOffMilliseconds;
+            _initialBackOffMilliseconds = initialBackOffMilliseconds;
             if (maxBackOffMilliseconds < 0) throw new ConfigurationException("Maximum back-off must be greater than or equal to zero.");
-            _maxBackoffMilliseconds = maxBackOffMilliseconds;
+            _maxBackOffMilliseconds = maxBackOffMilliseconds;
             if (multiplier <= 0) throw new ConfigurationException("Multiplier must be greater than zero.");
             _multiplier = multiplier;
             _timeoutMilliseconds = timeoutMilliseconds;
@@ -111,7 +109,7 @@ namespace Hazelcast.Clustering
         /// </summary>
         internal int GetNewBackoff()
         {
-            return (int)Math.Min(_currentBackOffMilliseconds * _multiplier, _maxBackoffMilliseconds);
+            return (int)Math.Min(_currentBackOffMilliseconds * _multiplier, _maxBackOffMilliseconds);
         }
 
         /// <inheritdoc />

--- a/src/Hazelcast.Net/Core/AsyncQueue.cs
+++ b/src/Hazelcast.Net/Core/AsyncQueue.cs
@@ -35,6 +35,11 @@ namespace Hazelcast.Core
         private bool _completed;
 
         /// <summary>
+        /// (internals for tests only) Gets the count of items in the queue.
+        /// </summary>
+        internal int Count => _items.Count;
+
+        /// <summary>
         /// Tries to write an item to the queue.
         /// </summary>
         /// <param name="item">The item.</param>


### PR DESCRIPTION
All fixes that are known for `5.0.3` are backported.

- Unisocket (non-smart-routing) mode is known to be unreliable (https://github.com/hazelcast/hazelcast-csharp-client/issues/595)
- Retry Strategy Period Calculation(https://github.com/hazelcast/hazelcast-csharp-client/issues/657)
- Delay on Member Reconnection (https://github.com/hazelcast/hazelcast-csharp-client/issues/658)
- Member list logging is too verbose (https://github.com/hazelcast/hazelcast-csharp-client/issues/596)