### PR TITLE
Update codecs [API-1706]

### DIFF
--- a/src/Hazelcast.Net.Tests/Protocol/HoldersTests.cs
+++ b/src/Hazelcast.Net.Tests/Protocol/HoldersTests.cs
@@ -78,7 +78,7 @@ namespace Hazelcast.Tests.Protocol
             var comparatorData = new HeapData();
             var partitionKeyData = new HeapData();
 
-            var holder = new PagingPredicateHolder(anchorDataListHolder, predicateData, comparatorData, 5, 12, 3, partitionKeyData);
+            var holder = new PagingPredicateHolder(anchorDataListHolder, predicateData, comparatorData, 5, 12, 3, partitionKeyData, false, null);
 
             Assert.That(holder.AnchorDataListHolder, Is.SameAs(anchorDataListHolder));
             Assert.That(holder.PredicateData, Is.SameAs(predicateData));

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/SchemasLocalTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/SchemasLocalTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.Core;
@@ -134,7 +135,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             {
                 Assert.That(requestMessage.MessageType, Is.EqualTo(ClientSendSchemaCodec.RequestMessageType));
                 Interlocked.Increment(ref count);
-                return Task.FromResult(ClientSendSchemaServerCodec.EncodeResponse());
+                return Task.FromResult(ClientSendSchemaServerCodec.EncodeResponse(new HashSet<Guid>()));
             }));
 
             var schema = GetSchema();
@@ -215,7 +216,7 @@ namespace Hazelcast.Tests.Serialization.Compact
                 Interlocked.Increment(ref count);
                 Assert.That(requestMessage.MessageType, Is.EqualTo(ClientSendSchemaCodec.RequestMessageType));
                 await semaphore.WaitAsync();
-                return ClientSendAllSchemasServerCodec.EncodeResponse();
+                return ClientSendSchemaServerCodec.EncodeResponse(new HashSet<Guid>());
             }));
 
             // add a schema that needs to be pushed to the cluster
@@ -250,7 +251,7 @@ namespace Hazelcast.Tests.Serialization.Compact
                 Interlocked.Increment(ref count);
                 Assert.That(requestMessage.MessageType, Is.EqualTo(ClientSendSchemaCodec.RequestMessageType));
                 await semaphore.WaitAsync();
-                return ClientSendAllSchemasServerCodec.EncodeResponse();
+                return ClientSendSchemaServerCodec.EncodeResponse(new HashSet<Guid>());
             }));
 
             // add a schema that needs to be pushed to the cluster
@@ -294,7 +295,7 @@ namespace Hazelcast.Tests.Serialization.Compact
                 if (Interlocked.Increment(ref count) == 1)
                     throw new Exception("bang!");
                 Assert.That(requestMessage.MessageType, Is.EqualTo(ClientSendSchemaCodec.RequestMessageType));
-                return Task.FromResult(ClientSendAllSchemasServerCodec.EncodeResponse());
+                return Task.FromResult(ClientSendSchemaServerCodec.EncodeResponse(new HashSet<Guid>()));
             }));
 
             // add a schema that needs to be pushed to the cluster

--- a/src/Hazelcast.Net/Models/BTreeIndexOptions.cs
+++ b/src/Hazelcast.Net/Models/BTreeIndexOptions.cs
@@ -1,32 +1,42 @@
 ﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#nullable enable
+
 namespace Hazelcast.Models;
 
