### PR TITLE
Fix tests

### DIFF
--- a/src/Hazelcast.Net.Testing/Networking/NetworkAddressExtensions.cs
+++ b/src/Hazelcast.Net.Testing/Networking/NetworkAddressExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Hazelcast.Networking;
+
+namespace Hazelcast.Testing.Networking;
+
+/// <summary>
+/// Provides extension methods for the <see cref="NetworkAddress"/> class.
+/// </summary>
+public static class NetworkAddressExtensions
+{
+    /// <summary>
+    /// Clones this address with a unique test endpoint port.
+    /// </summary>
+    /// <param name="address">The address.</param>
+    /// <returns>A clone of the address with a unique test endpoint port.</returns>
+    public static NetworkAddress WithTestEndPointPort(this NetworkAddress address) =>
+        new(address, TestEndPointPort.GetNext());
+}

--- a/src/Hazelcast.Net.Testing/TestServer/ClientRequest.cs
+++ b/src/Hazelcast.Net.Testing/TestServer/ClientRequest.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#nullable enable
+
+using System.Linq;
+using System.Threading.Tasks;
+using Hazelcast.Core;
+using Hazelcast.Exceptions;
+using Hazelcast.Messaging;
+using Hazelcast.Protocol.Models;
+using Hazelcast.Testing.Protocol;
+
+namespace Hazelcast.Testing.TestServer;
+
+internal class ClientRequest<TState> : ClientRequest
+{
+    public ClientRequest(ClientRequest request, TState state)
+        : base(request.Server, request.Connection, request.Message)
+    {
+        State = state;
+    }
+
+    /// <summary>
+    /// Gets the state object.
+    /// </summary>
+    public TState State { get; }
+}
+
+/// <summary>
+/// Represents a client request handled by a server.
+/// </summary>
+internal class ClientRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClientRequest"/> class.
+    /// </summary>
+    /// <param name="server">The server.</param>
+    /// <param name="connection">The client connection.</param>
+    /// <param name="message">The message.</param>
+    public ClientRequest(Server server, ClientMessageConnection connection, ClientMessage message)
+    {
+        Server = server;
+        Connection = connection;
+        Message = message;
+    }
+
+    /// <summary>
+    /// Gets the server.
+    /// </summary>
+    public Server Server { get; }
+
+    /// <summary>
+    /// Gets the client connection.
+    /// </summary>
+    public ClientMessageConnection Connection { get; }
+
+    /// <summary>
+    /// Gets the message.
+    /// </summary>
+    public ClientMessage Message { get; }
+
+    /// <summary>
+    /// Responds to the request.
+    /// </summary>
+    /// <param name="responseMessage">The response message.</param>
+    public async Task RespondAsync(ClientMessage responseMessage)
+    {
+        responseMessage.CorrelationId = Message.CorrelationId;
+        responseMessage.Flags |= ClientMessageFlags.BeginFragment | ClientMessageFlags.EndFragment;
+        await Connection.SendAsync(responseMessage).CfAwait();
+    }
+
+    /// <summary>
+    /// Responds to the request with an error.
+    /// </summary>
+    /// <param name="errorCode">The error code.</param>
+    /// <param name="errorMessage">The error message.</param>
+    public async Task ErrorAsync(RemoteError errorCode, string? errorMessage = null)
+    {
+        var errorHolders = new[]
+        {
+            new ErrorHolder(errorCode, "?", errorMessage ?? "error", Enumerable.Empty<StackTraceElement>())
+        };
+        var responseMessage = ErrorsServerCodec.EncodeResponse(errorHolders);
+        await RespondAsync(responseMessage);
+    }
+
+    /// <summary>
+    /// Raises an event in response to the request.
+    /// </summary>
+    /// <param name="eventMessage">The event message.</param>
+    /// <param name="correlationId">The event correlation identifier.</param>
+    public async Task RaiseAsync(ClientMessage eventMessage, long correlationId = -1)
+    {
+        eventMessage.CorrelationId = correlationId > 0 ? correlationId : Message.CorrelationId;
+        eventMessage.Flags |= ClientMessageFlags.BeginFragment | ClientMessageFlags.EndFragment;
+        await Connection.SendAsync(eventMessage).CfAwait();
+    }
+}

