### PR TITLE
[API-1824] Fix Compact Serialization as per QA

### DIFF
--- a/src/Hazelcast.Net.Testing/Accessors/MemberConnectionAccessor.cs
+++ b/src/Hazelcast.Net.Testing/Accessors/MemberConnectionAccessor.cs
@@ -22,10 +22,10 @@ namespace Hazelcast.Testing.Accessors
         public MemberConnectionAccessor(MemberConnection instance): base(instance)
         { }
 
-        public bool Active
+        public bool Connected
         {
-            get => GetField<bool>("_active");
-            set => SetField("_active", value);
+            get => GetField<bool>("_connected");
+            set => SetField("_connected", value);
         }
 
         public Guid MemberId

--- a/src/Hazelcast.Net.Testing/RemoteControllerClientExtensions.cs
+++ b/src/Hazelcast.Net.Testing/RemoteControllerClientExtensions.cs
@@ -167,7 +167,7 @@ namespace Hazelcast.Testing
                     })
                     .MembersUpdated((sender, args) =>
                     {
-                        // removing one member amongst others triggers this event
+                        // removing one member amongst others triggers this event (but does not disconnect the client)
                         if (args.RemovedMembers.Count > 0) removed.Release();
                     }))
                 .CfAwait();

--- a/src/Hazelcast.Net.Testing/RemoteControllerClientExtensions.cs
+++ b/src/Hazelcast.Net.Testing/RemoteControllerClientExtensions.cs
@@ -160,8 +160,14 @@ namespace Hazelcast.Testing
             var removed = new SemaphoreSlim(0);
 
             var subscriptionId = await clientInternal.SubscribeAsync(on => on
+                    .StateChanged((sender, args) =>
+                    {
+                        // removing the only member disconnects the client and triggers this event
+                        if (args.State == ClientState.Disconnected) removed.Release();
+                    })
                     .MembersUpdated((sender, args) =>
                     {
+                        // removing one member amongst others triggers this event
                         if (args.RemovedMembers.Count > 0) removed.Release();
                     }))
                 .CfAwait();

--- a/src/Hazelcast.Net.Tests/Clustering/ConnectMembersTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/ConnectMembersTests.cs
@@ -61,6 +61,7 @@ namespace Hazelcast.Tests.Clustering
             var cancellation = new CancellationTokenSource();
             var connecting = ConnectMembers(queue, cancellation.Token);
 
+            queue.Resume(); // the queue is initially suspended, resume
 
             // -- connects
 
@@ -210,6 +211,8 @@ namespace Hazelcast.Tests.Clustering
 
             var cancellation = new CancellationTokenSource();
             var connecting = ConnectMembers(queue, cancellation.Token);
+
+            queue.Resume(); // the queue is initially suspended, resume
 
             // -- connects
 

--- a/src/Hazelcast.Net.Tests/Clustering/MemberConnectionTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberConnectionTests.cs
@@ -397,7 +397,7 @@ namespace Hazelcast.Tests.Clustering
                 new SslOptions(), new Int64Sequence(), loggerFactory
             );
 
-            connection.Accessor().Active = true;
+            connection.Accessor().Connected = true;
             connection.Accessor().MemberId = member.Id;
 
             return connection;

--- a/src/Hazelcast.Net.Tests/Clustering/SubscriptionCollectTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/SubscriptionCollectTests.cs
@@ -24,6 +24,7 @@ using Hazelcast.Protocol.Codecs;
 using Hazelcast.Protocol.Models;
 using Hazelcast.Serialization;
 using Hazelcast.Testing;
+using Hazelcast.Testing.Logging;
 using Hazelcast.Testing.TestServer;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
@@ -92,7 +93,9 @@ namespace Hazelcast.Tests.Clustering
 
             HConsole.WriteLine(this, "Start client");
 
