### PR TITLE
More stable tests coverage

### DIFF
--- a/src/Hazelcast.Net.Benchmarks/CompareAutoBatcher.cs
+++ b/src/Hazelcast.Net.Benchmarks/CompareAutoBatcher.cs
@@ -247,7 +247,6 @@ namespace Hazelcast.Benchmarks
                 var batchNumber = GetNextBatchNumber();
                 if (batchNumber >= _batchCount) throw new InvalidOperationException("Overflow.");
                 var batch = new Batch(batchNumber * _batchSize, 1, _batchSize, Timeout.InfiniteTimeSpan);
-                SetBatch(batch);
                 return Task.FromResult(batch);
             }
         }

--- a/src/Hazelcast.Net.Tests/Clustering/ClientConnectionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/ClientConnectionsTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
+using System.Threading.Tasks;
+using Hazelcast.Clustering;
+using Hazelcast.Partitioning;
+using Hazelcast.Serialization;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Hazelcast.Tests.Clustering;
+
+[TestFixture]
+public class ClientConnectionsTests
+{
+    [Test]
+    public async Task ConnectMemberCoverage()
+    {
+        // this test validates that the ConnectMembers task of ClientConnections can complete nicely
+        // without being hard-canceled - this is required to get a stable test coverage (as it may
+        // or may not happen in other tests, depending on timing)
+
+        var loggerFactory = new NullLoggerFactory();
+        var options = new HazelcastOptions();
+        var serializationService = new SerializationServiceBuilder(loggerFactory).Build();
+        var clusterState = new ClusterState(options, "cluster-name", "client-name", new Partitioner(), loggerFactory);
+        var clusterMembers = new ClusterMembers(clusterState, new TerminateConnections(loggerFactory));
+        var clusterConnections = new ClusterConnections(clusterState, clusterMembers, serializationService);
+
+        var connectMembersField = typeof (ClusterConnections).GetField("_connectMembers", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.That(connectMembersField, Is.Not.Null);
+        var connectMembers = (Task) connectMembersField.GetValue(clusterConnections);
+
+        // and now, the ConnectMembers background task should be running
+        // now, we want to stop it without throwing - just nicely exiting its foreach loop
+        // this means closing the MemberConnectionQueue, which is owned by ClusterMembers
+
+        // disposing ClusterMembers is going to close the queue indeed
+        await clusterMembers.DisposeAsync();
+
+        // and the task completes nicely
+        Assert.That(connectMembers.Status, Is.EqualTo(TaskStatus.RanToCompletion));
+    }
+}

--- a/src/Hazelcast.Net.Tests/Clustering/InvocationTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/InvocationTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#nullable enable
+
+using Hazelcast.Clustering;
+using Hazelcast.Core;
+using Hazelcast.Messaging;
+using Hazelcast.Protocol.Codecs;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using Hazelcast.Exceptions;
+using Hazelcast.Testing;
+
+namespace Hazelcast.Tests.Clustering;
+
+[TestFixture]
+public class InvocationTests
+{
+    [Test]
+    public async Task Test()
+    {
+        var message = ClientPingCodec.EncodeRequest();
+        var options = new MessagingOptions
+        {
+            MaxFastInvocationCount = 0,
+            MinRetryDelayMilliseconds = 10,
+            RetryTimeoutSeconds = 1
+        };
+
+        var clock = new TestClockSource { Now = DateTime.Now };
+        using var clockOverride = Clock.Override(clock);
+
+        // because RetryTimeoutSeconds = 1, cannot retry after 10s
+        var invocation = new Invocation(message, options);
+        var startTime = Clock.ToDateTime(invocation.StartTime);
+        clock.Now = startTime.AddSeconds(10);
+        await AssertEx.ThrowsAsync<TaskTimeoutException>(async () => await invocation.WaitRetryAsync(() => 0));
+
+        // because RetryTimeoutSeconds = 1, can retry after 10ms
+        // because MaxFastInvocationCount = 0, will immediately delay
+        // delay is 1, 2, 4, 8, 16 ms but
+        // - never less than MinRetryDelayMilliseconds
+        // - never more than the total remaining time
+        // so we're going to wait for 10ms here
+        invocation = new Invocation(message, options);
+        startTime = Clock.ToDateTime(invocation.StartTime);
+        clock.Now = startTime.AddMilliseconds(10);
+        await invocation.WaitRetryAsync(() => 0);
+
+        // delay is constrained by remaining time, so here we do *not* wait for 10s
+        options.MinRetryDelayMilliseconds = 10_000;
+        invocation = new Invocation(message, options);
+        startTime = Clock.ToDateTime(invocation.StartTime);
+        clock.Now = startTime.AddMilliseconds(10);
+        await invocation.WaitRetryAsync(() => 0);
+    }
+
+    private class TestClockSource : IClockSource
+    {
+        public DateTime Now { get; set; }
+    }
+}

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -383,8 +383,8 @@ namespace Hazelcast.Clustering
         /// <param name="invocation">The invocation.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <remarks>After first connection is established, <b>TargetDisconnectedException</b> may be thrown. If
-        // the connected member reports an IP address different from the configured one. In this case, connection
-        // will be switched, and an exception will be thrown.</remarks>
+        /// the connected member reports an IP address different from the configured one. In this case, connection
+        /// will be switched, and an exception will be thrown.</remarks>
         /// <returns>A task that will complete when the response has been received, and represents the response.</returns>
         public Task<ClientMessage> SendAsync(Invocation invocation, CancellationToken cancellationToken = default)
         {

--- a/src/Hazelcast.Net/Core/Clock.cs
+++ b/src/Hazelcast.Net/Core/Clock.cs
@@ -84,7 +84,7 @@ namespace Hazelcast.Core
         /// </summary>
         /// <remarks>The epoch time in milliseconds.</remarks>
         public static long Milliseconds
-            => ToEpoch(DateTime.UtcNow);
+            => ToEpoch(Now);
 
         public static DateTime Now
             => _clockSource.Now;

--- a/src/Hazelcast.Net/DistributedObjects/Impl/AutoBatcher.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/AutoBatcher.cs
@@ -38,9 +38,7 @@ namespace Hazelcast.DistributedObjects.Impl
             var responseMessage = await _messaging.SendAsync(requestMessage).CfAwait();
             var response = FlakeIdGeneratorNewIdBatchCodec.DecodeResponse(responseMessage);
 
-            var batch = new Batch(response.Base, response.Increment, response.BatchSize, _options.PrefetchValidityPeriod);
-            SetBatch(batch); // important!
-            return batch;
+            return new Batch(response.Base, response.Increment, response.BatchSize, _options.PrefetchValidityPeriod);
         }
     }
 }

