### PR TITLE
Updates to compact following QA/review

### DIFF
--- a/src/Hazelcast.Net/Serialization/Compact/CompactOptions.cs
+++ b/src/Hazelcast.Net/Serialization/Compact/CompactOptions.cs
@@ -24,12 +24,8 @@ using Hazelcast.Exceptions;
 namespace Hazelcast.Serialization.Compact
 {
     /// <summary>
-    /// (preview) Represents the compact serialization options.
+    /// Represents the compact serialization options.
     /// </summary>
-    /// <remarks>
-    /// <para>During the preview period, compact serialization is not enabled by default.</para>
-    /// <para>The options represented by this class may change in breaking ways in the future.</para>
-    /// </remarks>
     public sealed class CompactOptions
     {
         // we have, by design:

--- a/src/Hazelcast.Net/Serialization/Compact/ICompactWriter.cs
+++ b/src/Hazelcast.Net/Serialization/Compact/ICompactWriter.cs
@@ -27,14 +27,6 @@ namespace Hazelcast.Serialization.Compact
         // the two methods, thus avoiding allocating an extra nullable struct and/or
         // boxing when it is not necessary.
 
-        /// <summary>
-        /// Gets the <see cref="FieldKind"/> of a field.
-        /// </summary>
-        /// <param name="name">The name of the field.</param>
-        /// <returns>The <see cref="FieldKind"/> of the field, which can be <see cref="FieldKind.NotAvailable"/> if the field does not exist.</returns>
-        FieldKind GetFieldKind(string name);
-
-
         // do NOT remove nor alter the <generated></generated> lines!
         // <generated>
 

--- a/src/Hazelcast.Net/Serialization/Compact/SchemaBuilderWriter.cs
+++ b/src/Hazelcast.Net/Serialization/Compact/SchemaBuilderWriter.cs
@@ -30,9 +30,6 @@ namespace Hazelcast.Serialization.Compact
             _typeName = typeName;
         }
 
-        public FieldKind GetFieldKind(string name)
-            => throw new NotSupportedException();
-
         private void AddField(string name, FieldKind kind)
             => _fields.Add(new SchemaField(name, kind));
 


### PR DESCRIPTION
Following QA/review of Compact, the following changes are made:
- Documentation of `CompactOptions` still contained mentions of the "preview" period, we remove them.
- `ICompactWriter` contained a `GetFieldKind` method which was a leftover of the development period, we remove it.