-            var options = new HazelcastOptionsBuilder().With(options =>
+            var options = new HazelcastOptionsBuilder()
+                .WithHConsoleLogger()
+                .With(options =>
             {
                 options.Networking.Addresses.Add("127.0.0.1:11001");
                 options.Networking.Addresses.Add("127.0.0.1:11002");

--- a/src/Hazelcast.Net.Tests/Remote/ClientTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientTests.cs
@@ -23,7 +23,7 @@ using NUnit.Framework;
 namespace Hazelcast.Tests.Remote
 {
     [TestFixture]
-    [Timeout(10_000)]
+    [Timeout(30_000)]
     public class ClientTests : SingleMemberRemoteTestBase
     {
         [Test]
@@ -40,7 +40,7 @@ namespace Hazelcast.Tests.Remote
         }
 
         [Test]
-        public async Task ClientStaringClientWithConfig()
+        public async Task ClientStartingClientWithConfig()
         {
             var clientStarting =  HazelcastClientFactory.GetNewStartingClient(CreateHazelcastOptions());
             await clientStarting.Task;
@@ -48,7 +48,7 @@ namespace Hazelcast.Tests.Remote
         }
         
         [Test]
-        public async Task ClientStaringClientWithConfig2()
+        public async Task ClientStatringClientWithConfig2()
         {
             var o = CreateHazelcastOptions();
             var clientStarting =  HazelcastClientFactory.GetNewStartingClient(options=>

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/CompactQaTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/CompactQaTests.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hazelcast.Core;
+using Hazelcast.Exceptions;
+using Hazelcast.Messaging;
+using Hazelcast.Networking;
+using Hazelcast.Partitioning;
+using Hazelcast.Protocol.Codecs;
+using Hazelcast.Serialization;
+using Hazelcast.Testing;
+using Hazelcast.Testing.Logging;
+using NUnit.Framework;
+
+namespace Hazelcast.Tests.Serialization.Compact;
+
+[TestFixture]
+public class CompactQaTests : ClusterRemoteTestBase
+{
+    private IDisposable UseHConsole() => HConsole.Capture(o => o
+        .Configure().SetMaxLevel()
+        .Configure(this).SetPrefix("TEST")
+        .Configure<SocketConnectionBase>().SetIndent(8).SetPrefix("SOCKET").SetLevel(0)
+        .Configure<ClientMessageConnection>().SetMinLevel()
+        .Configure<AsyncContext>().SetMinLevel()
+        .Configure<Partitioner>().SetLevel(1));
+
+    [Test]
+    public async Task ClientGoesOffline()
+    {
+        using var _ = UseHConsole();
+
+        var throwException = false;
+
+        // start a member
+        var member = await RcClient.StartMemberAsync(RcCluster).CfAwait();
+        await using var cleanup = new DisposeAsyncAction(async () => await RcClient.StopMemberAsync(RcCluster, member));
+
+        // use a clean client + hook into cluster messaging to capture messages (before client starts)
+        await using var client = HazelcastClientFactory.CreateClient(CreateHazelcastOptions());
+        // use an internal-level handler, exceptions in user-level handlers are caught
+        client.Cluster.Connections.ConnectionOpened += (_, _, _, _) =>
+        {
+            if (throwException) throw new Exception("bang!");
+            return default;
+        };
+        await client.StartAsync(CancellationToken.None);
+
+        var map = await client.GetMapAsync<int, IGenericRecord>("bar");
+        await map.PutAsync(1, GenericRecordBuilder.Compact("bar1").Build());
+
+        // stop the member, wait until it is actually removed (else we might reconnect to it)
+        await RcClient.StopMemberWaitRemovedAsync(client, RcCluster, member).CfAwait();
+
+        // trigger exceptions
+        throwException = true;
+
+        // start another member
+        member = await RcClient.StartMemberAsync(RcCluster).CfAwait();
+
+        // this will never complete because we'll never be able to reconnect
+        //
+        // Java: ReconnectMode can be OFF, ON (blocking invocations) or ASYNC (not blocking, triggers HazelcastClientOfflineException)
+        // .NET: ReconnectMode can be DoNotReconnect = OFF, ReconnectSync or ReconnectAsync - but these two have the same effect
+        //
+        // In Java, ASYNC causes any invocation to *immediately* fail with HazelcastClientOfflineException if the client is
+        // reconnecting, whereas ON causes the invocation to be retried, and it may eventually fail with OperationTimeoutException.
+        //
+        // In .NET, invocations are tried (and retried) while the client is reconnecting, until either the client reconnects and
+        // the invocation succeeds, or it times out. So, essentially, .NET is ON and it makes sense that we get a TaskTimeoutException
+        // below.
+
+        await AssertEx.ThrowsAsync<TaskTimeoutException>(async () => await map.PutAsync(2, GenericRecordBuilder.Compact("bar2").Build()).CfAwait());
+
+        await RcClient.StopMemberAsync(RcCluster, member).CfAwait();
+    }
+
+    [Test]
+    public async Task ClusterRestart()
+    {
+        //using var _ = UseHConsole();
+
+        // start a member
+        var member = await RcClient.StartMemberAsync(RcCluster).CfAwait();
+        await using var cleanup = new DisposeAsyncAction(async () => await RcClient.StopMemberAsync(RcCluster, member));
+
+        var messages = new List<ClientMessage>();
+
+        // use a clean client + hook into cluster messaging to capture messages (before client starts)
+        await using var client = HazelcastClientFactory.CreateClient(CreateHazelcastOptions());
+        client.Cluster.Messaging.SendingMessage += message =>
+        {
+            messages.Add(message);
+            return default;
+        };
+        await client.StartAsync(CancellationToken.None);
+
+        var map = await client.GetMapAsync<int, IGenericRecord>("bar");
+
+        // add values = will publish the corresponding schemas
+        await map.PutAsync(1, GenericRecordBuilder.Compact("bar1").Build());
+        await map.PutAsync(2, GenericRecordBuilder.Compact("bar2").Build());
+
+        // stop the member, wait until it is actually removed (else we might reconnect to it)
+        await RcClient.StopMemberWaitRemovedAsync(client, RcCluster, member);
+
+        messages.Clear();
+
+        // start another member
+        member = await RcClient.StartMemberAsync(RcCluster);
+
+        // new member, values are lost
+        var value1 = await map.GetAsync(1);
+        Assert.That(value1, Is.Null);
+
+        // if we've been reconnected, schemas have been republished
+        Assert.That(messages.Any(x => x.MessageType == ClientSendAllSchemasCodec.RequestMessageType));
+
+        await RcClient.StopMemberAsync(RcCluster, member).CfAwait();
+    }
+
+    [Test]
+    public async Task ReadSchemaAfterWrite_withObjectValueType()
+    {
+        //using var _ = UseHConsole();
+
+        // start a member
+        var member = await RcClient.StartMemberAsync(RcCluster).CfAwait();
+        await using var cleanup = new DisposeAsyncAction(async () => await RcClient.StopMemberAsync(RcCluster, member));
+
+        // use a clean client
+        await using var client = await CreateAndStartClientAsync();
+
+        var map = await client.GetMapAsync<int, object>("bar");
+
+        await map.PutAsync(1, GenericRecordBuilder.Compact("bar1").Build());
+        var value = await map.PutAsync(1, GenericRecordBuilder.Compact("bar2").Build());
+        Assert.That(value, Is.Not.Null);
+        Assert.That(value, Is.InstanceOf<IGenericRecord>());
+
+        await RcClient.StopMemberAsync(RcCluster, member).CfAwait();
+    }
+
+    protected override HazelcastOptions CreateHazelcastOptions()
+    {
+        var options = base.CreateHazelcastOptions();
+        options.Networking.ReconnectMode = ReconnectMode.ReconnectSync;
+        options.Messaging.RetryTimeoutSeconds = 10;
+        return options;
+    }
+
+    protected override HazelcastOptionsBuilder CreateHazelcastOptionsBuilder()
+    {
+        return base.CreateHazelcastOptionsBuilder().WithHConsoleLogger();
+    }
+}

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/CompactQaTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/CompactQaTests.cs
@@ -66,6 +66,7 @@ public class CompactQaTests : ClusterRemoteTestBase
 
     [TestCase(true)]
     [TestCase(false)]
+    [Explicit]
     public async Task ExceptionPreventsClientFromReconnecting(bool recover)
     {
         using var _ = UseHConsole();

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/CompactSerializationSerializerTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/CompactSerializationSerializerTests.cs
@@ -234,8 +234,18 @@ namespace Hazelcast.Tests.Serialization.Compact
 
             var input = new ObjectDataInput(output.ToByteArray(), orw, Endianness.BigEndian);
 
-            // fails because the type cannot be constructed
-            Assert.Throws<SerializationException>(() => serializer.Read(input));
+            // fails because the type cannot be constructed, and therefore we cannot create a
+            // proper compact serialization registration producing an ImpossibleType = we don't
+            // know how to deserialize.
+            Assert.Throws<SerializationException>(() => serializer.Read<ImpossibleType>(input));
+
+            // on the other hand, if we don't specify the type, we indicate that we accept any
+            // object, and therefore since we fail to create a proper registration we fall back
+            // to generic record.
+            input.Position = 0;
+            var obj = serializer.Read(input);
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj, Is.InstanceOf<IGenericRecord>());
         }
 
         public class ImpossibleType

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/CompactSerializerTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/CompactSerializerTests.cs
@@ -186,6 +186,66 @@ namespace Hazelcast.Tests.Serialization.Compact
             Assert.Throws<ArgumentNullException>(() => ((Type)null).IsICompactSerializerOfTSerialized(out _));
         }
 
+        [Test]
+        public void ZeroConfigContainsExplicit()
+        {
+            var options = new SerializationOptions();
+            options.Compact.AddSerializer(new ThingCompactSerializer()); // Thing is explicit
+
+            // create the entire serialization service
+            var messaging = Mock.Of<IClusterMessaging>();
+            var service = HazelcastClientFactory.CreateSerializationService(options, messaging, new NullLoggerFactory());
+
+            var inner = new Thing
+            {
+                Name = "thingName",
+                Value = 42
+            };
+
+            var outer = new ThingNest
+            {
+                Name = "nestName",
+                Thing = inner
+            };
+
+            Console.WriteLine("ToData:");
+            var data = service.ToData(outer, false);
+            var obj = service.ToObject<ThingNest>(data);
+
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.Thing.Value, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void ExplicitContainsZeroConfig()
+        {
+            var options = new SerializationOptions();
+            options.Compact.AddSerializer(new ThingNestCompactSerializer()); // ThingNest is explicit
+
+            // create the entire serialization service
+            var messaging = Mock.Of<IClusterMessaging>();
+            var service = HazelcastClientFactory.CreateSerializationService(options, messaging, new NullLoggerFactory());
+
+            var inner = new Thing
+            {
+                Name = "thingName",
+                Value = 42
+            };
+
+            var outer = new ThingNest
+            {
+                Name = "nestName",
+                Thing = inner
+            };
+
+            Console.WriteLine("ToData:");
+            var data = service.ToData(outer, false);
+            var obj = service.ToObject<ThingNest>(data);
+
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.Thing.Value, Is.EqualTo(42));
+        }
+
         private class DefaultNameThingSerializer : CompactSerializerBase<Thing>
         {
             public override Thing Read(ICompactReader reader) => throw new NotSupportedException();

--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -935,7 +935,18 @@ namespace Hazelcast.Clustering
             // ended by now
             _cancel.Cancel();
             if (_connectMembers != null)
-                await _connectMembers.CfAwaitCanceled();
+            {
+                try
+                {
+                    await _connectMembers.CfAwait(120_000); // give it 2 mins
+                }
+                catch (OperationCanceledException)
+                { }
+                catch (Exception e)
+                {
+                    _logger.IfWarning()?.LogWarning(e, "Caught exception when waiting for ConnectMembers to terminate.");
+                }
+            }
             _cancel.Dispose();
 
             // stop and dispose the reconnect task if it's running

--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -920,7 +920,6 @@ namespace Hazelcast.Clustering
                 if (_completions.TryRemove(connection, out var completion)) completion.SetResult(null);
             }
 
-            connection.EnableEvents();
             return connection;
         }
 

--- a/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
@@ -271,24 +271,23 @@ namespace Hazelcast.Clustering
 
             // NOTE: *every* invocation sent to the cluster goes through the code below
 
-            // if the client is active but not connected, we are going to retry the invocation for a while (assuming it
-            // is retryable) and then timeout and bubble the invocation to the user - and we do *not* have a way to sort
-            // of suspend the whole client waiting for it to reconnect, because... what sense does it make? That would
-            // be the "sync" reconnect mode - TODO: figure this out
-
             while (true)
             {
                 try
                 {
+                    HConsole.WriteLine(this, "Trying...");
                     var connection = GetInvocationConnection(invocation); // non-null, throws if no connections
                     return await connection.SendAsync(invocation, cancellationToken).CfAwait();
                 }
                 catch (TaskCanceledException)
                 {
+                    HConsole.WriteLine(this, "Canceled.");
                     throw;
                 }
                 catch (Exception exception)
                 {
+                    HConsole.WriteLine(this, "Exception.");
+
                     // if the client is not active, die - an active client is starting, started, connected or
                     // disconnected - but attempting to reconnect - whereas a non-active client is down and
                     // will not go back up
@@ -311,11 +310,13 @@ namespace Hazelcast.Clustering
                     if (!invocation.IsRetryable(exception, retryUnsafeOperations, retryOnClientReconnecting))
                         throw;
 
+                    HConsole.WriteLine(this, "Wait...");
+
                     // else, wait for retrying
                     // this will throw if it cannot retry
                     await invocation.WaitRetryAsync(() => _clusterState.GetNextCorrelationId(), cancellationToken).CfAwait();
 
-                    HConsole.WriteLine(this, "Retrying...");
+                    HConsole.WriteLine(this, "Retry");
                 }
             }
         }

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -60,9 +60,16 @@ namespace Hazelcast.Clustering
         private ClientSocketConnection _socketConnection;
         private ClientMessageConnection _messageConnection;
 
-        private readonly object _mutex = new object();
+        private readonly object _mutex = new();
         private volatile bool _disposed;
-        private volatile bool _active;
+
+        // _connected indicates whether the connection is "connected" ie went through auth successfully
+        // and returned from ConnectAsync. then, "things" will happen (mostly, the ConnectionOpened
+        // event) and then, _eventsEnabled will switch to true to indicate that the connection is fully
+        // operational an can raise events. if "things" fail, then the connection may reveive events,
+        // but should not raise them as they are not valid.
+        private volatile bool _connected;
+        private volatile bool _eventsEnabled;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemberConnection"/> class.
@@ -119,6 +126,16 @@ namespace Hazelcast.Clustering
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        public void EnableEvents()
+        {
+            lock (_mutex)
+                if (_connected && !_disposed)
+                    _eventsEnabled = true;
+        }
+
         #endregion
 
         /// <summary>
@@ -129,7 +146,7 @@ namespace Hazelcast.Clustering
         /// <summary>
         /// Whether the connection is active.
         /// </summary>
-        public bool Active => _active;
+        public bool Active => _connected;
 
         /// <summary>
         /// Gets the unique identifier of the cluster member that this connection is connected to.
@@ -231,7 +248,7 @@ namespace Hazelcast.Clustering
             lock (_mutex)
             {
                 disposed = _disposed;
-                _active = !_disposed;
+                _connected = !_disposed;
             }
 
             if (disposed)
@@ -315,8 +332,15 @@ namespace Hazelcast.Clustering
         {
             try
             {
-                HConsole.WriteLine(this, $"Raise event {Id.ToShortString()}:{message.CorrelationId}");
-                _receivedEvent(message);
+                if (!_eventsEnabled)
+                {
+                    HConsole.WriteLine(this, $"Ignore event {Id.ToShortString()}:{message.CorrelationId}");
+                }
+                else
+                {
+                    HConsole.WriteLine(this, $"Raise event {Id.ToShortString()}:{message.CorrelationId}");
+                    _receivedEvent(message);
+                }
             }
             catch (Exception e)
             {
@@ -423,7 +447,7 @@ namespace Hazelcast.Clustering
                 HConsole.WriteLine(this, "Exception while sending: " + e);
                 captured = e;
                 _invocations.TryRemove(invocation.CorrelationId, out _);
-                if (_active) throw; // if not active, better throw a disconnected exception below
+                if (_connected) throw; // if not active, better throw a disconnected exception below
                 success = false;
             }
 
@@ -432,7 +456,7 @@ namespace Hazelcast.Clustering
                 _invocations.TryRemove(invocation.CorrelationId, out _);
                 HConsole.WriteLine(this, "Failed to send a message.");
 
-                if (!_active)
+                if (!_connected)
                     throw new TargetDisconnectedException(captured);
 
                 // TODO: we need a better exception
@@ -475,8 +499,8 @@ namespace Hazelcast.Clustering
             {
                 if (_disposed) return;
                 _disposed = true;
-                active = _active;
-                _active = false;
+                active = _connected;
+                _connected = false;
             }
 
             try

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -62,14 +62,7 @@ namespace Hazelcast.Clustering
 
         private readonly object _mutex = new();
         private volatile bool _disposed;
-
-        // _connected indicates whether the connection is "connected" ie went through auth successfully
-        // and returned from ConnectAsync. then, "things" will happen (mostly, the ConnectionOpened
-        // event) and then, _eventsEnabled will switch to true to indicate that the connection is fully
-        // operational an can raise events. if "things" fail, then the connection may reveive events,
-        // but should not raise them as they are not valid.
         private volatile bool _connected;
-        private volatile bool _eventsEnabled;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemberConnection"/> class.
@@ -124,16 +117,6 @@ namespace Hazelcast.Clustering
                     throw new InvalidOperationException(ExceptionMessages.PropertyIsNowReadOnly);
                 _closed = value;
             }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public void EnableEvents()
-        {
-            lock (_mutex)
-                if (_connected && !_disposed)
-                    _eventsEnabled = true;
         }
 
         #endregion
@@ -332,15 +315,8 @@ namespace Hazelcast.Clustering
         {
             try
             {
-                if (!_eventsEnabled)
-                {
-                    HConsole.WriteLine(this, $"Ignore event {Id.ToShortString()}:{message.CorrelationId}");
-                }
-                else
-                {
-                    HConsole.WriteLine(this, $"Raise event {Id.ToShortString()}:{message.CorrelationId}");
-                    _receivedEvent(message);
-                }
+                HConsole.WriteLine(this, $"Raise event {Id.ToShortString()}:{message.CorrelationId}");
+                _receivedEvent(message);
             }
             catch (Exception e)
             {

--- a/src/Hazelcast.Net/Clustering/MemberConnectionQueue.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnectionQueue.cs
@@ -20,288 +20,303 @@ using Hazelcast.Core;
 using Hazelcast.Models;
 using Microsoft.Extensions.Logging;
 
-namespace Hazelcast.Clustering
+namespace Hazelcast.Clustering;
+
+/// <summary>
+/// Represents the queue of members that need to be connected.
+/// </summary>
+internal class MemberConnectionQueue : IAsyncEnumerable<MemberConnectionRequest>, IAsyncDisposable
 {
+    private readonly AsyncQueue<MemberConnectionRequest> _requests = new();
+    private readonly AsyncQueue<MemberConnectionRequest> _delayed = new();
+    private readonly CancellationTokenSource _cancel = new();
+
+    private readonly SemaphoreSlim _resume = new(1); // blocks the queue when it is suspended
+    private readonly SemaphoreSlim _enumerate = new(1); // ensures there can be only 1 concurrent enumerator
+
+    private readonly object _mutex = new();
+
+    private readonly ILogger _logger;
+    private readonly Task _delaying;
+
+    private volatile bool _disposed;
+    private MemberConnectionRequest _request;
+    private bool _suspended = true;
+
     /// <summary>
-    /// Represents the queue of members that need to be connected.
+    /// Initializes a new instance of the <see cref="MemberConnectionQueue"/> class.
     /// </summary>
-    internal class MemberConnectionQueue : IAsyncEnumerable<MemberConnectionRequest>, IAsyncDisposable
+    /// <param name="loggerFactory">A logger factory.</param>
+    public MemberConnectionQueue(ILoggerFactory loggerFactory)
     {
-        private readonly AsyncQueue<MemberConnectionRequest> _requests = new AsyncQueue<MemberConnectionRequest>();
-        private readonly AsyncQueue<MemberConnectionRequest> _delayed = new AsyncQueue<MemberConnectionRequest>();
-        private readonly CancellationTokenSource _cancel = new CancellationTokenSource();
+        if (loggerFactory == null) throw new ArgumentNullException(nameof(loggerFactory));
+        _logger = loggerFactory.CreateLogger<MemberConnectionQueue>();
+        _delaying = Delay();
 
-        private readonly SemaphoreSlim _resume = new SemaphoreSlim(0); // blocks the queue when it is suspended
-        private readonly SemaphoreSlim _enumerate = new SemaphoreSlim(1); // ensures there can be only 1 concurrent enumerator
+        HConsole.Configure(x => x.Configure<MemberConnectionQueue>().SetPrefix("MBRQ"));
+    }
 
-        private readonly object _mutex = new object();
+    public event EventHandler<MemberConnectionRequest> ConnectionFailed;
 
-        private readonly ILogger _logger;
-        private readonly Task _delaying;
+    /// <summary>
+    /// (internals for tests only) Gets the count of requests in the queue.
+    /// </summary>
+    internal int RequestsCount => _requests.Count;
 
-        private volatile bool _disposed;
-        private MemberConnectionRequest _request;
-        private bool _suspended;
+    /// <summary>
+    /// (internals for tests only) Gets the count of delayed requests in the queue.
+    /// </summary>
+    internal int DelayedRequestsCount => _delayed.Count;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MemberConnectionQueue"/> class.
-        /// </summary>
-        /// <param name="loggerFactory">A logger factory.</param>
-        public MemberConnectionQueue(ILoggerFactory loggerFactory)
+    /// <summary>
+    /// Suspends the queue.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> that will be completed when the queue is suspended.</returns>
+    /// <remarks>
+    /// <para>If an item is being processed, this waits for the processing to complete.</para>
+    /// <para>When the queue is suspended, calls to the enumerator's MoveNextAsync() method blocks.</para>
+    /// </remarks>
+    public ValueTask SuspendAsync()
+    {
+        lock (_mutex)
         {
-            if (loggerFactory == null) throw new ArgumentNullException(nameof(loggerFactory));
-            _logger = loggerFactory.CreateLogger<MemberConnectionQueue>();
-            _delaying = Delay();
+            if (_disposed) return default; // nothing to suspend - but no need to throw about it
+            if (_suspended) return default; // already suspended
 
-            HConsole.Configure(x => x.Configure<MemberConnectionQueue>().SetPrefix("MBRQ"));
+            _logger.IfDebug()?.LogDebug("Suspend the members connection queue.");
+            _suspended = true;
+
+            // the default MemberConnectionRequest's Completion is the default ValueTask
+            // otherwise, is used to ensure that the request is completed before actually being suspended
+            return _request == null ? default : _request.Completion;
         }
+    }
 
-        public event EventHandler<MemberConnectionRequest> ConnectionFailed;
-
-        /// <summary>
-        /// (internals for tests only) Gets the count of requests in the queue.
-        /// </summary>
-        internal int RequestsCount => _requests.Count;
-
-        /// <summary>
-        /// (internals for tests only) Gets the count of delayed requests in the queue.
-        /// </summary>
-        internal int DelayedRequestsCount => _delayed.Count;
-
-        /// <summary>
-        /// Suspends the queue.
-        /// </summary>
-        /// <returns>A <see cref="ValueTask"/> that will be completed when the queue is suspended.</returns>
-        /// <remarks>
-        /// <para>If an item is being processed, this waits for the processing to complete.</para>
-        /// <para>When the queue is suspended, calls to the enumerator's MoveNextAsync() method blocks.</para>
-        /// </remarks>
-        public ValueTask SuspendAsync()
+    /// <summary>
+    /// Clears the queue.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The queue is not suspended.</exception>
+    public void Clear()
+    {
+        lock (_mutex)
         {
-            lock (_mutex)
+            if (_disposed) return; // nothing to resume - but no need to throw about it
+            if (!_suspended) throw new InvalidOperationException("Cannot clear the queue when it is not suspended.");
+            _logger.IfDebug()?.LogDebug("Clear the members connection queue.");
+            _requests.ForEach(x => x.Cancel());
+            _delayed.ForEach(x => x.Cancel());
+        }
+    }
+
+    /// <summary>
+    /// Resumes the queue.
+    /// </summary>
+    /// <remarks>
+    /// <para>If <paramref name="drain"/> is <c>true</c>, de-queues and ignores all queued items.</para>
+    /// <para>Unblocks calls to the enumerator MoveNextAsync() method.</para>
+    /// </remarks>
+    public void Resume(bool drain = false)
+    {
+        lock (_mutex)
+        {
+            if (_disposed) return; // nothing to resume - but no need to throw about it
+            if (!_suspended) return; // no need to resume
+            _logger.IfDebug()?.LogDebug("{DrainState} the members connection queue.", (drain ? "Drain and resume" : "Resume"));
+            if (drain)
             {
-                if (_disposed) return default; // nothing to suspend - but no need to throw about it
+                _requests.ForEach(x => x.Cancel());
+                _delayed.ForEach(x => x.Cancel());
+            }
+            _suspended = false;
+            _resume.Release();
+        }
+    }
 
-                _logger.IfDebug()?.LogDebug("Suspend the members connection queue.");
-                _suspended = true;
+    /// <summary>
+    /// Adds a member to connect.
+    /// </summary>
+    /// <param name="member">The member to connect.</param>
+    public void Add(MemberInfo member)
+    {
+        if (_disposed) return; // no need to add - no need to throw about it
 
-                // _request is a struct and cannot be null
-                // the default MemberConnectionRequest's Completion is the default ValueTask
-                // otherwise, is used to ensure that the request is completed before actually being suspended
-                return _request.Completion;
+        lock (_mutex)
+        {
+            if (!_requests.TryWrite(new MemberConnectionRequest(member)))
+            {
+                // that should not happen, but log to be sure
+                _logger.IfWarning()?.LogWarning("Failed to add member ({MemberId}).", member.Id.ToShortString());
+            }
+            else
+            {
+                _logger.IfDebug()?.LogDebug("Added member {MemberId}", member.Id.ToShortString());
             }
         }
+    }
 
-        /// <summary>
-        /// Resumes the queue.
-        /// </summary>
-        /// <remarks>
-        /// <para>If <paramref name="drain"/> is <c>true</c>, de-queues and ignores all queued items.</para>
-        /// <para>Unblocks calls to the enumerator MoveNextAsync() method.</para>
-        /// </remarks>
-        public void Resume(bool drain = false)
+    /// <summary>
+    /// Adds a request again.
+    /// </summary>
+    /// <param name="request">The request.</param>
+    public void AddAgain(MemberConnectionRequest request)
+    {
+        if (_disposed || request.Cancelled) return; // no need to add - no need to throw about it
+
+        request.Reset();
+        _delayed.TryWrite(request);
+    }
+
+    private async Task Delay()
+    {
+        const int minDelay = 1000; // milliseconds - but later on each request could have a retry strategy
+
+        await foreach (var request in _delayed.WithCancellation(_cancel.Token))
         {
-            lock (_mutex)
+            var delay = minDelay - (int)request.Elapsed.TotalMilliseconds;
+            _logger.IfDebug()?.LogDebug("Request for member {Member} delayed {Delay}ms", request.Member.Id.ToShortString(), delay > 0 ? delay : 0);
+            if (delay > 0) await Task.Delay(delay, _cancel.Token).CfAwait();
+            _logger.IfDebug()?.LogDebug("Request for member {Member} queued for retry", request.Member.Id.ToShortString());
+            _requests.TryWrite(request);
+        }
+    }
+
+    // when receiving members from the cluster... if a member is gone,
+    // we need to remove it from the queue, no need to ever try to connect
+    // to it again - so it remains in the _members async queue, but we
+    // flag it so that when we dequeue it, we can ignore it
+
+    /// <summary>
+    /// Removes a member.
+    /// </summary>
+    /// <param name="memberId">The identifier of the member.</param>
+    public void Remove(Guid memberId)
+    {
+        // cancel all corresponding requests - see notes in AsyncQueue, this is best-effort,
+        // a member that we want to remove *may* end up being enumerated, and we're going to
+        // to to connect to it, and either fail, or drop the connection - accepted tradeoff
+        lock (_mutex) {
+            _requests.ForEach(x =>
             {
-                if (_disposed) return; // nothing to resume - but no need to throw about it
-                if (!_suspended) throw new InvalidOperationException("Not suspended.");
-                _logger.IfDebug()?.LogDebug("{DrainState} the members connection queue.", (drain ? "Drain and resume" : "Resume"));
-                if (drain)
-                {
-                    _requests.ForEach(x => x.Cancel());
-                    _delayed.ForEach(x => x.Cancel());
-                }
-                _suspended = false;
-                _resume.Release();
-            }
-        }
-
-        /// <summary>
-        /// Adds a member to connect.
-        /// </summary>
-        /// <param name="member">The member to connect.</param>
-        public void Add(MemberInfo member)
-        {
-            if (_disposed) return; // no need to add - no need to throw about it
-
-            lock (_mutex)
+                if (x.Member.Id == memberId) x.Cancel();
+            });
+            _delayed.ForEach(x =>
             {
-                if (!_requests.TryWrite(new MemberConnectionRequest(member)))
-                {
-                    // that should not happen, but log to be sure
-                    _logger.IfWarning()?.LogWarning("Failed to add member ({MemberId}).", member.Id.ToShortString());
-                }
-                else
-                {
-                    _logger.IfDebug()?.LogDebug("Added member {MemberId}", member.Id.ToShortString());
-                }
-            }
+                if (x.Member.Id == memberId) x.Cancel();
+            });
+        }
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerator<MemberConnectionRequest> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(MemberConnectionQueue));
+
+        // ensure that disposing this class cancels the enumeration
+        return new AsyncEnumerator(this, _cancel.Token, cancellationToken);
+    }
+
+    private class AsyncEnumerator : IAsyncEnumerator<MemberConnectionRequest>
+    {
+        private readonly MemberConnectionQueue _queue;
+        private readonly CancellationTokenSource _cancellation;
+        private IAsyncEnumerator<MemberConnectionRequest> _queueRequestsEnumerator;
+
+        public AsyncEnumerator(MemberConnectionQueue queue, CancellationToken cancellationToken1, CancellationToken cancellationToken2)
+        {
+            _queue = queue;
+            _cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken1, cancellationToken2);
         }
 
-        /// <summary>
-        /// Adds a request again.
-        /// </summary>
-        /// <param name="request">The request.</param>
-        public void AddAgain(MemberConnectionRequest request)
+        public async ValueTask<bool> MoveNextAsync()
         {
-            if (_disposed || request.Cancelled) return; // no need to add - no need to throw about it
+            if (_cancellation.IsCancellationRequested) return false;
 
-            request.Reset();
-            _delayed.TryWrite(request);
-        }
-
-        private async Task Delay()
-        {
-            const int minDelay = 1000; // milliseconds - but later on each request could have a retry strategy
-
-            await foreach (var request in _delayed.WithCancellation(_cancel.Token))
+            // if this is the first call, validate that we are only enumerating once at a time & create the enumerator
+            if (_queueRequestsEnumerator == null)
             {
-                var delay = minDelay - (int)request.Elapsed.TotalMilliseconds;
-                _logger.IfDebug()?.LogDebug("Request for member {Member} delayed {Delay}ms", request.Member.Id.ToShortString(), delay > 0 ? delay : 0);
-                if (delay > 0) await Task.Delay(delay, _cancel.Token).CfAwait();
-                _logger.IfDebug()?.LogDebug("Request for member {Member} queued for retry", request.Member.Id.ToShortString());
-                _requests.TryWrite(request);
-            }
-        }
-
-        // when receiving members from the cluster... if a member is gone,
-        // we need to remove it from the queue, no need to ever try to connect
-        // to it again - so it remains in the _members async queue, but we
-        // flag it so that when we dequeue it, we can ignore it
-
-        /// <summary>
-        /// Removes a member.
-        /// </summary>
-        /// <param name="memberId">The identifier of the member.</param>
-        public void Remove(Guid memberId)
-        {
-            // cancel all corresponding requests - see notes in AsyncQueue, this is best-effort,
-            // a member that we want to remove *may* end up being enumerated, and we're going to
-            // to to connect to it, and either fail, or drop the connection - accepted tradeoff
-            lock (_mutex) {
-                _requests.ForEach(x =>
-                {
-                    if (x.Member.Id == memberId) x.Cancel();
-                });
-                _delayed.ForEach(x =>
-                {
-                    if (x.Member.Id == memberId) x.Cancel();
-                });
-            }
-        }
-
-        /// <inheritdoc />
-        public IAsyncEnumerator<MemberConnectionRequest> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        {
-            if (_disposed) throw new ObjectDisposedException(nameof(MemberConnectionQueue));
-
-            // ensure that disposing this class cancels the enumeration
-            return new AsyncEnumerator(this, _cancel.Token, cancellationToken);
-        }
-
-        private class AsyncEnumerator : IAsyncEnumerator<MemberConnectionRequest>
-        {
-            private readonly MemberConnectionQueue _queue;
-            private readonly CancellationTokenSource _cancellation;
-            private IAsyncEnumerator<MemberConnectionRequest> _queueRequestsEnumerator;
-
-            public AsyncEnumerator(MemberConnectionQueue queue, CancellationToken cancellationToken1, CancellationToken cancellationToken2)
-            {
-                _queue = queue;
-                _cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken1, cancellationToken2);
+                var acquired = await _queue._enumerate.WaitAsync(TimeSpan.Zero, default).CfAwait();
+                if (!acquired) throw new InvalidOperationException("Can only enumerate once at a time.");
+                _queueRequestsEnumerator = _queue._requests.GetAsyncEnumerator(_cancellation.Token);
             }
 
-            public async ValueTask<bool> MoveNextAsync()
+            // there is only one consumer, and the consumer *must* complete a request before picking a new one
+            if (_queue._request != null && !_queue._request.Completed)
             {
-                if (_cancellation.IsCancellationRequested) return false;
+                throw new InvalidOperationException("Cannot move to next request if previous request has not completed.");
+            }
 
-                // if this is the first call, validate that we are only enumerating once at a time & create the enumerator
-                if (_queueRequestsEnumerator == null)
-                {
-                    var acquired = await _queue._enumerate.WaitAsync(TimeSpan.Zero, default).CfAwait();
-                    if (!acquired) throw new InvalidOperationException("Can only enumerate once at a time.");
-                    _queueRequestsEnumerator = _queue._requests.GetAsyncEnumerator(_cancellation.Token);
-                }
+            // loop until we have a valid request to return, because we may dequeue nulls or cancelled members
+            while (!_cancellation.IsCancellationRequested)
+            {
+                // dequeue a request
+                if (!await _queueRequestsEnumerator.MoveNextAsync().CfAwait())
+                    return false;
 
-                // there is only one consumer, and the consumer *must* complete a request before picking a new one
-                if (_queue._request != null && !_queue._request.Completed)
-                {
-                    throw new InvalidOperationException("Cannot move to next request if previous request has not completed.");
-                }
-
-                // loop until we have a valid request to return, because we may dequeue nulls or cancelled members
                 while (!_cancellation.IsCancellationRequested)
                 {
-                    // dequeue a request
-                    if (!await _queueRequestsEnumerator.MoveNextAsync().CfAwait())
-                        return false;
-
-                    while (!_cancellation.IsCancellationRequested)
+                    // if not suspended, make that request the current one and return - this request is not in the queue
+                    // anymore, it's going to be processed no matter what even if the queue is drained or the member is
+                    // removed, and then the established connection (if any) will be dropped
+                    lock (_queue._mutex)
                     {
-                        // if not suspended, make that request the current one and return - this request is not in the queue
-                        // anymore, it's going to be processed no matter what even if the queue is drained or the member is
-                        // removed, and then the established connection (if any) will be dropped
-                        lock (_queue._mutex)
+                        if (!_queue._suspended)
                         {
-                            if (!_queue._suspended)
-                            {
-                                var request = _queueRequestsEnumerator.Current;
-                                if (request.Member == null || request.Cancelled) break; // that request is to be skipped
-                                request.Failed += (r, _) => _queue.ConnectionFailed?.Invoke(_queue, (MemberConnectionRequest)r);
-                                _queue._request = request;
-                                return true;
-                            }
+                            var request = _queueRequestsEnumerator.Current;
+                            if (request.Member == null || request.Cancelled) break; // that request is to be skipped
+                            request.Failed += (r, _) => _queue.ConnectionFailed?.Invoke(_queue, (MemberConnectionRequest)r);
+                            _queue._request = request;
+                            return true;
                         }
-
-                        // if we reach this point, we did not return nor break = the queue was suspended, wait until it is released
-                        // and then loop within the nested while => the dequeued request will be considered again
-                        await _queue._resume.WaitAsync(_cancellation.Token).CfAwaitCanceled();
                     }
-                }
 
-                return false;
+                    // if we reach this point, we did not return nor break = the queue was suspended, wait until it is released
+                    // and then loop within the nested while => the dequeued request will be considered again
+                    await _queue._resume.WaitAsync(_cancellation.Token).CfAwaitCanceled();
+                }
             }
 
-            /// <inheritdoc />
-            public MemberConnectionRequest Current => _queue._request;
-
-            public async ValueTask DisposeAsync()
-            {
-                if (_queueRequestsEnumerator != null)
-                {
-                    await _queueRequestsEnumerator.DisposeAsync().CfAwait();
-                    _queue._enumerate.Release();
-                }
-
-                _cancellation.Dispose();
-            }
+            return false;
         }
 
         /// <inheritdoc />
