### PR TITLE
Overloads for SQL Execute with `params` option

### DIFF
--- a/src/Hazelcast.Net/Sql/ISqlService.cs
+++ b/src/Hazelcast.Net/Sql/ISqlService.cs
@@ -37,6 +37,20 @@ namespace Hazelcast.Sql
         Task<ISqlQueryResult> ExecuteQueryAsync(string sql, object[] parameters = null, SqlStatementOptions options = null, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Executes a SQL query.
+        /// </summary>
+        /// <param name="sql">The SQL query text to execute.</param>        
+        /// <param name="options">Options for the SQL query (defaults to <see cref="SqlStatementOptions.Default"/>).</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <param name="parameters">Parameters for the SQL query.</param>
+        /// <returns>An <see cref="ISqlQueryResult"/> instance that represents the result of the query.</returns>
+        /// <remarks>
+        /// <para>The <paramref name="sql"/> query text can contain parameter placeholders, specified via a '?' character. Each
+        /// occurrence of the '?' character is replaced by the next parameter from the <paramref name="parameters"/> ordered list.</para>
+        /// </remarks>
+        Task<ISqlQueryResult> ExecuteQueryAsync(string sql, SqlStatementOptions options = null, CancellationToken cancellationToken = default, params object[] parameters);
+
+        /// <summary>
         /// Executes a SQL command.
         /// </summary>
         /// <param name="sql">The SQL command text to execute.</param>
@@ -49,5 +63,19 @@ namespace Hazelcast.Sql
         /// occurrence of the '?' character is replaced by the next parameter from the <paramref name="parameters"/> ordered list.</para>
         /// </remarks>
         Task<long> ExecuteCommandAsync(string sql, object[] parameters = null, SqlStatementOptions options = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a SQL command.
+        /// </summary>
+        /// <param name="sql">The SQL command text to execute.</param>        
+        /// <param name="options">Options for the SQL command (defaults to <see cref="SqlStatementOptions.Default"/>).</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <param name="parameters">Parameters for the SQL command.</param>
+        /// <returns>The number of rows affected byt the command.</returns>
+        /// <remarks>
+        /// <para>The <paramref name="sql"/> query text can contain parameter placeholders, specified via a '?' character. Each
+        /// occurrence of the '?' character is replaced by the next parameter from the <paramref name="parameters"/> ordered list.</para>
+        /// </remarks>
+        Task<long> ExecuteCommandAsync(string sql, SqlStatementOptions options = null, CancellationToken cancellationToken = default, params object[] parameters);
     }
 }

--- a/src/Hazelcast.Net/Sql/SqlService.cs
+++ b/src/Hazelcast.Net/Sql/SqlService.cs
@@ -61,6 +61,12 @@ namespace Hazelcast.Sql
         }
 
         /// <inheritdoc/>
+        public Task<ISqlQueryResult> ExecuteQueryAsync(string sql, SqlStatementOptions options = null, CancellationToken cancellationToken = default, params object[] parameters)
+        {
+            return ExecuteQueryAsync(sql, parameters, options, cancellationToken);
+        }
+
+        /// <inheritdoc/>
         public async Task<long> ExecuteCommandAsync(string sql, object[] parameters = null, SqlStatementOptions options = null, CancellationToken cancellationToken = default)
         {
             parameters ??= Array.Empty<object>();
@@ -71,6 +77,12 @@ namespace Hazelcast.Sql
             // and... in case token is cancelled, it's pretty much the same
 
             return await FetchUpdateCountAsync(queryId, sql, parameters, options, cancellationToken).CfAwait();
+        }
+
+        /// <inheritdoc/>
+        public Task<long> ExecuteCommandAsync(string sql, SqlStatementOptions options = null, CancellationToken cancellationToken = default, params object[] parameters)
+        {
+            return ExecuteCommandAsync(sql, parameters, options, cancellationToken);
         }
 
         private async Task<SqlExecuteCodec.ResponseParameters> FetchAndValidateResponseAsync(SqlQueryId queryId,


### PR DESCRIPTION
New alternative overloads are introduced with `params` option on `ISqlService.ExecuteXXXAsync()`. Please see https://github.com/hazelcast/hazelcast-csharp-client/issues/599 for detailed explanation.