### PR TITLE
[compact 5] Upgrade to C# 9 [API-971]

### DIFF
--- a/src/Hazelcast.Net/Polyfills/IsExternalInit.cs
+++ b/src/Hazelcast.Net/Polyfills/IsExternalInit.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#nullable enable
+
+using System.ComponentModel;
+
+// this is required to get the C# 9 'init' setter to work in pre .NET 5 code
+// note: it *must* be defined for *all* TFM and not #if-restricted to pre .NET 5
+// https://stackoverflow.com/questions/64749385/predefined-type-system-runtime-compilerservices-isexternalinit-is-not-defined
+// https://stackoverflow.com/questions/62648189/testing-c-sharp-9-0-in-vs2019-cs0518-isexternalinit-is-not-defined-or-imported
+
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    { }
+}


### PR DESCRIPTION
In preparation for compact serialization, we upgrade our C# language version to version 9 (current latest version being 10). This will allow us to simplify how we handle generic constraints in some situations. This is purely a client code level thing and has no impact on the resulting code that we ship or on people using our client.