### PR TITLE
Make Retry Strategy Logs More Visible [API-1832]

### DIFF
--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -600,7 +600,7 @@ namespace Hazelcast.Clustering
                         }
                         else
                         {
-                            _logger.IfDebug()?.LogDebug("Failed to connect to address {Address}.", address);
+                            _logger.IfWarning()?.LogWarning("Failed to connect to address {Address}.", address);
                         }
                     }
                 }

--- a/src/Hazelcast.Net/Clustering/RetryStrategy.cs
+++ b/src/Hazelcast.Net/Clustering/RetryStrategy.cs
@@ -132,7 +132,7 @@ namespace Hazelcast.Clustering
 
             var delay = GetDelay(elapsed);
 
-            _logger.IfDebug()?.LogDebug("Unable to {Action} after {Attempts} attempts and {Elapsed}ms, will retry in {Delay}ms", _action, _attempts, elapsed, delay);
+            _logger.IfWarning()?.LogWarning("Unable to {Action} after {Attempts} attempts and {Elapsed}ms, will retry in {Delay}ms", _action, _attempts, elapsed, delay);
 
             try
             {


### PR DESCRIPTION
Retry strategy was logging in debug level. It's hard to see if retry strategy is working in normal circumstances. So, aligned the log level with Java client and made it more visible.