### PR TITLE
Prepare for TPC (3) [API-1850]

### DIFF
--- a/src/Hazelcast.Net/Clustering/Cluster.cs
+++ b/src/Hazelcast.Net/Clustering/Cluster.cs
@@ -68,7 +68,7 @@ namespace Hazelcast.Clustering
             Events = new ClusterEvents(State, Messaging, _terminateConnections, Members);
             SerializationService = serializationServiceFactory(Messaging);
             Connections = new ClusterConnections(State, Members, SerializationService);
-            Heartbeat = new Heartbeat(State, Messaging, options.Heartbeat, _terminateConnections);
+            Heartbeat = new Heartbeat(State, options.Heartbeat, _terminateConnections);
 
             HConsole.Configure(x => x.Configure<Cluster>().SetIndent(2).SetPrefix("CLUSTER"));
         }

--- a/src/Hazelcast.Net/Messaging/ConnectionLifeState.cs
+++ b/src/Hazelcast.Net/Messaging/ConnectionLifeState.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Hazelcast.Messaging;
+
+/// <summary>
+/// Describes the life state of a <see cref="ClientMessageConnection"/>.
+/// </summary>
+internal enum ConnectionLifeState : byte
+{
+    // note: order is important for the Worse() extension method to work
+
+    /// <summary>
+    /// The connection has timed out.
+    /// </summary>
+    Dead = 0,
+
+    /// <summary>
+    /// The connection has not been used recently.
+    /// </summary>
+    Cold = 1,
+
+    /// <summary>
+    /// The connection has been used recently.
+    /// </summary>
+    Warm = 2
+}

--- a/src/Hazelcast.Net/Messaging/ConnectionLifeStateExtensions.cs
+++ b/src/Hazelcast.Net/Messaging/ConnectionLifeStateExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Hazelcast.Messaging;
+
+/// <summary>
+/// Provides extension methods for the <see cref="ConnectionLifeState"/> enum.
+/// </summary>
+internal static class ConnectionLifeStateExtensions
+{
+    /// <summary>
+    /// Gets the worse out of two states.
+    /// </summary>
+    /// <param name="state">This state.</param>
+    /// <param name="other">The other state.</param>
+    /// <returns>Gets the worse out of the two states.</returns>
+    public static ConnectionLifeState Worse(this ConnectionLifeState state, ConnectionLifeState other)
+        => (ConnectionLifeState)Math.Min((byte)state, (byte)other);
+}


### PR DESCRIPTION
This is the final preparation PR for TPC. This one refactors heartbeat (because we're going to have to heartbeat TPC connections too).

The idea here is that heartbeat now asks the `MemberConnection` to report all the `ClientMessageConnection` it has (currently still only 1) and each `ClientMessageConnection` is able to report its `ConnectionLifeState` which is either `Dead` (timed out), `Cold` (not used in a long time) or `Warm` (used recently). And it's up to heartbeat to sort them out and terminates the `Dead` ones and ping the `Cold` ones. 

Also `MemberConnection` now has an additional message to send a message (here, the ping request) to one specific underlying `ClientMessageConnection`.

When we implement TPC, the `MemberConnection` will simply have to return the TPC connection too, and heartbeat will be happy.