-/// <summary>
-/// Configures indexing options for <see cref="IndexType.Bitmap"/> indexes.
-/// </summary>
-public class BitmapIndexOptions
+// Configures indexing options for <see cref="IndexType.BTree"/> indexes.
+internal class BTreeIndexOptions
 {
-    /// <summary>
-    /// Gets or sets the unique key.
-    /// </summary>
-    public string UniqueKey { get; set; } = Query.Predicates.KeyName;
+    private Capacity? _pageSize;
 
     /// <summary>
-    /// Gets or sets the <see cref="UniqueKeyTransformation"/> which will be
-    /// applied to the <see cref="UniqueKey"/> value.
+    /// Gets the default page size.
     /// </summary>
-    public UniqueKeyTransformation UniqueKeyTransformation { get; set; } = UniqueKeyTransformation.Object;
+    public Capacity DefaultPageSize { get; } = new(16, MemoryUnit.KiloBytes);
+
+    /// <summary>
+    /// Gets or sets the page size.
+    /// </summary>
+    public Capacity PageSize
+    {
+        get => _pageSize ?? DefaultPageSize;
+        set => _pageSize = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the memory tier options.
+    /// </summary>
+    public MemoryTierOptions MemoryTierOptions { get; set; } = new();
 }

--- a/src/Hazelcast.Net/Models/Capacity.cs
+++ b/src/Hazelcast.Net/Models/Capacity.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Hazelcast.Models;
+
+/// <summary>
+/// Represents a memory capacity.
+/// </summary>
+internal class Capacity
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Capacity"/> class.
+    /// </summary>
+    /// <param name="value">The memory capacity expressed in bytes.</param>
+    public Capacity(long value)
+        : this(value, MemoryUnit.Bytes)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Capacity"/> class.
+    /// </summary>
+    /// <param name="value">The memory capacity expressed in the specified <paramref name="unit"/>.</param>
+    /// <param name="unit">The memory capacity unit.</param>
+    public Capacity(long value, MemoryUnit unit)
+    {
+        if (value < 0) throw new ArgumentException("Value must be greater than or equal to zero.", nameof(value));
+
+        Value = value;
+        Unit = unit switch
+        {
+            MemoryUnit.Bytes or
+            MemoryUnit.KiloBytes or
+            MemoryUnit.MegaBytes or 
+            MemoryUnit.GigaBytes => unit,
+            _ => throw new ArgumentException("Value must be a valid MemoryUnit.", nameof(unit))
+        };
+    }
+
+    /// <summary>
+    /// Gets the memory capacity expressed in <see cref="Unit"/>.
+    /// </summary>
+    public long Value { get; }
+
+    /// <summary>
+    /// Gets the memory capacity unit.
+    /// </summary>
+    public MemoryUnit Unit { get; }
+
+    // NOTE:
+    // not implementing all the conversion logic for now
+    // (see Capacity.java and MemoryUnit.java)
+}

--- a/src/Hazelcast.Net/Models/IndexOptions.cs
+++ b/src/Hazelcast.Net/Models/IndexOptions.cs
@@ -69,6 +69,11 @@ namespace Hazelcast.Models
         public BitmapIndexOptions BitmapIndexOptions { get; set; } = new BitmapIndexOptions();
 
         /// <summary>
+        /// Gets or sets the btree index options.
+        /// </summary>
+        internal BTreeIndexOptions BTreeIndexOptions { get; set; } = new();
+
+        /// <summary>
         /// Adds an indexed attribute.
         /// </summary>
         /// <param name="attribute">The name of the attribute.</param>

--- a/src/Hazelcast.Net/Models/MemoryTierOptions.cs
+++ b/src/Hazelcast.Net/Models/MemoryTierOptions.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,18 +15,18 @@
 namespace Hazelcast.Models;
 
 /// <summary>
-/// Configures indexing options for <see cref="IndexType.Bitmap"/> indexes.
+/// Represents options of a tiered-store.
 /// </summary>
-public class BitmapIndexOptions
+internal class MemoryTierOptions
 {
-    /// <summary>
-    /// Gets or sets the unique key.
-    /// </summary>
-    public string UniqueKey { get; set; } = Query.Predicates.KeyName;
+    private static readonly Capacity DefaultCapacity = new(256, MemoryUnit.MegaBytes);
 
     /// <summary>
-    /// Gets or sets the <see cref="UniqueKeyTransformation"/> which will be
-    /// applied to the <see cref="UniqueKey"/> value.
+    /// Gets or sets the memory capacity.
     /// </summary>
-    public UniqueKeyTransformation UniqueKeyTransformation { get; set; } = UniqueKeyTransformation.Object;
+    public Capacity Capacity { get; set; } = DefaultCapacity;
+
+    // NOTE:
+    // not implementing all equality + serialization support
+    // (see MemoryTierConfig.java)
 }

--- a/src/Hazelcast.Net/Models/MemoryUnit.cs
+++ b/src/Hazelcast.Net/Models/MemoryUnit.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,18 +15,27 @@
 namespace Hazelcast.Models;
 
 /// <summary>
-/// Configures indexing options for <see cref="IndexType.Bitmap"/> indexes.
+/// Represents a memory size unit.
 /// </summary>