+        public MemberConnectionRequest Current => _queue._request;
+
         public async ValueTask DisposeAsync()
         {
-            // note: DisposeAsync should not throw (CA1065)
-
-            lock (_mutex)
+            if (_queueRequestsEnumerator != null)
             {
-                if (_disposed) return;
-                _disposed = true;
+                await _queueRequestsEnumerator.DisposeAsync().CfAwait();
+                _queue._enumerate.Release();
             }
 
-            _requests.Complete();
-            _delayed.Complete();
-            _cancel.Cancel();
-            _cancel.Dispose();
-
-            await _delaying.CfAwaitNoThrow();
-
-            // cannot wait until enumeration (if any) is complete,
-            // because that depends on the caller calling MoveNext,
-            // instead, we return false if the caller calls MoveNext,
-            // and the caller should dispose the enumerator
-
-            _resume.Dispose();
-            _enumerate.Dispose();
+            _cancellation.Dispose();
         }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        // note: DisposeAsync should not throw (CA1065)
+
+        lock (_mutex)
+        {
+            if (_disposed) return;
+            _disposed = true;
+        }
+
+        _requests.Complete();
+        _delayed.Complete();
+        _cancel.Cancel();
+        _cancel.Dispose();
+
+        await _delaying.CfAwaitNoThrow();
+
+        // cannot wait until enumeration (if any) is complete,
+        // because that depends on the caller calling MoveNext,
+        // instead, we return false if the caller calls MoveNext,
+        // and the caller should dispose the enumerator
+
+        _resume.Dispose();
+        _enumerate.Dispose();
     }
 }

