### PR TITLE
Rewire Events [API-1824]

### DIFF
--- a/src/Hazelcast.Net.Tests/Serialization/Compact/SchemasLocalTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/SchemasLocalTests.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Hazelcast.Clustering;
 using Hazelcast.Core;
 using Hazelcast.Exceptions;
 using Hazelcast.Messaging;
@@ -50,6 +51,11 @@ public class SchemasLocalTests
         {
             if (triggerEvents && SendingMessage != null) await SendingMessage.AwaitEach(requestMessage).CfAwait();
             return await _respond(requestMessage);
+        }
+
+        public Task<ClientMessage> SendToMemberAsync(ClientMessage message, MemberConnection memberConnection, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
 
         public async Task<ClientMessage> SendAsync(ClientMessage requestMessage, CancellationToken cancellationToken)

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/SchemasRemoteTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/SchemasRemoteTests.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Hazelcast.Clustering;
 using Hazelcast.Core;
 using Hazelcast.Messaging;
 using Hazelcast.Protocol.Codecs;
@@ -55,6 +56,11 @@ namespace Hazelcast.Tests.Serialization.Compact
 
                 Interlocked.Increment(ref _count);
                 return _messaging.SendAsync(requestMessage, triggerEvents, cancellationToken);
+            }
+
+            public Task<ClientMessage> SendToMemberAsync(ClientMessage message, MemberConnection memberConnection, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
             }
 
             public IEnumerable<Guid> GetConnectedMembers() => _messaging.GetConnectedMembers();

--- a/src/Hazelcast.Net/Clustering/ClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterEvents.cs
@@ -41,13 +41,13 @@ namespace Hazelcast.Clustering
         private readonly DistributedEventScheduler _scheduler;
         private readonly ILogger _logger;
 
-        private readonly CancellationTokenSource _cancel = new CancellationTokenSource();
-        private readonly object _mutex = new object(); // subscriptions and connections
+        private readonly CancellationTokenSource _cancel = new();
+        private readonly object _mutex = new(); // subscriptions and connections
 
         private Func<ValueTask> _partitionsUpdated;
         private Func<MembersUpdatedEventArgs, ValueTask> _membersUpdated;
 
-        private readonly object _clusterViewsMutex = new object();
+        private readonly object _clusterViewsMutex = new();
         private MemberConnection _clusterViewsConnection; // the connection which supports the view event
         private long _clusterViewsCorrelationId; // the correlation id of the view event subscription
         private Task _clusterViewsTask; // the task that assigns a connection to support the view event
@@ -55,26 +55,26 @@ namespace Hazelcast.Clustering
         private volatile int _disposed;
 
         // connections
-        private readonly HashSet<MemberConnection> _connections = new HashSet<MemberConnection>();
-        private TaskCompletionSource<object> _connectionOpened;
+        private readonly HashSet<MemberConnection> _connections = new();
+        private TaskCompletionSource<MemberConnection> _connectionOpened;
 
         // subscription id -> subscription
         // the master subscriptions list
-        private readonly ConcurrentDictionary<Guid, ClusterSubscription> _subscriptions = new ConcurrentDictionary<Guid, ClusterSubscription>();
+        private readonly ConcurrentDictionary<Guid, ClusterSubscription> _subscriptions = new();
 
         // subscribe tasks
-        private readonly object _subscribeTasksMutex = new object();
-        private Dictionary<MemberConnection, Task> _subscribeTasks = new Dictionary<MemberConnection, Task>(); // the tasks that subscribe new connections
+        private readonly object _subscribeTasksMutex = new();
+        private Dictionary<MemberConnection, Task> _subscribeTasks = new(); // the tasks that subscribe new connections
 
         // correlation id -> subscription
         // used to match a subscription to an incoming event message
         // each connection has its own correlation id, so there can be many entries per cluster subscription
-        private readonly ConcurrentDictionary<long, ClusterSubscription> _correlatedSubscriptions = new ConcurrentDictionary<long, ClusterSubscription>();
+        private readonly ConcurrentDictionary<long, ClusterSubscription> _correlatedSubscriptions = new();
 
         // ghost subscriptions, to be collected
         // subscriptions that have failed to properly unsubscribe and now we need to take care of them