-public class BitmapIndexOptions
+internal enum MemoryUnit
 {
     /// <summary>
-    /// Gets or sets the unique key.
+    /// Memory size in bytes.
     /// </summary>
-    public string UniqueKey { get; set; } = Query.Predicates.KeyName;
+    Bytes = 0,
 
     /// <summary>
-    /// Gets or sets the <see cref="UniqueKeyTransformation"/> which will be
-    /// applied to the <see cref="UniqueKey"/> value.
+    /// Memory size in kilobytes.
     /// </summary>
-    public UniqueKeyTransformation UniqueKeyTransformation { get; set; } = UniqueKeyTransformation.Object;
+    KiloBytes = 1,
+
+    /// <summary>
+    /// Memory size in megabytes.
+    /// </summary>
+    MegaBytes = 2,
+
+    /// <summary>
+    /// MemorySize in gigabytes.
+    /// </summary>
+    GigaBytes = 3
 }

--- a/src/Hazelcast.Net/Protocol/BuiltInCodecs/CustomTypeFactory.cs
+++ b/src/Hazelcast.Net/Protocol/BuiltInCodecs/CustomTypeFactory.cs
@@ -68,9 +68,11 @@ namespace Hazelcast.Protocol.BuiltInCodecs
             return new HazelcastJsonValue(value);
         }
 
-        public static IndexOptions CreateIndexConfig(string name, int indexType, List<string> attributes, BitmapIndexOptions bitmapIndexOptions)
+        public static IndexOptions CreateIndexConfig(string name, int indexType, List<string> attributes, BitmapIndexOptions bitmapIndexOptions, bool bTreeIndexConfigExists, BTreeIndexOptions bTreeIndexConfig)
         {
-            return new IndexOptions(attributes) { Name = name, Type = (IndexType) indexType, BitmapIndexOptions = bitmapIndexOptions };
+            var options = new IndexOptions(attributes) { Name = name, Type = (IndexType) indexType, BitmapIndexOptions = bitmapIndexOptions };
+            if (bTreeIndexConfigExists) options.BTreeIndexOptions = bTreeIndexConfig;
+            return options;
         }
 
         public static BitmapIndexOptions CreateBitmapIndexOptions(string uniqueKey, int uniqueKeyTransformation)
@@ -102,5 +104,13 @@ namespace Hazelcast.Protocol.BuiltInCodecs
 
         public static Schema CreateSchema(string typename, IEnumerable<SchemaField> fields)
           => new Schema(typename, fields.ToArray());
+
+        public static Capacity CreateCapacity(long value, int unit) => new(value, (MemoryUnit) unit);
+
+        public static MemoryTierOptions CreateMemoryTierConfig(Capacity capacity)
+            => new() { Capacity = capacity };
+
+        public static BTreeIndexOptions CreateBTreeIndexConfig(Capacity pageSize, MemoryTierOptions options)
+            => new() { PageSize = pageSize, MemoryTierOptions = options };
     }
 }

--- a/src/Hazelcast.Net/Protocol/BuiltInCodecs/SetUUIDCodec.cs
+++ b/src/Hazelcast.Net/Protocol/BuiltInCodecs/SetUUIDCodec.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hazelcast.Core;
+using Hazelcast.Messaging;
+
+namespace Hazelcast.Protocol.BuiltInCodecs;
+
+internal static class SetUUIDCodec
+{
+    public static void Encode(ClientMessage clientMessage, IEnumerable<Guid> collection)
+    {
+        var itemCount = collection.Count();
+        var frame = new Frame(new byte[itemCount * BytesExtensions.SizeOfCodecGuid]);
+
+        var i = 0;
+        foreach (var guid in collection)
+        {
+            frame.Bytes.WriteGuidL(i * BytesExtensions.SizeOfCodecGuid, guid);
+            i++;
+        }
+
+        clientMessage.Append(frame);
+    }
+
+    public static ISet<Guid> Decode(IEnumerator<Frame> iterator)
+    {
+        return Decode(iterator.Take());
+    }
+
+    public static HashSet<Guid> Decode(Frame frame)
+    {
+        var itemCount = frame.Bytes.Length / BytesExtensions.SizeOfCodecGuid;
+        var result = new HashSet<Guid>();
+        for (var i = 0; i < itemCount; i++)
+        {
+            result.Add(frame.Bytes.ReadGuidL(i * BytesExtensions.SizeOfCodecGuid));
+        }
+        return result;
+    }
+}