--- a/src/Hazelcast.Net/Core/DisposeAction.cs
+++ b/src/Hazelcast.Net/Core/DisposeAction.cs
@@ -14,28 +14,27 @@
 
 using System;
 
-namespace Hazelcast.Core
+namespace Hazelcast.Core;
+
+/// <summary>
+/// Represents an <see cref="IDisposable"/> that executes an <see cref="Action"/> when disposed.
+/// </summary>
+internal class DisposeAction : IDisposable
 {
+    private readonly Action _action;
+
     /// <summary>
-    /// Represents an <see cref="IDisposable"/> that executes an <see cref="Action"/> when disposed.
+    /// Initializes a new instance of the <see cref="DisposeAction"/> class with an action.
     /// </summary>
-    internal class DisposeAction : IDisposable
+    /// <param name="action">The action to execute when this instance is disposed.</param>
+    public DisposeAction(Action action)
     {
-        private readonly Action _action;
+        _action = action;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DisposeAction"/> class with an action.
-        /// </summary>
-        /// <param name="action"></param>
-        public DisposeAction(Action action)
-        {
-            _action = action;
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            _action();
-        }
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _action();
     }
 }

--- a/src/Hazelcast.Net/Core/DisposeAsyncAction.cs
+++ b/src/Hazelcast.Net/Core/DisposeAsyncAction.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Hazelcast.Core;
+
+/// <summary>
+/// Represents an <see cref="IAsyncDisposable"/> that executes a <see cref="Func{Task}"/> when disposed.
+/// </summary>
+internal class DisposeAsyncAction : IAsyncDisposable
+{
+    private readonly Func<ValueTask> _action;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DisposeAction"/> class with an action.
+    /// </summary>
+    /// <param name="action">The action to execute when this instance is disposed.</param>
+    public DisposeAsyncAction(Func<ValueTask> action)
+    {
+        _action = action;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => _action();
+}

--- a/src/Hazelcast.Net/Core/HConsole.cs
+++ b/src/Hazelcast.Net/Core/HConsole.cs
@@ -100,7 +100,11 @@ namespace Hazelcast.Core
             {
                 if (TextBuilder.Length > 0)
                 {
-                    Console.Write(TextBuilder.ToString());
+                    var text = TextBuilder.ToString();
+                    if (!string.IsNullOrWhiteSpace(Options.Filename))
+                        System.IO.File.WriteAllText(Options.Filename, text);
+                    else
+                        Console.Write(text);
                     TextBuilder.Clear();
                 }
             }

--- a/src/Hazelcast.Net/Core/HConsoleOptions.cs
+++ b/src/Hazelcast.Net/Core/HConsoleOptions.cs
@@ -53,7 +53,9 @@ namespace Hazelcast.Core
         /// <returns></returns>
         public HConsoleOptions WithFilename(string filename)
         {
+#if HZ_CONSOLE
             Filename = filename;
+#endif
             return this;
         }
 

--- a/src/Hazelcast.Net/Core/HConsoleOptions.cs
+++ b/src/Hazelcast.Net/Core/HConsoleOptions.cs
@@ -47,6 +47,17 @@ namespace Hazelcast.Core
         #region Configure
 
         /// <summary>
+        /// Specifies a filename where to write the console text.
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <returns></returns>
+        public HConsoleOptions WithFilename(string filename)
+        {
+            Filename = filename;
+            return this;
+        }
+
+        /// <summary>
         /// Configures default options.
         /// </summary>
         /// <returns>The default options to configure.</returns>
@@ -212,6 +223,11 @@ namespace Hazelcast.Core
 
             return config;
         }
