### PR TITLE
Fix unstable tests

### DIFF
--- a/src/Hazelcast.Net.Tests/Sql/SqlQueryResultTests.cs
+++ b/src/Hazelcast.Net.Tests/Sql/SqlQueryResultTests.cs
@@ -114,8 +114,13 @@ namespace Hazelcast.Tests.Sql
 
             await AssertEx.ThrowsAsync<OperationCanceledException>(async () =>
             {
-                using var cancellationSource = new CancellationTokenSource(50);
-                await result.Take(5).ToListAsync(cancellationSource.Token);
+                using var cancellationSource = new CancellationTokenSource();
+                var count = 0;
+                await result.Take(5).Select(x =>
+                {
+                    if (count++ == 2) cancellationSource.Cancel();
+                    return x;
+                }).ToListAsync(cancellationSource.Token);
             });
         }
 


### PR DESCRIPTION
Fixing a test that was unstable. It was doing:
```
using var cancellationSource = new CancellationTokenSource(50);
await result.Take(5).ToListAsync(cancellationSource.Token);
```
And expecting an exception, but depending on timing, the `CancellationTokenSource` could cancel after the `ToListAsync` has completed. It's a bad idea to depend on timing. Replacing with:
```
using var cancellationSource = new CancellationTokenSource();
var count = 0;
await result.Take(5).Select(x =>
{
    if (count++ == 2) cancellationSource.Cancel();
    return x;
}).ToListAsync(cancellationSource.Token);
```
So essentially cancelling the `CancellationTokenSource` after 3 items have been returned, so we *know* it's going to be cancelled in a controlled way and before `ToListAsync` completes.