-        private readonly HashSet<MemberSubscription> _collectSubscriptions = new HashSet<MemberSubscription>();
-        private readonly object _collectMutex = new object();
+        private readonly HashSet<MemberSubscription> _collectSubscriptions = new();
+        private readonly object _collectMutex = new();
         private Task _collectTask; // the task that collects ghost subscriptions
 
         static ClusterEvents()
@@ -462,6 +462,28 @@ namespace Hazelcast.Clustering
             }
         }
 
+        private ValueTask<MemberConnection> WaitForConnection(CancellationToken cancellationToken)
+        {
+            var c = _clusterMembers.GetRandomConnection();
+            return c == null
+                ? WaitForConnectionAsync(cancellationToken)
+                : new ValueTask<MemberConnection>(c);
+
+            async ValueTask<MemberConnection> WaitForConnectionAsync(CancellationToken token)
+            {
+                MemberConnection c = null;
+                while (!token.IsCancellationRequested && ((c = _clusterMembers.GetRandomConnection()) == null || !c.Active))
+                {
+                    lock (_mutex) _connectionOpened = new TaskCompletionSource<MemberConnection>();
+                    using var reg = token.Register(() => _connectionOpened.TrySetCanceled());
+                    c = await _connectionOpened.Task.CfAwait();
+                    lock (_mutex) _connectionOpened = null;
+                    if (c is { Active: true }) break; // return the connection that was opened
+                }
+                return c;
+            }
+        }
+
         /// <summary>
         /// Assigns a connection to support the cluster view event.
         /// </summary>