--- a/src/Hazelcast.Net/Protocol/BuiltInCodecs/SetUUIDCodec.cs
+++ b/src/Hazelcast.Net/Protocol/BuiltInCodecs/SetUUIDCodec.cs
@@ -25,12 +25,12 @@ internal static class SetUUIDCodec
     public static void Encode(ClientMessage clientMessage, IEnumerable<Guid> collection)
     {
         var itemCount = collection.Count();
-        var frame = new Frame(new byte[itemCount * BytesExtensions.SizeOfCodecGuid]);
+        var frame = new Frame(new byte[itemCount * BytesExtensions.SizeOfGuid]);
 
         var i = 0;
         foreach (var guid in collection)
         {
-            frame.Bytes.WriteGuidL(i * BytesExtensions.SizeOfCodecGuid, guid);
+            frame.Bytes.WriteGuidL(i * BytesExtensions.SizeOfGuid, guid);
             i++;
         }
 
@@ -44,11 +44,11 @@ internal static class SetUUIDCodec
 
     public static HashSet<Guid> Decode(Frame frame)
     {
-        var itemCount = frame.Bytes.Length / BytesExtensions.SizeOfCodecGuid;
+        var itemCount = frame.Bytes.Length / BytesExtensions.SizeOfGuid;
         var result = new HashSet<Guid>();
         for (var i = 0; i < itemCount; i++)
         {
-            result.Add(frame.Bytes.ReadGuidL(i * BytesExtensions.SizeOfCodecGuid));
+            result.Add(frame.Bytes.ReadGuidL(i * BytesExtensions.SizeOfGuid));
         }
         return result;
     }

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientFetchSchemaCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientFetchSchemaCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientFetchSchemaCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientFetchSchemaCodec.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientSendAllSchemasCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientSendAllSchemasCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientSendAllSchemasCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientSendAllSchemasCodec.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientSendSchemaCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientSendSchemaCodec.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Hazelcast.Net/Protocol/Codecs/ClientSendSchemaCodec.cs
+++ b/src/Hazelcast.Net/Protocol/Codecs/ClientSendSchemaCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -91,15 +91,21 @@ namespace Hazelcast.Protocol.Codecs
 
         public sealed class ResponseParameters
         {
+
+            /// <summary>
+            /// UUIDs of the members that the schema is replicated
+            ///</summary>
+            public ISet<Guid> ReplicatedMembers { get; set; }
         }
 
 #if SERVER_CODEC
-        public static ClientMessage EncodeResponse()
+        public static ClientMessage EncodeResponse(ISet<Guid> replicatedMembers)
         {
             var clientMessage = new ClientMessage();
             var initialFrame = new Frame(new byte[ResponseInitialFrameSize], (FrameFlags) ClientMessageFlags.Unfragmented);
             initialFrame.Bytes.WriteIntL(Messaging.FrameFields.Offset.MessageType, ResponseMessageType);
             clientMessage.Append(initialFrame);
+            SetUUIDCodec.Encode(clientMessage, replicatedMembers);
             return clientMessage;
         }
 #endif
@@ -109,6 +115,7 @@ namespace Hazelcast.Protocol.Codecs
             using var iterator = clientMessage.GetEnumerator();
             var response = new ResponseParameters();
             iterator.Take(); // empty initial frame
+            response.ReplicatedMembers = SetUUIDCodec.Decode(iterator);
             return response;
         }
 