+
+        /// <summary>
+        /// Gets a filename where to write the console text.
+        /// </summary>
+        public string Filename { get; private set; }
 #endif
     }
 }

--- a/src/Hazelcast.Net/HazelcastClientFactory.cs
+++ b/src/Hazelcast.Net/HazelcastClientFactory.cs
@@ -322,7 +322,7 @@ namespace Hazelcast
         }
 
         // creates the client
-        private static HazelcastClient CreateClient(HazelcastOptionsBase hazelcastOptions)
+        internal static HazelcastClient CreateClient(HazelcastOptionsBase hazelcastOptions)
         {
             if (hazelcastOptions == null) throw new ArgumentNullException(nameof(hazelcastOptions));
 


### PR DESCRIPTION
NOTE: this is PR #782 but for some reason GitHub does not pick the latest changes that were force-pushed after a rebase. It usually always work, no idea what is happening here. This PR is *identical* to the other one except it's rebased on top of `master`.

This PR addresses issues raised during QA review of Compact Serialization. This issues are highlighted by the newly introduced `CompactQaTests` class. The two issues were:
* As per `ClusterRestart` test, the client would hang when trying to reconnect to a cluster. This was caused by `Schemas.PublishSchemasAsync` where we need to use `SendToMemberAsync` not `SendAsync` when reconnecting, but we forgot to update one of the two cases of the `switch` statement.
* As per `ReadSchemaAfterWrite_withObjectValueType`, a map of `<int, object>` would fail to deserialize an object `IGenericRecord` and return it as `object`. This was due to `CompactSerializationSerializer.GetOrCreateRegistration` throwing an exception - there was even a comment about it not being OK for generic records. The feature has now been implemented.

In addition working on these issues has revealed some more networking instabilities.

In addition, while working on the first issue, we realized that, should an exception occur during the execution of the `ConnectionOpened` event handlers, the connection could end up in an unstable state (never disposed nor closed) and the client may hang. That is illustrated by the `ClientGoesOffline` test. Issue is fixed in `ClusterConnections` where we now correctly handle the situation (if a handler throws, the connection is teared down).

This was mostly due to the background connection task running even when the client is not connected. This is fixed by making sure this task only runs when the client is considered connected. However, this breaks the "address-rerouting" feature of the .NET client where we redirected a connection to the exact address reported by a member. This feature has therefore been disabled.