@@ -472,33 +494,11 @@ namespace Hazelcast.Clustering
         {
             // TODO: consider throttling
 
-            ValueTask<MemberConnection> WaitRandomConnection(CancellationToken token)
-            {
-                var c = _clusterMembers.GetRandomConnection();
-                return c == null
-                    ? WaitRandomConnection2(token)
-                    : new ValueTask<MemberConnection>(c);
-            }
-
-            async ValueTask<MemberConnection> WaitRandomConnection2(CancellationToken token)
-            {
-                MemberConnection c = null;
-                while (!token.IsCancellationRequested &&
-                       ((c = _clusterMembers.GetRandomConnection()) == null || !c.Active))
-                {
-                    lock (_mutex) _connectionOpened = new TaskCompletionSource<object>();
-                    using var reg = token.Register(() => _connectionOpened.TrySetCanceled());
-                    await _connectionOpened.Task.CfAwait();
-                    lock (_mutex) _connectionOpened = null;
-                }
-                return c;
-            }
-
             // this will only exit once a connection is assigned, or the task is
             // cancelled, when the cluster goes down (and never up again)
             while (!cancellationToken.IsCancellationRequested)
             {
-                connection ??= await WaitRandomConnection(cancellationToken).CfAwait();
+                connection ??= await WaitForConnection(cancellationToken).CfAwait();
 
                 // try to subscribe, relying on the default invocation timeout,
                 // so this is not going to last forever - we know it will end
@@ -788,7 +788,7 @@ namespace Hazelcast.Clustering
             {
                 _connections.Add(connection);
                 subscriptions = _subscriptions.Values.ToList();
-                _connectionOpened?.TrySetResult(null);
+                _connectionOpened?.TrySetResult(connection);
             }
 
             // in case we don't have one already...

--- a/src/Hazelcast.Net/HazelcastClient.cs
+++ b/src/Hazelcast.Net/HazelcastClient.cs
@@ -123,11 +123,12 @@ namespace Hazelcast
             // when a connection is closed, notify the heartbeat service
             Cluster.Connections.ConnectionClosed += conn => { Cluster.Heartbeat.RemoveConnection(conn); return default; };
 
-            // when a connection is closed, clears the associated subscriptions + ensure there is a cluster views connection
-            Cluster.Connections.ConnectionClosed += Cluster.Events.OnConnectionClosed;
-
             // when a connection is closed, notify the members service (may change the client state)
             Cluster.Connections.ConnectionClosed += async conn => { await Cluster.Members.RemoveConnectionAsync(conn).CfAwait(); };
+
+            // when a connection is closed, clears the associated subscriptions + ensure there is a cluster views connection
+            // 
+            Cluster.Connections.ConnectionClosed += Cluster.Events.OnConnectionClosed;
 
             // when a connection is closed, trigger the user-level event
             Cluster.Connections.ConnectionClosed += conn => Trigger<ConnectionClosedEventHandler, ConnectionClosedEventArgs>(new ConnectionClosedEventArgs(conn));

--- a/src/Hazelcast.Net/HazelcastClient.cs
+++ b/src/Hazelcast.Net/HazelcastClient.cs
@@ -79,51 +79,92 @@ namespace Hazelcast
 
         private void WireComponents()
         {
+            // this is the *only* place where independent components are wired together
+            //
             // assigning multi-cast handlers *must* use +=
+            // and then, handlers will run in the order they have been assigned
+            //
+            // this order is *important* for instance when a connection is opened we *must*
+            // publish compact schemas (if it is the first connection to a cluster) *before*
+            // notifying ClusterMembers, i.e. before the client state turns to 'connected'
+            // and client-level invocations (e.g. map.put) are allowed.
+            //
+            // the .NET client does not implement "urgent" invocations - properly ordering
+            // handlers here achieve the same result: separating "system-level" invocations
+            // from "user-level" invocations -- which require the client to be in the
+            // 'connected' state to run.
 
-            // when an object is created/destroyed, trigger the user-level events
-            Cluster.Events.ObjectCreated
-                += Trigger<DistributedObjectCreatedEventHandler, DistributedObjectCreatedEventArgs>;
+            // before sending a message, ensure we send the required compact schemas, if any
+            Cluster.Messaging.SendingMessage += SerializationService.CompactSerializer.BeforeSendingMessage;
 
-            Cluster.Events.ObjectDestroyed
-                += Trigger<DistributedObjectDestroyedEventHandler, DistributedObjectDestroyedEventArgs>;
+            // when a connection is created, wire its ReceivedEvent -> Events.OnReceivedEvent in order to handle events
+            Cluster.Connections.ConnectionCreated += Cluster.Events.OnConnectionCreated;
+
+            // when a distributed object is created, trigger the user-level event
+            Cluster.Events.ObjectCreated += Trigger<DistributedObjectCreatedEventHandler, DistributedObjectCreatedEventArgs>;
+
+            // when a distributed object is destroyed, trigger the user-level event
+            Cluster.Events.ObjectDestroyed += Trigger<DistributedObjectDestroyedEventHandler, DistributedObjectDestroyedEventArgs>;
 
             // when client/cluster state changes, trigger user-level events
-            Cluster.State.StateChanged
-                += state => Trigger<StateChangedEventHandler, StateChangedEventArgs>(new StateChangedEventArgs(state));
+            Cluster.State.StateChanged += state => Trigger<StateChangedEventHandler, StateChangedEventArgs>(new StateChangedEventArgs(state));
 
             // when partitions are updated, trigger the user-level event
-            Cluster.Events.PartitionsUpdated
-                += Trigger<PartitionsUpdatedEventHandler>;
+            Cluster.Events.PartitionsUpdated += Trigger<PartitionsUpdatedEventHandler>;
 
             // when a partition is lost, trigger the user-level event
-            Cluster.Events.PartitionLost
-                += Trigger<PartitionLostEventHandler, PartitionLostEventArgs>;
+            Cluster.Events.PartitionLost += Trigger<PartitionLostEventHandler, PartitionLostEventArgs>;
 
             // when members are updated, trigger the user-level event
-            Cluster.Events.MembersUpdated
-                += Trigger<MembersUpdatedEventHandler, MembersUpdatedEventArgs>;
+            Cluster.Events.MembersUpdated += Trigger<MembersUpdatedEventHandler, MembersUpdatedEventArgs>;
+
+            // -- ConnectionClosed -- order is *important* --
+
+            // when a connection is closed, notify the heartbeat service
+            Cluster.Connections.ConnectionClosed += conn => { Cluster.Heartbeat.RemoveConnection(conn); return default; };
+
+            // when a connection is closed, clears the associated subscriptions + ensure there is a cluster views connection
+            Cluster.Connections.ConnectionClosed += Cluster.Events.OnConnectionClosed;
+
+            // when a connection is closed, notify the members service (may change the client state)
+            Cluster.Connections.ConnectionClosed += async conn => { await Cluster.Members.RemoveConnectionAsync(conn).CfAwait(); };
 
             // when a connection is closed, trigger the user-level event
-            Cluster.Connections.ConnectionClosed
-                += conn => Trigger<ConnectionClosedEventHandler, ConnectionClosedEventArgs>(new ConnectionClosedEventArgs(conn));
+            Cluster.Connections.ConnectionClosed += conn => Trigger<ConnectionClosedEventHandler, ConnectionClosedEventArgs>(new ConnectionClosedEventArgs(conn));
 
-            // when a connection is opened, DistributedObjects.OnConnectionOpened checks whether it is the first
-            // connection to a new cluster, and then re-creates all the known distributed object so far on the
-            // new cluster. it does so by using the new connection, which should be stable: the only reason why
-            // a new connection could be teared down by ClusterMembers is if there already are known connections,
-            // which cannot be the case if this is the first connection. So we are not going to, like, jump to
-            // another connection while this runs - there's one and only connection for now.
-            Cluster.Connections.ConnectionOpened
-                += _distributedOjects.OnConnectionOpened;
+            // -- ConnectionOpened -- order is *important* --
+
+            // when the first connection to a cluster is opened, distributed objects may be re-created, compact
+            // schemas may be published, etc. this is all performed using the new connection, which should be
+            // stable. if it dies, then the client ends up disconnected again, and everything starts from scratch.
+            //
+            // while attempting the first connection, there is no members-connection task running, so there cannot
+            // be any other connection: it is not possible that this new connection dies and the client ends up
+            // running with other connections, but not fully initialized.
+            //
+            // note: because event subscriptions are installed before Cluster.Members is notified of the connection
+            // and can change the client state to 'connected', the client can potentially receive events before
+            // it is considered 'connected' and can issue user-level invocations. This happens too in Java.
+
+            // when the first connection to a cluster is opened, make sure we recreate the distributed objects
+            Cluster.Connections.ConnectionOpened += _distributedOjects.OnConnectionOpened;
 
             // when the first connection to a cluster is opened, make sure we republish all schemas
-            Cluster.Connections.ConnectionOpened
-                += Cluster.SerializationService.CompactSerializer.Schemas.OnConnectionOpened;
+            Cluster.Connections.ConnectionOpened += Cluster.SerializationService.CompactSerializer.Schemas.OnConnectionOpened;
+
+            // when a connection is opened, install event subscriptions + ensure there is a cluster views connection
+            Cluster.Connections.ConnectionOpened += Cluster.Events.OnConnectionOpened;
+            
+            // when a connection is opened, notify the heartbeat service
+            Cluster.Connections.ConnectionOpened += (conn, _, _, _) => { Cluster.Heartbeat.AddConnection(conn); return default; };
+
+            // and now, we can change the client state and let user-level invocations go through
+
+            // when a connection is opened, notify the members service (may change the client state)
+            Cluster.Connections.ConnectionOpened += (conn, _, _, isNewCluster) => { Cluster.Members.AddConnection(conn, isNewCluster); return default; };
 
             // when a connection is opened, trigger the user-level event.
-            Cluster.Connections.ConnectionOpened
-                += (conn, _, _, isNewCluster) => Trigger<ConnectionOpenedEventHandler, ConnectionOpenedEventArgs>(new ConnectionOpenedEventArgs(conn, isNewCluster));
+            Cluster.Connections.ConnectionOpened += (conn, _, _, isNewCluster) => Trigger<ConnectionOpenedEventHandler, ConnectionOpenedEventArgs>(new ConnectionOpenedEventArgs(conn, isNewCluster));
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/Messaging/IClusterMessaging.cs
+++ b/src/Hazelcast.Net/Messaging/IClusterMessaging.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Hazelcast.Clustering;
 using Hazelcast.Models;
 
 namespace Hazelcast.Messaging
@@ -46,6 +47,15 @@ namespace Hazelcast.Messaging
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The response message.</returns>
         Task<ClientMessage> SendAsync(ClientMessage requestMessage, bool raiseEvents, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sends a message to a member.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <param name="memberConnection">The member connection.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that will complete when the response is received, and represent the response message.</returns>
+        Task<ClientMessage> SendToMemberAsync(ClientMessage message, MemberConnection memberConnection, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the identifiers of the connected members.


### PR DESCRIPTION
This PR groups all events wiring in one single place in `HazelcastClient`, thus giving a clear view of what happens, and when.

Also, it re-orders some events to ensure that, for instance, Compact Serialization schemas are sent to a new cluster *before* the client is considered connected and can issue user-level invocations. This is documented in the source code.