### PR TITLE
Fix naming confusion on LINQ.

### DIFF
--- a/src/Hazelcast.Net.Linq.Async/Visitors/QueryBinder.cs
+++ b/src/Hazelcast.Net.Linq.Async/Visitors/QueryBinder.cs
@@ -249,7 +249,7 @@ namespace Hazelcast.Linq.Visitors
             var projector = Expression.MemberInit(Expression.New(map.ElementType), bindings);
             var entryType = typeof(IEnumerable<>).MakeGenericType(map.ElementType);
 
-            var selectExp = new SelectExpression(selectAlias, entryType, columns.AsReadOnly(), new MapExpression(entryType, mapAlias, GetMapName(map)));
+            var selectExp = new SelectExpression(selectAlias, entryType, columns.AsReadOnly(), new MapExpression(entryType, GetMapName(map), mapAlias));
             return new ProjectionExpression(selectExp, projector, entryType);
         }
 

--- a/src/Hazelcast.Net.Tests/Linq/QueryBinderTests.cs
+++ b/src/Hazelcast.Net.Tests/Linq/QueryBinderTests.cs
@@ -72,7 +72,7 @@ namespace Hazelcast.Tests.Linq
             var projection = projectedExp.Source as SelectExpression;
             Assert.That(projection.Columns.Count, Is.EqualTo(2));
             Assert.AreEqual(projection.Columns.Select(p => p.Name).Intersect(columnNames), columnNames);
-            Assert.AreEqual(((MapExpression)((SelectExpression)projection.From).From).Alias, nameof(DummyType));//redundant queries are another PR's deal.
+            Assert.AreEqual(((MapExpression)((SelectExpression)projection.From).From).Name, nameof(DummyType));//redundant queries are another PR's deal.
 
             var where = projectedExp.Source.Where as BinaryExpression;
             Assert.AreEqual(where.NodeType, ExpressionType.Equal);

--- a/src/Hazelcast.Net.Tests/Linq/QueryBuildingTests.cs
+++ b/src/Hazelcast.Net.Tests/Linq/QueryBuildingTests.cs
@@ -62,7 +62,7 @@ namespace Hazelcast.Tests.Linq
             var projection = projectedExp.Source as SelectExpression;
             Assert.That(projection.Columns.Count, Is.EqualTo(ColumnNames.Count()));
             Assert.AreEqual(projection.Columns.Select(p => p.Name).Intersect(ColumnNames), ColumnNames);
-            Assert.AreEqual(((MapExpression)((SelectExpression)projection.From).From).Alias, nameof(DummyType));//redundandt queries are another PR's deal.
+            Assert.AreEqual(((MapExpression)((SelectExpression)projection.From).From).Name, nameof(DummyType));//redundandt queries are another PR's deal.
 
             var where = projectedExp.Source.Where as BinaryExpression;
             Assert.AreEqual(where.NodeType, ExpressionType.Equal);


### PR DESCRIPTION
It fixes the failed tests.