### PR TITLE
Fix more tests [API-1470]

### DIFF
--- a/src/Hazelcast.Net.Testing/Networking/SocketListener.cs
+++ b/src/Hazelcast.Net.Testing/Networking/SocketListener.cs
@@ -21,9 +21,6 @@ namespace Hazelcast.Testing.Networking
 {
     public class SocketListener : IDisposable
     {
-        private const int PortRange = 10; // offset goes +0 to +9
-        private static int _portOffset;
-
         private Socket _listener;
         private Socket _socket;
 
@@ -33,13 +30,6 @@ namespace Hazelcast.Testing.Networking
 
         public SocketListener(IPEndPoint endpoint, SocketListenerMode mode)
         {
-            // offset port - shutting down a socket and releasing it takes time, so if we
-            // keep using the same port, the retry loop below always kicks and slows the
-            // tests
-
-            endpoint.Port += _portOffset;
-            if (++_portOffset == PortRange) _portOffset = 0;
-
             // note
             // listen backlog 0 is equivalent to 1, backlog -1 means "system queue size"
             //

--- a/src/Hazelcast.Net.Testing/Networking/TestEndPointPort.cs
+++ b/src/Hazelcast.Net.Testing/Networking/TestEndPointPort.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+
+namespace Hazelcast.Testing.Networking
+{
+    /// <summary>
+    /// Produces unique test endpoint ports.
+    /// </summary>
+    public static class TestEndPointPort
+    {
+        private const int PortBase = 11000;
+        private static int _offset;
+
+        /// <summary>
+        /// Returns the next test endpoint port.
+        /// </summary>
+        /// <returns>The next test endpoint port.</returns>
+        public static int GetNext()
+        {
+            return PortBase + Interlocked.Increment(ref _offset);
+        }
+    }
+}

--- a/src/Hazelcast.Net.Tests/Clustering/MemberConnectionTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberConnectionTests.cs
@@ -29,6 +29,7 @@ using Hazelcast.Protocol.Models;
 using Hazelcast.Serialization;
 using Hazelcast.Testing;
 using Hazelcast.Testing.Accessors;
+using Hazelcast.Testing.Networking;
 using Hazelcast.Testing.Protocol;
 using Hazelcast.Testing.TestServer;
 using Microsoft.Extensions.Logging;
@@ -60,7 +61,7 @@ namespace Hazelcast.Tests.Clustering
 
             var loggerFactory = new NullLoggerFactory();
 
-            var address = NetworkAddress.Parse("127.0.0.1:11000");
+            var address = NetworkAddress.Parse($"127.0.0.1:{TestEndPointPort.GetNext()}");
 
             var state = new ServerState
             {

--- a/src/Hazelcast.Net.Tests/Core/SocketExtensionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Core/SocketExtensionsTests.cs
@@ -42,31 +42,19 @@ namespace Hazelcast.Tests.Core
         [Test]
         public async Task ConnectAsyncSuccess()
         {
-            var endpoint = IPEndPointEx.Parse("127.0.0.1:11000");
-
+            var endpoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), TestEndPointPort.GetNext());
             using var server = new SocketListener(endpoint, SocketListenerMode.AcceptOnce);
-
             using var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
             await socket.ConnectAsync(endpoint, -1);
             // connected!
-
-            try
-            {
-                socket.Shutdown(SocketShutdown.Both);
-                socket.Close();
-                socket.Dispose();
-            }
-            catch { /* doesn't matter */ }
         }
 
         [Test]
         public async Task ConnectAsyncConnectionRefused1()
         {
-            // note: SocketListener will offset / randomize the port to avoid collisions
-            var endpoint = IPEndPointEx.Parse("127.0.0.1:11000");
-
+            var endpoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), TestEndPointPort.GetNext());
             using var server = new SocketListener(endpoint, SocketListenerMode.ConnectionRefused);
-
             using var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
             await AssertEx.ThrowsAsync<SocketException>(async () =>
@@ -79,11 +67,8 @@ namespace Hazelcast.Tests.Core
         [Test]
         public async Task ConnectAsyncConnectionRefused2()
         {
-            // note: SocketListener will offset / randomize the port to avoid collisions
-            var endpoint = IPEndPointEx.Parse("127.0.0.1:11000");
-
+            var endpoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), TestEndPointPort.GetNext());
             using var server = new SocketListener(endpoint, SocketListenerMode.ConnectionRefused);
-
             using var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
             await AssertEx.ThrowsAsync<SocketException>(async () =>
@@ -96,9 +81,7 @@ namespace Hazelcast.Tests.Core
         [Test]
         public async Task ConnectAsyncConnectionRefused3()
         {
-            // note: SocketListener will offset / randomize the port to avoid collisions
-            var endpoint = IPEndPointEx.Parse("127.0.0.1:11000");
-
+            var endpoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), TestEndPointPort.GetNext());
             using var server = new SocketListener(endpoint, SocketListenerMode.ConnectionRefused);
             using var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 

--- a/src/Hazelcast.Net.Tests/Messaging/ClientMessageConnectionTests.cs
+++ b/src/Hazelcast.Net.Tests/Messaging/ClientMessageConnectionTests.cs
@@ -31,26 +31,32 @@ namespace Hazelcast.Tests.Messaging
     public class ClientMessageConnectionTests
     {
         [Test]
-        public void ArgumentExceptions()
+        public async Task ArgumentExceptions()
         {
-            var endpoint = NetworkAddress.Parse("127.0.0.1:11000").IPEndPoint;
-            var s = new ClientSocketConnection(Guid.NewGuid(), endpoint, new NetworkingOptions(), new SslOptions(), new NullLoggerFactory());
-            var c = new ClientMessageConnection(s, new NullLoggerFactory());
+            var endpoint = NetworkAddress.Parse($"127.0.0.1:{TestEndPointPort.GetNext()}").IPEndPoint;
+            await using var s = new ClientSocketConnection(Guid.NewGuid(), endpoint, new NetworkingOptions(), new SslOptions(), new NullLoggerFactory());
+            await using var c = new ClientMessageConnection(s, new NullLoggerFactory());
 
             Assert.ThrowsAsync<ArgumentNullException>(async () => _ = await c.SendAsync(null));
         }
 
         [Test]
-        public async Task OnReceiveMessage()
+        public async Task OnReceiveMessage1()
         {
-            var endpoint = NetworkAddress.Parse("127.0.0.1:11000").IPEndPoint;
-            var s = new ClientSocketConnection(Guid.NewGuid(), endpoint, new NetworkingOptions(), new SslOptions(), new NullLoggerFactory());
-            var c = new ClientMessageConnection(s, new NullLoggerFactory()) { OnReceiveMessage = OnReceiveMessageNotImplemented };
+            var endpoint = NetworkAddress.Parse($"127.0.0.1:{TestEndPointPort.GetNext()}").IPEndPoint;
+            await using var s = new ClientSocketConnection(Guid.NewGuid(), endpoint, new NetworkingOptions(), new SslOptions(), new NullLoggerFactory());
+            await using var c = new ClientMessageConnection(s, new NullLoggerFactory()) { OnReceiveMessage = OnReceiveMessageNotImplemented };
 
             Assert.That(c.OnReceiveMessage, Is.Not.Null);
             Assert.Throws<NotImplementedException>(() => c.OnReceiveMessage(default, default));
+        }
 
-            c = new ClientMessageConnection(s, new NullLoggerFactory());
+        [Test]
+        public async Task OnReceiveMessage2()
+        {
+            var endpoint = NetworkAddress.Parse($"127.0.0.1:{TestEndPointPort.GetNext()}").IPEndPoint;
+            await using var s = new ClientSocketConnection(Guid.NewGuid(), endpoint, new NetworkingOptions(), new SslOptions(), new NullLoggerFactory());
+            await using var c = new ClientMessageConnection(s, new NullLoggerFactory());
 
             using var l = new SocketListener(endpoint, SocketListenerMode.AcceptOnce);
 
@@ -63,11 +69,11 @@ namespace Hazelcast.Tests.Messaging
             => throw new NotImplementedException();
 
         [Test]
-        public void HandleFragments()
+        public async Task HandleFragments()
         {
-            var endpoint = NetworkAddress.Parse("127.0.0.1:11000").IPEndPoint;
-            var s = new ClientSocketConnection(Guid.NewGuid(), endpoint, new NetworkingOptions(), new SslOptions(), new NullLoggerFactory());
-            var c = new ClientMessageConnection(s, new NullLoggerFactory());
+            var endpoint = NetworkAddress.Parse($"127.0.0.1:{TestEndPointPort.GetNext()}").IPEndPoint;
+            await using var s = new ClientSocketConnection(Guid.NewGuid(), endpoint, new NetworkingOptions(), new SslOptions(), new NullLoggerFactory());
+            await using var c = new ClientMessageConnection(s, new NullLoggerFactory());
 
             ClientMessage recvd = null;
 
@@ -148,7 +154,7 @@ namespace Hazelcast.Tests.Messaging
                 await c.SendAsync(new ClientMessage(new Frame(new byte[64])));
             }
 
-            var address = NetworkAddress.Parse("127.0.0.1:11000");
+            var address = NetworkAddress.Parse($"127.0.0.1:{TestEndPointPort.GetNext()}");
             await using var server = new Hazelcast.Testing.TestServer.Server(address, ServerHandler, new NullLoggerFactory());
             await server.StartAsync();
 


### PR DESCRIPTION
Fix (hopefully) more unstable tests.

Some connection tests that use a custom port (eg 11000) keep failing and I *think* it's due to using the same port in two tests. We did have something in place to randomize the port, but not accross *all* tests. I have put in place a "ports source" that is going to supply ports eg 11000, 11001, 11002 for these tests (all of them) in order to see if it helps.

It's important because for compact, where we have about 18 PRs, 1/2 of them keep failing the build because of stupid tests.