### PR TITLE
[compact 9] Serialization - Introduce IRead/WriteObjectsFrom/ToObjectDataInput/Output [API-971]

### DIFF
--- a/src/Hazelcast.Net/Core/TypeExtensions.cs
+++ b/src/Hazelcast.Net/Core/TypeExtensions.cs
@@ -80,6 +80,27 @@ namespace Hazelcast.Core
         }
 
         /// <summary>
+        /// Determines whether this type is a <see cref="Nullable{T}"/> type.
+        /// </summary>
+        /// <param name="type">This type.</param>
+        /// <param name="underlyingType">The underlying type, if the type is nullable.</param>
+        /// <returns><c>true</c> if this type is a <see cref="Nullable{T}"/> type; otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">This <paramref name="type"/> is <c>null</c>.</exception>
+        public static bool IsNullableOfT(this Type type, out Type underlyingType)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof (Nullable<>))
+            {
+                underlyingType = type.GetGenericArguments()[0];
+                return true;
+            }
+
+            underlyingType = null;
+            return false;
+        }
+
+        /// <summary>
         /// Determines whether this type is nullable, i.e. when it supports <c>null</c> value.
         /// </summary>
         /// <param name="type">This type.</param>
@@ -162,10 +183,10 @@ namespace Hazelcast.Core
             { "System.Decimal", "decimal" }
         };
 
-        public static T MustBe<T>(this object obj)
+        public static T MustBe<T>(this object obj, string name = null)
         {
             if (obj is T t) return t;
-            throw new ArgumentException($"Object is not of type {typeof(T)}.", nameof(obj));
+            throw new ArgumentException($"Argument '{name ?? nameof(obj)}' is not of type {typeof(T)}.", name ?? nameof(obj));
         }
     }
 }

--- a/src/Hazelcast.Net/Serialization/IReadObjectsFromObjectDataInput.cs
+++ b/src/Hazelcast.Net/Serialization/IReadObjectsFromObjectDataInput.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Hazelcast.Serialization
+{
+    /// <summary>
+    /// Defines a service that can read objects from an <see cref="IObjectDataInput"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>This interface exists so that we don't have to pass the full serializers
+    /// in places where reading and writing objects is all we need, in order to reduce
+    /// the dependency surface and simplify implementation of tests.</para>
+    /// </remarks>
+    internal interface IReadObjectsFromObjectDataInput
+    {
+        /// <summary>
+        /// Reads an object.
+        /// </summary>
+        T Read<T>(IObjectDataInput input);
+
+        /// <summary>
+        /// Reads an object.
+        /// </summary>
+        object Read(IObjectDataInput input, Type type);
+    }
+}

--- a/src/Hazelcast.Net/Serialization/IWriteObjectsToObjectDataOutput.cs
+++ b/src/Hazelcast.Net/Serialization/IWriteObjectsToObjectDataOutput.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Hazelcast.Serialization
+{
+    /// <summary>
+    /// Defines a service that can write objects to an <see cref="IObjectDataOutput"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>This interface exists so that we don't have to pass the full serializers
+    /// in places where reading and writing objects is all we need, in order to reduce
+    /// the dependency surface and simplify implementation of tests.</para>
+    /// </remarks>
+    internal interface IWriteObjectsToObjectDataOutput
+    {
+        /// <summary>
+        /// Writes an object.
+        /// </summary>
+        void Write(IObjectDataOutput output, object obj);
+    }
+}

--- a/src/Hazelcast.Net/Serialization/ObjectDataInput.api.cs
+++ b/src/Hazelcast.Net/Serialization/ObjectDataInput.api.cs
@@ -275,7 +275,7 @@ namespace Hazelcast.Serialization
             return values;
         }
 
-        public T ReadObject<T>() => _serializationService.ReadObject<T>(this);
+        public T ReadObject<T>() => _objectsReader.Read<T>(this);
 
         public int Read(byte[] bytes)
         {

--- a/src/Hazelcast.Net/Serialization/ObjectDataInput.cs
+++ b/src/Hazelcast.Net/Serialization/ObjectDataInput.cs
@@ -22,13 +22,13 @@ namespace Hazelcast.Serialization
     internal partial class ObjectDataInput : IObjectDataInput, IDisposable
     {
         private byte[] _buffer;
-        private readonly SerializationService _serializationService;
+        private readonly IReadObjectsFromObjectDataInput _objectsReader;
         private int _length;
 
-        public ObjectDataInput(byte[] buffer, SerializationService serializationService, Endianness endianness, int offset = 0)
+        public ObjectDataInput(byte[] buffer, IReadObjectsFromObjectDataInput objectsReaderWriter, Endianness endianness, int offset = 0)
         {
             _buffer = buffer;
-            _serializationService = serializationService;
+            _objectsReader = objectsReaderWriter;
             Endianness = endianness;
             _length = buffer?.Length ?? 0;
             Debug.Assert(offset >= 0 && offset <= _length, "Wrong offset value for input");
@@ -38,7 +38,7 @@ namespace Hazelcast.Serialization
         /// <summary>
         /// Initializes the buffer.
         /// </summary>
-        /// <param name="data">The buffer data.</param>
+        /// <param name="buffer">The buffer data.</param>
         /// <param name="offset">The buffer data offset.</param>
         public void Initialize(byte[] buffer, int offset)
         {

--- a/src/Hazelcast.Net/Serialization/ObjectDataOutput.api.cs
+++ b/src/Hazelcast.Net/Serialization/ObjectDataOutput.api.cs
@@ -254,7 +254,7 @@ namespace Hazelcast.Serialization
 
         public void WriteObject(object value)
         {
-            _serializationService.Write(this, value);
+            _objectsWriter.Write(this, value);
         }
 
         public void Write(byte[] bytes)

--- a/src/Hazelcast.Net/Serialization/ObjectDataOutput.cs
+++ b/src/Hazelcast.Net/Serialization/ObjectDataOutput.cs
@@ -20,15 +20,15 @@ namespace Hazelcast.Serialization
     internal partial class ObjectDataOutput : IObjectDataOutput, IDisposable
     {
         private readonly int _initialBufferSize;
-        private readonly SerializationService _serializationService;
+        private readonly IWriteObjectsToObjectDataOutput _objectsWriter;
         private byte[] _buffer;
         private int _position;
 
-        internal ObjectDataOutput(int initialBufferSize, SerializationService serializationService, Endianness endianness)
+        internal ObjectDataOutput(int initialBufferSize, IWriteObjectsToObjectDataOutput objectsReaderWriter, Endianness endianness)
         {
             _initialBufferSize = initialBufferSize;
             _buffer = new byte[_initialBufferSize];
-            _serializationService = serializationService;
+            _objectsWriter = objectsReaderWriter;
             Endianness = endianness;
         }
 

--- a/src/Hazelcast.Net/Serialization/SerializationService.cs
+++ b/src/Hazelcast.Net/Serialization/SerializationService.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Hazelcast.Serialization
 {
-    internal sealed partial class SerializationService : IDisposable
+    internal sealed partial class SerializationService : IDisposable, IReadObjectsFromObjectDataInput, IWriteObjectsToObjectDataOutput
     {
         public const byte SerializerVersion = 1;
         private const int ConstantSerializersCount = SerializationConstants.ConstantSerializersArraySize;


### PR DESCRIPTION
Abstract the capability of reading & writing objects to `ObjectDataOutput` and from `ObjectDataInput` in an interface that can easily be mocked in tests.