### PR TITLE
Fix null connection exception during dispose [API-1821]

### DIFF
--- a/src/Hazelcast.Net/Clustering/ClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterEvents.cs
@@ -503,6 +503,10 @@ namespace Hazelcast.Clustering
                 // try to subscribe, relying on the default invocation timeout,
                 // so this is not going to last forever - we know it will end
                 var correlationId = _clusterState.GetNextCorrelationId();
+                
+                // Check once before subscription, state could be changed while waiting for a connection.
+                if(cancellationToken.IsCancellationRequested) break;
+                
                 if (!await SubscribeToClusterViewsAsync(connection, correlationId, cancellationToken).CfAwait()) // does not throw
                 {
                     // failed => try another connection

--- a/src/Hazelcast.Net/Clustering/ClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterEvents.cs
@@ -504,8 +504,8 @@ namespace Hazelcast.Clustering
                 // so this is not going to last forever - we know it will end
                 var correlationId = _clusterState.GetNextCorrelationId();
                 
-                // Check once before subscription, state could be changed while waiting for a connection.
-                if(cancellationToken.IsCancellationRequested) break;
+                // We can't use null connection here. Cancellation could be requested if it's null.
+                if(connection == null) break;
                 
                 if (!await SubscribeToClusterViewsAsync(connection, correlationId, cancellationToken).CfAwait()) // does not throw
                 {

--- a/src/Hazelcast.Net/Core/ConnectionRetryOptions.cs
+++ b/src/Hazelcast.Net/Core/ConnectionRetryOptions.cs
@@ -50,7 +50,7 @@ namespace Hazelcast.Core
         /// <summary>
         /// Gets or sets the multiplier.
         /// </summary>
-        public double Multiplier { get; set; } = 1;
+        public double Multiplier { get; set; } = 1.05;
 
         /// <summary>
         /// Gets or sets the timeout in milliseconds.


### PR DESCRIPTION
Fix null connection exception during dispose at cluster view subscription. `WaitForConnection ` returns null if cancelation is requested. During process, `SubscribeToClusterViewsAsync` takes null connection as an argument and fails. That causes problem while disposing the client, and so on tests.

Edit: Also, fixed the default value of multiplier in `ConnectionRetryOptions`.