### PR TITLE
[compact-6] Fix critical issue in ObjectDataOutput

### DIFF
--- a/src/Hazelcast.Net/Serialization/ObjectDataOutput.cs
+++ b/src/Hazelcast.Net/Serialization/ObjectDataOutput.cs
@@ -98,12 +98,14 @@ namespace Hazelcast.Serialization
 
         internal void EnsureAvailable(int count)
         {
+            // TODO - input/output should work with memory and span and not copy arrays
+
             if (_buffer != null)
             {
                 if (_buffer.Length - Position >= count) return;
                 var newCap = Math.Max(_buffer.Length << 1, _buffer.Length + count);
                 var newBuffer = new byte[newCap];
-                System.Buffer.BlockCopy(_buffer, 0, newBuffer, 0, Position);
+                System.Buffer.BlockCopy(_buffer, 0, newBuffer, 0, _buffer.Length);
                 _buffer = newBuffer;
             }
             else


### PR DESCRIPTION
This fixes a very small but kinda critical issue in `ObjectDataOutput` that only revealed when implementing compact - where we would block-copy a buffer using a wrong length. 1-line fix.