### PR TITLE
Default Reconnect Mode Set to Sync [API-1857]

### DIFF
--- a/src/Hazelcast.Net.Tests/Networking/NetworkingTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/NetworkingTests.cs
@@ -529,10 +529,11 @@ namespace Hazelcast.Tests.Networking
                     options.Preview.EnableNewReconnectOptions = true;
                     options.Preview.EnableNewRetryOptions = true;
                     options.Networking.Reconnect = reconnect;
+                    options.Networking.ReconnectMode = reconnect ? ReconnectMode.ReconnectSync : ReconnectMode.DoNotReconnect;
                 }
                 else
                 {
-                    if (reconnect) options.Networking.ReconnectMode = ReconnectMode.ReconnectAsync;
+                    if (!reconnect) options.Networking.ReconnectMode = ReconnectMode.DoNotReconnect;
                 }
 
                 options.Networking.Addresses.Add("127.0.0.1:11000");

--- a/src/Hazelcast.Net.Tests/Networking/RegressionWithRealNetworkTest.cs
+++ b/src/Hazelcast.Net.Tests/Networking/RegressionWithRealNetworkTest.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Hazelcast.Core;
+using Hazelcast.Exceptions;
 using Hazelcast.Networking;
 using Hazelcast.Testing;
 using Hazelcast.Testing.Logging;
@@ -294,6 +295,54 @@ namespace Hazelcast.Tests.Networking
             Assert.AreEqual(2, await map.GetAsync(1));
         }
 
+        
+        [Test]
+        public async Task TestReconnectModes([Values] ReconnectMode mode)
+        {
+  
+            await StartCluster(Hazelcast.Testing.Remote.Resources.hazelcast);
+            var member1 = await AddMember();
+            await using var client = await CreateAndStartClientAsync(options =>
+            {
+                options.Networking.ReconnectMode = mode;
+                options.ClusterName = _cluster.Id;
+            });
+
+            await AssertEx.SucceedsEventually(() =>
+                {
+                    Assert.AreEqual(1, client.Members.Count);
+                    Assert.AreEqual(ClientState.Connected,client.State);
+                }, 
+                120_000, 1000);
+            
+            // Shutdown member
+            await RemoveMember(member1.Uuid);
+
+            if (mode == ReconnectMode.DoNotReconnect)
+            {
+                await AssertEx.SucceedsEventually(() =>
+                    {
+                        //No need to check member count, client will go to shutdown directly.
+                        Assert.AreEqual(ClientState.Shutdown,client.State);
+                        Assert.ThrowsAsync<ClientOfflineException>(async () => await client.GetMapAsync<int, int>("someMap"));
+                    }, 120_000, 1000);
+            }
+            // Client will reconnect. FIXME: Separate sync and async modes when implemented. 
+            else
+            {
+                member1 = await AddMember();
+                await AssertEx.SucceedsEventually(() =>
+                    {
+                        Assert.AreEqual(1, client.Members.Count);
+                        Assert.AreEqual(ClientState.Connected,client.State);
+                    }, 120_000, 1000);
+                
+                await RemoveMember(member1.Uuid);    
+            }
+
+            await client.DisposeAsync();
+        }
+        
         private static string GetMemberConfigWithAddress(string memberAddress)
         {
             if (string.IsNullOrEmpty(memberAddress)) throw new ArgumentNullException(nameof(memberAddress));

--- a/src/Hazelcast.Net.Tests/Remote/ClientTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientTests.cs
@@ -23,7 +23,7 @@ using NUnit.Framework;
 namespace Hazelcast.Tests.Remote
 {
     [TestFixture]
-    [Timeout(4_000)]
+    [Timeout(10_000)]
     public class ClientTests : SingleMemberRemoteTestBase
     {
         [Test]

--- a/src/Hazelcast.Net/Networking/NetworkingOptions.cs
+++ b/src/Hazelcast.Net/Networking/NetworkingOptions.cs
@@ -111,7 +111,7 @@ namespace Hazelcast.Networking
         /// <summary>
         /// Gets or sets the <see cref="ReconnectMode"/> in case the client is disconnected.
         /// </summary>
-        public ReconnectMode ReconnectMode { get; set; } = ReconnectMode.DoNotReconnect;
+        public ReconnectMode ReconnectMode { get; set; } = ReconnectMode.ReconnectSync;
 
         /// <summary>
         /// Whether to attempt to automatically reconnect a client that has been disconnected.


### PR DESCRIPTION
Corrected the default mode, and fixed the related tests. Documentation matches with the behavior now. 