### PR TITLE
Refactor port expansion [API-1486]

### DIFF
--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -519,8 +519,11 @@ namespace Hazelcast.Clustering
                 yield return address;
 
             // get configured addresses that haven't been tried already
-            addresses = _clusterState.AddressProvider.GetAddresses();
-            foreach (var address in Distinct(addresses, distinct, shuffle))
+            // shuffle them if needed - but keep trying primary addresses before secondary addresses
+            var (primary, secondary) = _clusterState.AddressProvider.GetAddresses();
+            foreach (var address in Distinct(primary, distinct, shuffle))
+                yield return address;
+            foreach (var address in Distinct(secondary, distinct, shuffle))
                 yield return address;
         }
 

--- a/src/Hazelcast.Net/Networking/IAddressProviderSource.cs
+++ b/src/Hazelcast.Net/Networking/IAddressProviderSource.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 namespace Hazelcast.Networking
 {
     /// <summary>
-    /// Defines a source of internal-to-public addesses map for the <see cref="AddressProvider"/>.
+    /// Defines a source of addresses for the <see cref="AddressProvider"/>.
     /// </summary>
     internal interface IAddressProviderSource
     {
@@ -25,11 +25,23 @@ namespace Hazelcast.Networking
         /// Provides an internal-to-public addresses map.
         /// </summary>
         /// <returns>An internal-to-public addresses map.</returns>
-        IDictionary<NetworkAddress, NetworkAddress> CreateInternalToPublicMap();
+        //IDictionary<NetworkAddress, NetworkAddress> CreateInternalToPublicMap();
 
         /// <summary>
         /// Determines whether this source maps addresses.
         /// </summary>
         bool Maps { get; }
+
+        //IReadOnlyCollection<NetworkAddress> PrimaryAddresses { get; }
+
+        //IReadOnlyCollection<NetworkAddress> SecondaryAddresses { get; }
+
+        (IReadOnlyCollection<NetworkAddress> Primary, IReadOnlyCollection<NetworkAddress> Secondary) GetAddresses(bool forceRefresh);
+
+        //NetworkAddress Map(NetworkAddress address);
+
+        //(bool Fresh, IDictionary<NetworkAddress, NetworkAddress> Map) EnsureMap(bool forceRenew);
+
+        bool TryMap(NetworkAddress address, bool forceRefreshMap, out NetworkAddress result, out bool freshMap);
     }
 }


### PR DESCRIPTION
closing #677 

The PR restructure how a source provides addresses to the `AddressProvider`, so that the source can provide *primary* and *secondary* addresses just like Java does. A new `ExpandedPortsAreSecondaryAddresses` test has been added to `AddressProviderTests` to validate that expanded ports (5702, 5703...) are returned as secondary while 5701 is primary. Next, `ClusterConnection` has been fixed to shuffle primary and secondary addresses, without mixing them, thus testing all 5701 ports before expanded ports.