--- a/src/Hazelcast.Net/Protocol/CustomCodecs/BTreeIndexConfigCodec.cs
+++ b/src/Hazelcast.Net/Protocol/CustomCodecs/BTreeIndexConfigCodec.cs
@@ -36,28 +36,28 @@ using Microsoft.Extensions.Logging;
 
 namespace Hazelcast.Protocol.CustomCodecs
 {
-    internal static class SchemaCodec
+    internal static class BTreeIndexConfigCodec
     {
 
-        public static void Encode(ClientMessage clientMessage, Hazelcast.Serialization.Compact.Schema schema)
+        public static void Encode(ClientMessage clientMessage, Hazelcast.Models.BTreeIndexOptions bTreeIndexConfig)
         {
             clientMessage.Append(Frame.CreateBeginStruct());
 
-            StringCodec.Encode(clientMessage, schema.TypeName);
-            ListMultiFrameCodec.Encode(clientMessage, schema.Fields, FieldDescriptorCodec.Encode);
+            CapacityCodec.Encode(clientMessage, bTreeIndexConfig.PageSize);
+            MemoryTierConfigCodec.Encode(clientMessage, bTreeIndexConfig.MemoryTierOptions);
 
             clientMessage.Append(Frame.CreateEndStruct());
         }
 
-        public static Hazelcast.Serialization.Compact.Schema Decode(IEnumerator<Frame> iterator)
+        public static Hazelcast.Models.BTreeIndexOptions Decode(IEnumerator<Frame> iterator)
         {
             // begin frame
             iterator.Take();
-            var typeName = StringCodec.Decode(iterator);
-            var fields = ListMultiFrameCodec.Decode(iterator, FieldDescriptorCodec.Decode);
+            var pageSize = CapacityCodec.Decode(iterator);
+            var memoryTierConfig = MemoryTierConfigCodec.Decode(iterator);
 
             iterator.SkipToStructEnd();
-            return CustomTypeFactory.CreateSchema(typeName, fields);
+            return CustomTypeFactory.CreateBTreeIndexConfig(pageSize, memoryTierConfig);
         }
     }
 }

--- a/src/Hazelcast.Net/Protocol/CustomCodecs/FieldDescriptorCodec.cs
+++ b/src/Hazelcast.Net/Protocol/CustomCodecs/FieldDescriptorCodec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Hazelcast.Net/Protocol/CustomCodecs/FieldDescriptorCodec.cs
+++ b/src/Hazelcast.Net/Protocol/CustomCodecs/FieldDescriptorCodec.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Hazelcast.Net/Protocol/CustomCodecs/MemoryTierConfigCodec.cs
+++ b/src/Hazelcast.Net/Protocol/CustomCodecs/MemoryTierConfigCodec.cs
@@ -36,28 +36,26 @@ using Microsoft.Extensions.Logging;
 
 namespace Hazelcast.Protocol.CustomCodecs
 {
-    internal static class SchemaCodec
+    internal static class MemoryTierConfigCodec
     {
 
-        public static void Encode(ClientMessage clientMessage, Hazelcast.Serialization.Compact.Schema schema)
+        public static void Encode(ClientMessage clientMessage, Hazelcast.Models.MemoryTierOptions memoryTierConfig)
         {
             clientMessage.Append(Frame.CreateBeginStruct());
 
-            StringCodec.Encode(clientMessage, schema.TypeName);
-            ListMultiFrameCodec.Encode(clientMessage, schema.Fields, FieldDescriptorCodec.Encode);
+            CapacityCodec.Encode(clientMessage, memoryTierConfig.Capacity);
 
             clientMessage.Append(Frame.CreateEndStruct());
         }
 
-        public static Hazelcast.Serialization.Compact.Schema Decode(IEnumerator<Frame> iterator)
+        public static Hazelcast.Models.MemoryTierOptions Decode(IEnumerator<Frame> iterator)
         {
             // begin frame
             iterator.Take();
-            var typeName = StringCodec.Decode(iterator);
-            var fields = ListMultiFrameCodec.Decode(iterator, FieldDescriptorCodec.Decode);
+            var capacity = CapacityCodec.Decode(iterator);
 
             iterator.SkipToStructEnd();
-            return CustomTypeFactory.CreateSchema(typeName, fields);
+            return CustomTypeFactory.CreateMemoryTierConfig(capacity);
         }
     }
 }

--- a/src/Hazelcast.Net/Protocol/CustomCodecs/PagingPredicateHolderCodec.cs
+++ b/src/Hazelcast.Net/Protocol/CustomCodecs/PagingPredicateHolderCodec.cs
@@ -57,6 +57,7 @@ namespace Hazelcast.Protocol.CustomCodecs
             CodecUtil.EncodeNullable(clientMessage, pagingPredicateHolder.PredicateData, DataCodec.Encode);
             CodecUtil.EncodeNullable(clientMessage, pagingPredicateHolder.ComparatorData, DataCodec.Encode);
             CodecUtil.EncodeNullable(clientMessage, pagingPredicateHolder.PartitionKeyData, DataCodec.Encode);