--- a/src/Hazelcast.Net/Messaging/ClientMessageConnection.cs
+++ b/src/Hazelcast.Net/Messaging/ClientMessageConnection.cs
@@ -128,6 +128,12 @@ namespace Hazelcast.Messaging
                 }
             }
 
+            // NOTE
+            // bufferReference.Buffer is a 'readonly struct', so its content (i.e. the content
+            // of the bytes variable) *cannot* be modified - we pass bytes as a 'ref' to the
+            // Frame.ReadXxx(ref bytes) methods, and they replace bytes with a new value - we
+            // then have to update bufferReference.Buffer back
+
             // TODO: consider buffering here
             // at the moment we are buffering in the pipe, but we have already
             // created the byte array, so ... might be nicer to copy now

--- a/src/Hazelcast.Net/Messaging/ClientMessageConnection.cs
+++ b/src/Hazelcast.Net/Messaging/ClientMessageConnection.cs
@@ -128,9 +128,6 @@ namespace Hazelcast.Messaging
                 }
             }
 
-            // update the reference
-            bufferReference.Buffer = bytes;
-
             // TODO: consider buffering here
             // at the moment we are buffering in the pipe, but we have already
             // created the byte array, so ... might be nicer to copy now
@@ -146,7 +143,7 @@ namespace Hazelcast.Messaging
             bufferReference.Buffer = bytes;
 
             _bytesLength = -1;
-            HConsole.WriteLine(this, 2, $"Frame is complete");
+            HConsole.WriteLine(this, 2, "Frame is complete");
 
             // we now have a fully assembled message
             // don't test _currentFrame.IsFinal, adding the frame to a message has messed it

--- a/src/Hazelcast.Net/NearCaching/NearCacheBase.cs
+++ b/src/Hazelcast.Net/NearCaching/NearCacheBase.cs
@@ -430,6 +430,10 @@ namespace Hazelcast.NearCaching
                 if (Interlocked.CompareExchange(ref _expiring, 1, 0) == 1)
                     return;
 
+                // double check
+                if (Clock.Milliseconds < _lastExpire + _cleanupInterval)
+                    return;
+
                 _lastExpire = Clock.Milliseconds;
 
                 await DoExpireEntries().CfAwait();


### PR DESCRIPTION
This PR adds some tests and fixes a few things, in order to ensure a more stable tests coverage. Looking at [this Codecov report](https://app.codecov.io/gh/hazelcast/hazelcast-csharp-client/pull/731) for instance, it was clear at one point that the PR was reducing coverage because it did not run through some code paths, mostly due to timing issues. This is annoying. With these tests, we should *always* run through these code paths, and things should be better.