--- a/src/Hazelcast.Net.Testing/TestServer/ServerSocketConnection.cs
+++ b/src/Hazelcast.Net.Testing/TestServer/ServerSocketConnection.cs
@@ -43,7 +43,7 @@ namespace Hazelcast.Testing.TestServer
             _acceptingSocket = socket ?? throw new ArgumentNullException(nameof(socket));
 
             var prefix = "SVR.CONN".Dot(hcname);
-            HConsole.Configure(x => x.Configure(this).SetIndent(32).SetPrefix($"{prefix} [{id}]"));
+            HConsole.Configure(x => x.Configure(this).SetIndent(32).SetPrefix($"{prefix} [{id.ToShortString()}]"));
         }
 
         /// <summary>

--- a/src/Hazelcast.Net.Testing/TestServer/ServerSocketListener.cs
+++ b/src/Hazelcast.Net.Testing/TestServer/ServerSocketListener.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#nullable enable
+
 using System;
 using System.Net;
 using System.Net.Sockets;
@@ -19,184 +21,183 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.Core;
 
-namespace Hazelcast.Testing.TestServer
+namespace Hazelcast.Testing.TestServer;
+
+/// <summary>
+/// Represents a server listener.
+/// </summary>
+/// <remarks>
+/// <para>The server listener is not thread-safe in some ways, e.g. trying to stop it
+/// while it is starting, and other exotic operations, are going to produce unspecified
+/// results.</para>
+/// <para>The server listener is not fully multi-threaded.</para>
+/// </remarks>
+internal sealed class ServerSocketListener : IAsyncDisposable
 {
+    private readonly IPEndPoint _endpoint;
+    private readonly string _hcname;
+
+    private Action<ServerSocketConnection> _onAcceptConnection;
+    private Func<ServerSocketListener, ValueTask> _onShutdown;
+    private Socket _listeningSocket;
+    private bool _stopped;
+    private Task _accepting;
+    private int _isActive;
+
     /// <summary>
-    /// Represents a server listener.
+    /// Initializes a new instance of the <see cref="ServerSocketListener"/> class.
     /// </summary>
-    /// <remarks>
-    /// <para>The server listener is not thread-safe in some ways, e.g. trying to stop it
-    /// while it is starting, and other exotic operations, are going to produce unspecified
-    /// results.</para>
-    /// <para>The server listener is not fully multi-threaded.</para>
-    /// </remarks>
-    internal sealed class ServerSocketListener : IAsyncDisposable
+    /// <param name="endpoint">The socket endpoint.</param>
+    /// <param name="hcname">An HConsole name complement.</param>
+    public ServerSocketListener(IPEndPoint endpoint, string hcname)
     {
-        private readonly IPEndPoint _endpoint;
-        private readonly string _hcname;
+        _endpoint = endpoint;
+        _hcname = hcname;
 
-        private Action<ServerSocketConnection> _onAcceptConnection;
-        private Func<ServerSocketListener, ValueTask> _onShutdown;
-        private Socket _listeningSocket;
-        private bool _stopped;
-        private Task _accepting;
-        private int _isActive;
+        HConsole.Configure(x => x.Configure(this).SetIndent(24).SetPrefix("LISTENER".Dot(hcname)));
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ServerSocketListener"/> class.
-        /// </summary>
-        /// <param name="endpoint">The socket endpoint.</param>
-        /// <param name="hcname">An HConsole name complement.</param>
-        public ServerSocketListener(IPEndPoint endpoint, string hcname)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerSocketListener"/> class.
+    /// </summary>
+    /// <param name="endpoint">The socket endpoint.</param>
+    public ServerSocketListener(IPEndPoint endpoint)
+        : this(endpoint, string.Empty)
+    { }
+
+    /// <summary>
+    /// Gets or sets the action that will be executed when a connection has been accepted.
+    /// </summary>
+    public Action<ServerSocketConnection> OnAcceptConnection
+    {
+        // note: this action is not async
+
+        get => _onAcceptConnection;
+        set
         {
-            _endpoint = endpoint;
-            _hcname = hcname;
+            if (_isActive == 1 || _stopped)
+                throw new InvalidOperationException("Cannot set the property once the listener is active.");
 
-            HConsole.Configure(x => x.Configure(this).SetIndent(24).SetPrefix("LISTENER".Dot(hcname)));
+            _onAcceptConnection = value ?? throw new ArgumentNullException(nameof(value));
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the action that will be executed when the listener has shut down.
+    /// </summary>
+    public Func<ServerSocketListener, ValueTask> OnShutdown
+    {
+        get => _onShutdown;
+        set
+        {
+            if (_isActive == 1 || _stopped)
+                throw new InvalidOperationException("Cannot set the property once the listener is active.");
+
+            _onShutdown = value ?? throw new ArgumentNullException(nameof(value));
+        }
+    }
+
+    /// <summary>
+    /// Starts listening.
+    /// </summary>
+    /// <returns>A task that will complete when the listener has started listening.</returns>
+    /// <remarks>
+    /// <para>The listener must be disposed in order to stop. It cannot be restarted.</para>
+    /// </remarks>
+    public Task StartAsync()
+    {
+        if (_stopped)
+            throw new InvalidOperationException("Cannot start a listener that has been stopped.");
+
+        HConsole.WriteLine(this, "Start listener");
+
+        if (_onAcceptConnection == null)
+            throw new InvalidOperationException("No connection handler has been configured.");
+
+        HConsole.WriteLine(this, "Create listener socket");
+        _listeningSocket = new Socket(_endpoint.Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+        try
+        {
+            _listeningSocket.Bind(_endpoint);
+            _listeningSocket.Listen(10);
+        }
+        catch (Exception e)
+        {
+            HConsole.WriteLine(this, "Failed to bind socket");
+            HConsole.WriteLine(this, e);
+            throw;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ServerSocketListener"/> class.
-        /// </summary>
-        /// <param name="endpoint">The socket endpoint.</param>
-        public ServerSocketListener(IPEndPoint endpoint)
-            : this(endpoint, string.Empty)
-        { }
+        _accepting = AcceptAsync(_listeningSocket);
 
-        /// <summary>
-        /// Gets or sets the action that will be executed when a connection has been accepted.
-        /// </summary>
-        public Action<ServerSocketConnection> OnAcceptConnection
+        HConsole.WriteLine(this, "Started listener");
+
+        return Task.CompletedTask;
+    }
+
+    // reference: https://github.com/davidfowl/DotNetCodingPatterns/blob/main/2.md
+    // except here we want to be able to control when to stop accepting
+
+    private async Task AcceptAsync(Socket socket)
+    {
+        HConsole.WriteLine(this, "Start listening");
+        Interlocked.Exchange(ref _isActive, 1);
+
+        while (!_stopped)
         {
-            // note: this action is not async
-
-            get => _onAcceptConnection;
-            set
+            try
             {
-                if (_isActive == 1 || _stopped)
-                    throw new InvalidOperationException("Cannot set the property once the listener is active.");
-
-                _onAcceptConnection = value ?? throw new ArgumentNullException(nameof(value));
+                Accept(await socket.AcceptAsync().CfAwait());
             }
+            catch { /* stopped */ }
         }
 
-        /// <summary>
-        /// Gets or sets the action that will be executed when the listener has shut down.
-        /// </summary>
-        public Func<ServerSocketListener, ValueTask> OnShutdown
-        {
-            get => _onShutdown;
-            set
-            {
-                if (_isActive == 1 || _stopped)
-                    throw new InvalidOperationException("Cannot set the property once the listener is active.");
+        HConsole.WriteLine(this, "Stop listening");
+        if (Interlocked.CompareExchange(ref _isActive, 0, 1) == 0)
+            return;
 
-                _onShutdown = value ?? throw new ArgumentNullException(nameof(value));
-            }
+        // notify
+        if (_onShutdown != null) await _onShutdown.AwaitEach(this).CfAwait();
+    }
+
+    /// <summary>
+    /// Accepts a connection.
+    /// </summary>
+    private void Accept(Socket socket)
+    {
+        HConsole.WriteLine(this, "Accept connection");
+
+        try
+        {
+            // we now have a connection
+            _onAcceptConnection(new ServerSocketConnection(Guid.NewGuid(), socket, _hcname));
         }
-
-        /// <summary>
-        /// Starts listening.
-        /// </summary>
-        /// <returns>A task that will complete when the listener has started listening.</returns>
-        /// <remarks>
-        /// <para>The listener must be disposed in order to stop. It cannot be restarted.</para>
-        /// </remarks>
-        public Task StartAsync()
+        catch (Exception e)
         {
-            if (_stopped)
-                throw new InvalidOperationException("Cannot start a listener that has been stopped.");
-
-            HConsole.WriteLine(this, "Start listener");
-
-            if (_onAcceptConnection == null)
-                throw new InvalidOperationException("No connection handler has been configured.");
-
-            HConsole.WriteLine(this, "Create listener socket");
-            _listeningSocket = new Socket(_endpoint.Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            HConsole.WriteLine(this, "Failed to accept a connection");
+            HConsole.WriteLine(this, e);
 
             try
             {
-                _listeningSocket.Bind(_endpoint);
-                _listeningSocket.Listen(10);
+                socket.Dispose();
             }
-            catch (Exception e)
-            {
-                HConsole.WriteLine(this, "Failed to bind socket");
-                HConsole.WriteLine(this, e);
-                throw;
-            }
-
-            _accepting = AcceptAsync(_listeningSocket);
-
-            HConsole.WriteLine(this, "Started listener");
-
-            return Task.CompletedTask;
+            catch { /* ignore */}
         }
+    }
 
-        // reference: https://github.com/davidfowl/DotNetCodingPatterns/blob/main/2.md
-        // except here we want to be able to control when to stop accepting
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_stopped) return;
 
-        private async Task AcceptAsync(Socket socket)
+        try
         {
-            HConsole.WriteLine(this, "Start listening");
-            Interlocked.Exchange(ref _isActive, 1);
-
-            while (!_stopped)
-            {
-                try
-                {
-                    Accept(await socket.AcceptAsync().CfAwait());
-                }
-                catch { /* stopped */ }
-            }
-
-            HConsole.WriteLine(this, "Stop listening");
-            if (Interlocked.CompareExchange(ref _isActive, 0, 1) == 0)
-                return;
-
-            // notify
-            if (_onShutdown != null) await _onShutdown.AwaitEach(this).CfAwait();
+            _stopped = true;
+            if (_listeningSocket != null) _listeningSocket.Dispose();
+            if (_accepting != null) await _accepting.CfAwait();
+            HConsole.WriteLine(this, "Stopped listener");
         }
-
-        /// <summary>
-        /// Accepts a connection.
-        /// </summary>
-        private void Accept(Socket socket)
-        {
-            HConsole.WriteLine(this, "Accept connection");
-
-            try
-            {
-                // we now have a connection
-                _onAcceptConnection(new ServerSocketConnection(Guid.NewGuid(), socket, _hcname));
-            }
-            catch (Exception e)
-            {
-                HConsole.WriteLine(this, "Failed to accept a connection");
-                HConsole.WriteLine(this, e);
-
-                try
-                {
-                    socket.Dispose();
-                }
-                catch { /* ignore */}
-            }
-        }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            if (_stopped) return;
-
-            try
-            {
-                _stopped = true;
-                if (_listeningSocket != null) _listeningSocket.Dispose();
-                if (_accepting != null) await _accepting.CfAwait();
-                HConsole.WriteLine(this, "Stopped listener");
-            }
-            catch { /* ignore */ }
-        }
+        catch { /* ignore */ }
     }
 }

--- a/src/Hazelcast.Net.Testing/TestServer/SeverTState.cs
+++ b/src/Hazelcast.Net.Testing/TestServer/SeverTState.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#nullable enable
+
+using Hazelcast.Core;
+using System.Threading.Tasks;
+using System;
+
+namespace Hazelcast.Testing.TestServer;
+
+internal class Server<TState> : IAsyncDisposable
+{
+    private readonly Server _server;
+
+    public Server(Server server, TState state)
+    {
+        _server = server;
+        State = state;
+    }
+
+    /// <summary>
+    /// Gets the state object.
+    /// </summary>
+    public TState State { get; }
+
+    /// <summary>
+    /// Gets the cluster identifier of the server.
+    /// </summary>
+    public Guid ClusterId => _server.ClusterId;
+
+    /// <summary>
+    /// Starts the server.
+    /// </summary>
+    /// <returns>A task that will complete when the server has started.</returns>
+    public async Task<Server<TState>> StartAsync()
+    {
+        await _server.StartAsync().CfAwait();
+        return this;
+    }
+
+    public Task StopAsync() => _server.StopAsync();
+
+    /// <summary>
+    /// Assigns the handler for a request message type.
+    /// </summary>
+    /// <param name="messageType">The type of the request message.</param>
+    /// <param name="handler">The handler function.</param>
+    /// <returns>This server.</returns>
+    public Server<TState> Handle(int messageType, Func<ClientRequest<TState>, ValueTask> handler)
+    {
+        _server.Handle(messageType, request => handler(new ClientRequest<TState>(request, State)));
+        return this;
+    }
+
+    /// <summary>
+    /// Assigns the fallback handler. 
+    /// </summary>
+    /// <param name="handler">The handler function.</param>
+    /// <returns>This server.</returns>
+    public Server<TState> HandleFallback(Func<ClientRequest<TState>, ValueTask> handler)
+    {
+        _server.HandleFallback(request => handler(new ClientRequest<TState>(request, State)));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        return _server.DisposeAsync();
+    }
+}

--- a/src/Hazelcast.Net.Tests/Core/TaskCoreExtensionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Core/TaskCoreExtensionsTests.cs
@@ -312,7 +312,7 @@ namespace Hazelcast.Tests.Core
             Assert.That(cancellation.IsCancellationRequested, Is.True);
 
             // the task is faulted, and has thrown an exception!
-            Assert.That(e.Task.IsFaulted);
+            await AssertEx.SucceedsEventually(() => Assert.That(e.Task.IsFaulted), 10000, 500);
 
             // the exception has been observed, and would not leak
             // now, assuming we want to handle it, we can await the

--- a/src/Hazelcast.Net/Core/DumpCoreExtensions.cs
+++ b/src/Hazelcast.Net/Core/DumpCoreExtensions.cs
@@ -32,13 +32,14 @@ namespace Hazelcast.Core
         /// <param name="length">The number of bytes to dump, or zero to dump all bytes in the array.</param>
         /// <param name="formatted">Whether to format the output.</param>
         /// <returns>A readable string representation of the array of bytes.</returns>
-        public static string Dump(this byte[] bytes, int length = 0, bool formatted = true)
+        public static string Dump(this byte[] bytes, long length = 0, bool formatted = true)
         {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
             if (length > bytes.Length)
                 throw new InvalidOperationException(ExceptionMessages.NotEnoughBytes);
 
             if (length == 0) length = bytes.Length;
+            if (length == 0) return string.Empty;
 
             var text = new StringBuilder();
 
@@ -72,11 +73,13 @@ namespace Hazelcast.Core
         /// <param name="bytes">The sequence of bytes.</param>
         /// <param name="length">The number of bytes to dump, or zero to dump all bytes in the sequence.</param>
         /// <returns>A readable string representation of the sequence of bytes.</returns>
-        public static string Dump(this ReadOnlySequence<byte> bytes, int length = 0)
+        public static string Dump(this ReadOnlySequence<byte> bytes, long length = 0)
         {
-            var a = new byte[bytes.Length];
+            if (length == 0) length = bytes.Length;
+            if (length == 0) return string.Empty;
+            var a = new byte[length];
             bytes.CopyTo(a);
-            return a.Dump(length);
+            return a.Dump();
         }
     }
 }

--- a/src/Hazelcast.Net/Core/HConsole.cs
+++ b/src/Hazelcast.Net/Core/HConsole.cs
@@ -296,8 +296,9 @@ namespace Hazelcast.Core
         {
 #if HZ_CONSOLE
             if (source == null) throw new ArgumentNullException(nameof(source));
+            if (string.IsNullOrWhiteSpace(text)) return string.Empty;
             var info = Options.GetOptions(source);
-            if (info.Ignore(level)) return "";
+            if (info.Ignore(level)) return string.Empty;
             var prefix = new string(' ', info.FormattedPrefix.Length);
             text = "\n" + text;
             return text.Replace("\n", "\n" + prefix, StringComparison.Ordinal);


### PR DESCRIPTION
OK, this fixes the annoying `SocketConnectionTests.SendReceive` that started to fail with .NET 7. Why would it fail? Because we were *not* waiting for the server's response before checking the client's last-received date. Turns out with slow-enough code, it worked, but apparently with .NET 7 everything happens faster and now it fails. So, the test has been modified to wait for the response. As it should always have.

Now in the process of troubleshooting I refactored the server code to make everything cleaner, this is part of a work-in-progress branch that I have on my machine (so I just copied-and-pasted things that I have around). And so the PR modifies more than just the test. But it should not modify anything in the production code, just tests.