+            ListMultiFrameCodec.EncodeNullable(clientMessage, pagingPredicateHolder.PartitionKeysData, DataCodec.Encode);
 
             clientMessage.Append(Frame.CreateEndStruct());
         }
@@ -75,9 +76,16 @@ namespace Hazelcast.Protocol.CustomCodecs
             var predicateData = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
             var comparatorData = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
             var partitionKeyData = CodecUtil.DecodeNullable(iterator, DataCodec.Decode);
+            var isPartitionKeysDataExists = false;
+            ICollection<IData> partitionKeysData = default;
+            if (iterator.NextIsNotTheEnd())
+            {
+                partitionKeysData = ListMultiFrameCodec.DecodeNullable(iterator, DataCodec.Decode);
+                isPartitionKeysDataExists = true;
+            }
 
             iterator.SkipToStructEnd();
-            return new Hazelcast.Protocol.Models.PagingPredicateHolder(anchorDataListHolder, predicateData, comparatorData, pageSize, page, iterationTypeId, partitionKeyData);
+            return new Hazelcast.Protocol.Models.PagingPredicateHolder(anchorDataListHolder, predicateData, comparatorData, pageSize, page, iterationTypeId, partitionKeyData, isPartitionKeysDataExists, partitionKeysData);
         }
     }
 }

--- a/src/Hazelcast.Net/Protocol/CustomCodecs/SchemaCodec.cs
+++ b/src/Hazelcast.Net/Protocol/CustomCodecs/SchemaCodec.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Hazelcast.Net/Protocol/Models/PagingPredicateHolder.cs
+++ b/src/Hazelcast.Net/Protocol/Models/PagingPredicateHolder.cs
@@ -35,8 +35,11 @@ namespace Hazelcast.Protocol.Models
 
         internal IData PartitionKeyData { get; }
 
+        internal ICollection<IData> PartitionKeysData { get; }
+
         public PagingPredicateHolder(AnchorDataListHolder anchorDataListHolder, IData predicateData, IData comparatorData,
-            int pageSize, int page, byte iterationTypeId, IData partitionKeyData)
+            int pageSize, int page, byte iterationTypeId, IData partitionKeyData,
+            bool partitionKeysDataExists, ICollection<IData> partitionKeysData)
         {
             AnchorDataListHolder = anchorDataListHolder;
             PredicateData = predicateData;
@@ -45,6 +48,7 @@ namespace Hazelcast.Protocol.Models
             Page = page;
             IterationTypeId = iterationTypeId;
             PartitionKeyData = partitionKeyData;
+            if (partitionKeysDataExists) PartitionKeysData = partitionKeysData;
         }
 
         public static PagingPredicateHolder Of(IPredicate predicate, SerializationService serializationService)
@@ -92,7 +96,7 @@ namespace Hazelcast.Protocol.Models
                 throw new InvalidOperationException("The paging predicate does not specify an iteration type.");
 
             return new PagingPredicateHolder(anchorDataListHolder, predicateData, comparatorData, pagingPredicate.PageSize,
-                pagingPredicate.Page, (byte) pagingPredicate.IterationType, partitionKeyData);
+                pagingPredicate.Page, (byte) pagingPredicate.IterationType, partitionKeyData, false, null);
         }
     }
 }


### PR DESCRIPTION
In order to work on an issue with `Guid` (Java `UUID`) (de)serialization in codecs, we need to be able to re-generate the C# code for all codecs. Alas, the `hazelcast-client-protocol` repo has gotten out-of-sync: some of our changes were never merged there, and some codec definitions were extended.

Also, codecs were not necessarily generated as true UTF8+BOM files which can cause confusion during reviews (suddenly all codec files change because of encoding) so we need to stabilize this.

**This PR can only be merged after [hazelcast-client-protocol/442](https://github.com/hazelcast/hazelcast-client-protocol/pull/442) has been reviewed and merged. And then, the `protocol` submodule in this PR needs to be updated to the correct commit in the `hazelcast-client-protocol` repository.**

Then, our changes will be properly merged. And then, this PR can be reviewed.

Note that all additions to codecs (new config options...) are kept internal for now.