### PR TITLE
Fix: Client shuts down on failover [API-2176]

### DIFF
--- a/src/Hazelcast.Net.Testing/AssertEx.cs
+++ b/src/Hazelcast.Net.Testing/AssertEx.cs
@@ -29,8 +29,9 @@ namespace Hazelcast.Testing
         /// <param name="action">The action.</param>
         /// <param name="delayMilliseconds">How long to wait.</param>
         /// <param name="pollingMilliseconds">How often to try to run the action.</param>
+        /// <param name="message">The optional message that will be displayed on failure</param>
         /// <returns>A task that will complete when the action succeeds.</returns>
-        public static async ValueTask SucceedsEventually(Action action, int delayMilliseconds, int pollingMilliseconds)
+        public static async ValueTask SucceedsEventually(Action action, int delayMilliseconds, int pollingMilliseconds, string message = null)
         {
             var stopwatch = Stopwatch.StartNew();
 
@@ -53,7 +54,11 @@ namespace Hazelcast.Testing
                 }
 
                 if (stopwatch.ElapsedMilliseconds > delayMilliseconds - pollingMilliseconds)
+                {
+                    if (!string.IsNullOrWhiteSpace(message))
+                        throw new Exception(message);
                     throw new Exception($"Action is still failing after {delayMilliseconds}ms.", caught);
+                }
 
                 await Task.Delay(pollingMilliseconds);
             }

--- a/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
@@ -735,14 +735,12 @@ internal class FailoverTests : RemoteTestBase
     public static async Task AssertStateEventually(ConcurrentQueue<ClientState> states, ClientState expectedState, int timeoutMillis = 120_000)
     {
         var state = (ClientState) (-1);
-        try
-        {
-            await AssertEx.SucceedsEventually(() => { Assert.That(states.TryDequeue(out state)); }, timeoutMillis, 1000);
-        }
-        catch (Exception e)
-        {
-            throw new Exception($"Failed to get state {expectedState}, state did not change", e);
-        }
+        
+        await AssertEx.SucceedsEventually(
+            () => { Assert.That(states.TryDequeue(out state)); }, 
+            timeoutMillis, 1000,
+            $"Failed to get state {expectedState}, state did not change");
+
         Assert.That(state, Is.EqualTo(expectedState));
     }
 

--- a/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
@@ -30,731 +30,740 @@ using Moq;
 using NUnit.Framework;
 using Partitioner = Hazelcast.Partitioning.Partitioner;
 
-namespace Hazelcast.Tests.Clustering
+namespace Hazelcast.Tests.Clustering;
+
+[Category("enterprise")]
+[Timeout(150_000)]
+internal class FailoverTests : RemoteTestBase
 {
-    [Category("enterprise")]
-    [Timeout(150_000)]
-    internal class FailoverTests : RemoteTestBase
+    private const string Key0 = "keyForCluster0";
+    private const string Value0 = "valueForCluster0";
+
+    private const string Key1 = "keyForCluster1";
+    private const string Value1 = "valueForCluster1";
+
+    private const string Cluster0Address = "127.0.0.1:5701";
+    private const string Cluster1Address = "127.0.0.1:5711";
+    private const string Cluster2Address = "127.0.0.1:5721";
+
+    private IRemoteControllerClient _rcClient;
+    private Hazelcast.Testing.Remote.Cluster _cluster0; // primary cluster
+    private Hazelcast.Testing.Remote.Cluster _cluster1; // alternate cluster
+    private Hazelcast.Testing.Remote.Cluster _cluster2; // another cluster with a different partition count
+
+    private readonly Dictionary<Hazelcast.Testing.Remote.Cluster, List<Member>> _members
+        = new Dictionary<Hazelcast.Testing.Remote.Cluster, List<Member>>();
+
+    private async Task<Hazelcast.Testing.Remote.Cluster> CreateClusterAsync(string config)
     {
-        private const string Key0 = "keyForCluster0";
-        private const string Value0 = "valueForCluster0";
+        return await _rcClient.CreateClusterAsync(config).CfAwait();
+    }
 
-        private const string Key1 = "keyForCluster1";
-        private const string Value1 = "valueForCluster1";
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _rcClient = await ConnectToRemoteControllerAsync().CfAwait();
 
-        private const string Cluster0Address = "127.0.0.1:5701";
-        private const string Cluster1Address = "127.0.0.1:5711";
-        private const string Cluster2Address = "127.0.0.1:5721";
+        var config0 = TestFiles.ReadAllText(this, "Cluster/default.xml");
+        var config1 = TestFiles.ReadAllText(this, "Cluster/default-alt.xml");
+        var config2 = TestFiles.ReadAllText(this, "Cluster/default-part.xml");
 
-        private IRemoteControllerClient _rcClient;
-        private Hazelcast.Testing.Remote.Cluster _cluster0; // primary cluster
-        private Hazelcast.Testing.Remote.Cluster _cluster1; // alternate cluster
-        private Hazelcast.Testing.Remote.Cluster _cluster2; // another cluster with a different partition count
+        _cluster0 = await CreateClusterAsync(config0).CfAwait();
+        _cluster1 = await CreateClusterAsync(config1).CfAwait();
+        _cluster2 = await CreateClusterAsync(config2).CfAwait();
+    }
 
-        private readonly Dictionary<Hazelcast.Testing.Remote.Cluster, List<Member>> _members
-            = new Dictionary<Hazelcast.Testing.Remote.Cluster, List<Member>>();
-
-        private async Task<Hazelcast.Testing.Remote.Cluster> CreateClusterAsync(string config)
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_rcClient != null)
         {
-            return await _rcClient.CreateClusterAsync(config).CfAwait();
+            if (_cluster0 != null)
+                await _rcClient.ShutdownClusterAsync(_cluster0).CfAwait();
+
+            if (_cluster1 != null)
+                await _rcClient.ShutdownClusterAsync(_cluster1).CfAwait();
+
+            if (_cluster2 != null)
+                await _rcClient.ShutdownClusterAsync(_cluster2).CfAwait();
+
+            await _rcClient.ExitAsync().CfAwait();
         }
+    }
 
-        [OneTimeSetUp]
-        public async Task OneTimeSetUp()
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_rcClient != null)
         {
-            _rcClient = await ConnectToRemoteControllerAsync().CfAwait();
-
-            var config0 = TestFiles.ReadAllText(this, "Cluster/default.xml");
-            var config1 = TestFiles.ReadAllText(this, "Cluster/default-alt.xml");
-            var config2 = TestFiles.ReadAllText(this, "Cluster/default-part.xml");
-
-            _cluster0 = await CreateClusterAsync(config0).CfAwait();
-            _cluster1 = await CreateClusterAsync(config1).CfAwait();
-            _cluster2 = await CreateClusterAsync(config2).CfAwait();
-        }
-
-        [OneTimeTearDown]
-        public async Task OneTimeTearDown()
-        {
-            if (_rcClient != null)
-            {
-                if (_cluster0 != null)
-                    await _rcClient.ShutdownClusterAsync(_cluster0).CfAwait();
-
-                if (_cluster1 != null)
-                    await _rcClient.ShutdownClusterAsync(_cluster1).CfAwait();
-
-                if (_cluster2 != null)
-                    await _rcClient.ShutdownClusterAsync(_cluster2).CfAwait();
-
-                await _rcClient.ExitAsync().CfAwait();
-            }
-        }
-
-        [TearDown]
-        public async Task TearDown()
-        {
-            if (_rcClient != null)
-            {
-                foreach (var (cluster, members) in _members)
-                foreach (var member in members)
-                {
-                    await _rcClient.ShutdownMemberAsync(cluster.Id, member.Uuid);
-                }
-            }
-
-            _members.Clear();
-        }
-
-        /// <summary>
-        /// Starts members on a cluster.
-        /// </summary>
-        protected async Task<Member[]> StartMembersAsync(Hazelcast.Testing.Remote.Cluster cluster, int count)
-        {
-            if (!_members.TryGetValue(cluster, out var clusterMembers))
-                clusterMembers = _members[cluster] = new List<Member>();
-
-            var members = new Member[count];
-
-            for (var i = 0; i < count; i++)
-            {
-                members[i] = await _rcClient.StartMemberAsync(cluster.Id);
-                clusterMembers.Add(members[i]);
-            }
-
-            return members;
-        }
-
-        /// <summary>
-        /// Kills the specified cluster members.
-        /// </summary>
-        protected async Task StopMembersAsync(Hazelcast.Testing.Remote.Cluster cluster, Member[] members)
-        {
-            if (!_members.TryGetValue(cluster, out var clusterMembers))
-                clusterMembers = _members[cluster] = new List<Member>();
-
+            foreach (var (cluster, members) in _members)
             foreach (var member in members)
             {
                 await _rcClient.ShutdownMemberAsync(cluster.Id, member.Uuid);
-                clusterMembers.Remove(member);
             }
         }
 
-        /// <inheritdoc />
-        protected override HazelcastOptions CreateHazelcastOptions()
+        _members.Clear();
+    }
+
+    /// <summary>
+    /// Starts members on a cluster.
+    /// </summary>
+    protected async Task<Member[]> StartMembersAsync(Hazelcast.Testing.Remote.Cluster cluster, int count)
+    {
+        if (!_members.TryGetValue(cluster, out var clusterMembers))
+            clusterMembers = _members[cluster] = new List<Member>();
+
+        var members = new Member[count];
+
+        for (var i = 0; i < count; i++)
         {
-            var options = base.CreateHazelcastOptions();
-            if (_cluster0 != null && !string.IsNullOrWhiteSpace(_cluster0.Id))
-                options.ClusterName = _cluster0.Id;
-            return options;
+            members[i] = await _rcClient.StartMemberAsync(cluster.Id);
+            clusterMembers.Add(members[i]);
         }
 
-        private static ClusterState MockClusterState(HazelcastOptions options)
+        return members;
+    }
+
+    /// <summary>
+    /// Kills the specified cluster members.
+    /// </summary>
+    protected async Task StopMembersAsync(Hazelcast.Testing.Remote.Cluster cluster, Member[] members)
+    {
+        if (!_members.TryGetValue(cluster, out var clusterMembers))
+            clusterMembers = _members[cluster] = new List<Member>();
+
+        foreach (var member in members)
         {
-            return new ClusterState(options, "clusterName", "clientName", Mock.Of<Partitioner>(), new NullLoggerFactory());
+            await _rcClient.ShutdownMemberAsync(cluster.Id, member.Uuid);
+            clusterMembers.Remove(member);
         }
+    }
 
-        [Test]
-        public async Task TestFailsWhenEnabledWithNoCluster()
-        {
-            var failoverOptions = new HazelcastFailoverOptionsBuilder().Build();
+    /// <inheritdoc />
+    protected override HazelcastOptions CreateHazelcastOptions()
+    {
+        var options = base.CreateHazelcastOptions();
+        if (_cluster0 != null && !string.IsNullOrWhiteSpace(_cluster0.Id))
+            options.ClusterName = _cluster0.Id;
+        return options;
+    }
 
-            await AssertEx.ThrowsAsync<ConfigurationException>(async () => await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions));
-        }
+    private static ClusterState MockClusterState(HazelcastOptions options)
+    {
+        return new ClusterState(options, "clusterName", "clientName", Mock.Of<Partitioner>(), new NullLoggerFactory());
+    }
 
-        [Test]
-        public void TestClusterOptionsRotate()
-        {
-            const string clusterName1 = "first";
-            const string address1 = "1.1.1.1";
+    [Test]
+    public async Task TestFailsWhenEnabledWithNoCluster()
+    {
+        var failoverOptions = new HazelcastFailoverOptionsBuilder().Build();
 
-            const string clusterName2 = "second";
-            const string address2 = "2.2.2.2";
-            const string username = "MARVIN";
+        await AssertEx.ThrowsAsync<ConfigurationException>(async () => await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions));
+    }
 
-            var clusterChangedCount = 0;
+    [Test]
+    public void TestClusterOptionsRotate()
+    {
+        const string clusterName1 = "first";
+        const string address1 = "1.1.1.1";
 
-            var failoverOptions = new HazelcastFailoverOptionsBuilder()
-                .With(fo =>
-                {
-                    fo.TryCount = 2;
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            o.ClusterName = clusterName1;
-                            o.Networking.Addresses.Add(address1);
-                        })
-                        .Build());
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            o.ClusterName = clusterName2;
-                            o.Networking.Addresses.Add(address2);
-                            o.Authentication.ConfigureUsernamePasswordCredentials(username, "");
-                        })
-                        .Build());
-                })
-                .Build();
+        const string clusterName2 = "second";
+        const string address2 = "2.2.2.2";
+        const string username = "MARVIN";
 
-            // is normally set by HazelcastClientFactory, have to do it here for tests
-            failoverOptions.Enabled = true;
+        var clusterChangedCount = 0;
 
-            var options = failoverOptions.Clients[0];
-            options.FailoverOptions = failoverOptions;
-
-            var clusterState = MockClusterState(options);
-
-            var failover = new Failover(clusterState, options);
-
-            failover.ClusterChanged += _ =>
+        var failoverOptions = new HazelcastFailoverOptionsBuilder()
+            .With(fo =>
             {
-                clusterChangedCount++;
-            };
+                fo.TryCount = 2;
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        o.ClusterName = clusterName1;
+                        o.Networking.Addresses.Add(address1);
+                    })
+                    .Build());
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        o.ClusterName = clusterName2;
+                        o.Networking.Addresses.Add(address2);
+                        o.Authentication.ConfigureUsernamePasswordCredentials(username, "");
+                    })
+                    .Build());
+            })
+            .Build();
 
-            void AssertCluster1(Failover fo)
+        // is normally set by HazelcastClientFactory, have to do it here for tests
+        failoverOptions.Enabled = true;
+
+        var options = failoverOptions.Clients[0];
+        options.FailoverOptions = failoverOptions;
+
+        var clusterState = MockClusterState(options);
+
+        var failover = new Failover(clusterState, options);
+
+        failover.ClusterChanged += _ =>
+        {
+            clusterChangedCount++;
+        };
+
+        void AssertCluster1(Failover fo)
+        {
+            Assert.AreEqual(clusterName1, fo.CurrentClusterOptions.ClusterName);
+            Assert.True(fo.CurrentClusterOptions.Networking.Addresses.Contains(address1));
+        }
+
+        void AssertCluster2(Failover fo)
+        {
+            Assert.AreEqual(clusterName2, fo.CurrentClusterOptions.ClusterName);
+            Assert.True(fo.CurrentClusterOptions.Networking.Addresses.Contains(address2));
+            Assert.False(fo.CurrentClusterOptions.Networking.Addresses.Contains(address1));
+            Assert.AreEqual(fo.CurrentClusterOptions.Authentication.CredentialsFactory.Service.NewCredentials().Name, username);
+        }
+
+        // initial one must be cluster 1
+        AssertCluster1(failover);
+        clusterState.ChangeState(ClientState.Disconnected);
+
+        var expectedCount = 1;
+
+        // Loop 1, Try 1
+        Assert.That(failover.TryNextCluster());
+        AssertCluster2(failover);
+        Assert.AreEqual(expectedCount, clusterChangedCount);
+        Assert.AreEqual(expectedCount, failover.CurrentTryCount);
+        expectedCount++;
+
+        // Loop 1, Try 2
+        Assert.That(failover.TryNextCluster());
+        AssertCluster1(failover);
+        Assert.AreEqual(expectedCount, clusterChangedCount);
+        Assert.AreEqual(expectedCount, failover.CurrentTryCount);
+        expectedCount++;
+
+        // Loop 2, Try 1
+        Assert.That(failover.TryNextCluster());
+        AssertCluster2(failover);
+        Assert.AreEqual(expectedCount, clusterChangedCount);
+        Assert.AreEqual(expectedCount, failover.CurrentTryCount);
+        expectedCount++;
+
+        // Loop 2, Try 2
+        Assert.That(failover.TryNextCluster());
+        AssertCluster1(failover);
+        Assert.AreEqual(expectedCount, clusterChangedCount);
+        Assert.AreEqual(expectedCount, failover.CurrentTryCount);
+
+        // Loop 3-> spent all tries
+        Assert.False(failover.TryNextCluster());
+    }
+
+    [TestCase(true, 1)]
+    [TestCase(false, 1)]
+    public async Task TestClientCanFailover(bool smartRouting, int memberCount)
+    {
+        HConsole.Configure(options => options
+            .ConfigureDefaults(this)
+            .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
+        );
+
+        var states = new ConcurrentQueue<ClientState>();
+
+        var failoverOptions = new HazelcastFailoverOptionsBuilder()
+            .With(fo =>
             {
-                Assert.AreEqual(clusterName1, fo.CurrentClusterOptions.ClusterName);
-                Assert.True(fo.CurrentClusterOptions.Networking.Addresses.Contains(address1));
+                fo.TryCount = 2;
+
+                // first cluster is the primary, and able to configure everything
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        // this applies to this cluster only
+                        o.ClusterName = _cluster0.Id;
+                        o.Networking.Addresses.Clear();
+                        o.Networking.Addresses.Add(Cluster0Address);
+                        o.Networking.ReconnectMode = Hazelcast.Networking.ReconnectMode.ReconnectAsync;
+                        o.Networking.SmartRouting = smartRouting;
+
+                        // each single socket connection attempt has a 10s timeout
+                        // connection to a cluster has a total timeout of 20s
+                        o.Networking.ConnectionTimeoutMilliseconds = 10_000;
+                        o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 20_000;
+
+                        // this applies to all clusters
+                        o.AddSubscriber(events =>
+                            events.StateChanged((sender, arg) =>
+                            {
+                                HConsole.WriteLine(this, $"State changed to: {arg.State}");
+                                states.Enqueue(arg.State);
+                            }));
+                    })
+                    .Build());
+
+                // second cluster is alternate, can only configure network
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        o.ClusterName = _cluster1.Id;
+                        o.Networking.Addresses.Add(Cluster1Address);
+                        o.Networking.SmartRouting = smartRouting; // that doesn't override primary
+                    })
+                    .Build());
+            })
+            .WithHConsoleLogger()
+            .Build();
+
+        HConsole.WriteLine(this, "Start members of clusters 0 and 1");
+        var members0 = await StartMembersAsync(_cluster0, memberCount);
+        var members1 = await StartMembersAsync(_cluster1, memberCount);
+
+        HConsole.WriteLine(this, "Start failover client");
+        await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
+        var mapName = CreateUniqueName();
+        var map = await client.GetMapAsync<string, string>(mapName);
+        Assert.IsNotNull(map);
+
+        // first cluster should be 0
+        AssertState(states, ClientState.Starting);
+        AssertState(states, ClientState.Started);
+        AssertState(states, ClientState.Connected);
+        await AssertCluster(client, _cluster0.Id, map);
+
+        // stop cluster 0 members
+        HConsole.WriteLine(this, "Stop members of cluster 0");
+        await StopMembersAsync(_cluster0, members0);
+
+        // we should disconnect
+        await AssertStateEventually(states, ClientState.Disconnected);
+
+        // we should failover to cluster 1
+        await AssertStateEventually(states, ClientState.ClusterChanged);
+        await AssertStateEventually(states, ClientState.Connected);
+        await AssertCluster(client, _cluster1.Id, map);
+
+        // start cluster 0 members again
+        HConsole.WriteLine(this, "Start members of Cluster 0");
+        await StartMembersAsync(_cluster0, memberCount);
+
+        // stop cluster 1 members
+        HConsole.WriteLine(this, "Stop members of Cluster 1");
+        await StopMembersAsync(_cluster1, members1);
+
+        // we should disconnect
+        await AssertStateEventually(states, ClientState.Disconnected);
+
+        // we should failover to cluster 0
+        await AssertStateEventually(states, ClientState.ClusterChanged);
+        await AssertStateEventually(states, ClientState.Connected);
+        await AssertCluster(client, _cluster0.Id, map);
+    }
+
+    [TestCase(true, 1)]
+    [TestCase(false, 1)]
+    public async Task TestClientCanFailoverFirstClusterNotUp(bool smartRouting, int memberCount)
+    {
+        HConsole.Configure(options => options.ConfigureDefaults(this));
+
+        var states = new ConcurrentQueue<ClientState>();
+
+        var failoverOptions = new HazelcastFailoverOptionsBuilder()
+            .With(fo =>
+            {
+                fo.TryCount = 2;
+
+                // first cluster is the primary, and able to configure everything
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        // this applies to this cluster only
+                        o.ClusterName = _cluster0.Id;
+                        o.Networking.Addresses.Clear();
+                        o.Networking.Addresses.Add(Cluster0Address);
+                        o.Networking.ReconnectMode = Hazelcast.Networking.ReconnectMode.ReconnectAsync;
+                        o.Networking.SmartRouting = smartRouting;
+
+                        // each single socket connection attempt has a 10s timeout
+                        // connection to a cluster has a total timeout of 20s
+                        o.Networking.ConnectionTimeoutMilliseconds = 10_000;
+                        o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 20_000;
+
+                        // this applies to all clusters
+                        o.AddSubscriber(events =>
+                            events.StateChanged((sender, arg) =>
+                            {
+                                HConsole.WriteLine(this, $"State changed to: {arg.State}");
+                                states.Enqueue(arg.State);
+                            }));
+                    })
+                    .Build());
+
+                // second cluster is alternate, can only configure network
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        o.ClusterName = _cluster1.Id;
+                        o.Networking.Addresses.Add(Cluster1Address);
+                        o.Networking.SmartRouting = smartRouting; // that doesn't override primary
+                    })
+                    .Build());
+            })
+            .WithHConsoleLogger()
+            .Build();
+
+        HConsole.WriteLine(this, "Start members of clusters 1");
+        var members1 = await StartMembersAsync(_cluster1, memberCount);
+
+        HConsole.WriteLine(this, "Start failover client");
+        await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
+        var mapName = CreateUniqueName();
+        var map = await client.GetMapAsync<string, string>(mapName);
+        Assert.IsNotNull(map);
+
+        // first cluster should be 1, since 0 is not up
+        AssertState(states, ClientState.Starting);
+        AssertState(states, ClientState.Started);
+        AssertState(states, ClientState.ClusterChanged); // and we failed over
+        AssertState(states, ClientState.Connected);
+        await AssertCluster(client, _cluster1.Id, map);
+
+        HConsole.WriteLine(this, "Start members of clusters 0");
+        var members0 = await StartMembersAsync(_cluster0, memberCount);
+
+        HConsole.WriteLine(this, "Stop members of cluster 1");
+        await StopMembersAsync(_cluster1, members1);
+
+        // we should failover to cluster 0
+        await AssertStateEventually(states, ClientState.Disconnected);
+        await AssertStateEventually(states, ClientState.ClusterChanged);
+        await AssertStateEventually(states, ClientState.Connected);
+        await AssertCluster(client, _cluster0.Id, map);
+
+        // and again...
+
+        HConsole.WriteLine(this, "Start members of clusters 1");
+        await StartMembersAsync(_cluster1, memberCount);
+
+        HConsole.WriteLine(this, "Stop members of cluster 0");
+        await StopMembersAsync(_cluster0, members0);
+
+        // we should failover to cluster 1
+        await AssertStateEventually(states, ClientState.Disconnected);
+        await AssertStateEventually(states, ClientState.ClusterChanged);
+        await AssertStateEventually(states, ClientState.Connected);
+        await AssertCluster(client, _cluster1.Id, map);
+    }
+
+    [Test]
+
+    public async Task TestClientThrowExceptionOnFailover()
+    {
+        HConsole.Configure(options => options
+            .ConfigureDefaults(this)
+            .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
+        );
+
+        var failoverOptions = new HazelcastFailoverOptionsBuilder()
+            .With(fo =>
+            {
+                fo.TryCount = 2;
+
+                // first cluster is the primary, and able to config everything
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        o.ClusterName = _cluster0.Id;
+                        o.Networking.Addresses.Clear();
+                        o.Networking.Addresses.Add(Cluster0Address);
+                        o.Networking.ReconnectMode = Hazelcast.Networking.ReconnectMode.ReconnectAsync;
+                        o.Networking.ConnectionTimeoutMilliseconds = 10_000;
+                        o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 10_000;
+                    })
+                    .Build());
+
+                // cannot override load balancer, retry, heartbeat etc. just network info
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        o.ClusterName = _cluster1.Id;
+                        o.Networking.Addresses.Add(Cluster2Address);
+                    })
+                    .Build());
+            })
+            .WithHConsoleLogger()
+            .Build();
+
+        HConsole.WriteLine(this, "Creating Members");
+        var membersA = await StartMembersAsync(_cluster0, 1);
+
+        await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
+        var mapName = CreateUniqueName();
+
+        var map = await client.GetMapAsync<string, string>(mapName);
+        await map.PutAsync(Key0, Value0);
+
+        HConsole.WriteLine(this, $"SHUTDOWN: Members of Cluster A :{_cluster0.Id}");
+
+        // kill all members, client will try to fall over and eventually fail and shutdown
+        await StopMembersAsync(_cluster0, membersA);
+
+        await AssertEx.SucceedsEventually(async () =>
+        {
+            try
+            {
+                await client.GetMapAsync<string, string>(Key0);
+                throw new Exception("Expected GetMapAsync to fail.");
             }
-
-            void AssertCluster2(Failover fo)
+            catch (ClientOfflineException)
             {
-                Assert.AreEqual(clusterName2, fo.CurrentClusterOptions.ClusterName);
-                Assert.True(fo.CurrentClusterOptions.Networking.Addresses.Contains(address2));
-                Assert.False(fo.CurrentClusterOptions.Networking.Addresses.Contains(address1));
-                Assert.AreEqual(fo.CurrentClusterOptions.Authentication.CredentialsFactory.Service.NewCredentials().Name, username);
+                // expected
             }
-
-            // initial one must be cluster 1
-            AssertCluster1(failover);
-            clusterState.ChangeState(ClientState.Disconnected);
-
-            var expectedCount = 1;
-
-            // Loop 1, Try 1
-            Assert.That(failover.TryNextCluster());
-            AssertCluster2(failover);
-            Assert.AreEqual(expectedCount, clusterChangedCount);
-            Assert.AreEqual(expectedCount, failover.CurrentTryCount);
-            expectedCount++;
-
-            // Loop 1, Try 2
-            Assert.That(failover.TryNextCluster());
-            AssertCluster1(failover);
-            Assert.AreEqual(expectedCount, clusterChangedCount);
-            Assert.AreEqual(expectedCount, failover.CurrentTryCount);
-            expectedCount++;
-
-            // Loop 2, Try 1
-            Assert.That(failover.TryNextCluster());
-            AssertCluster2(failover);
-            Assert.AreEqual(expectedCount, clusterChangedCount);
-            Assert.AreEqual(expectedCount, failover.CurrentTryCount);
-            expectedCount++;
-
-            // Loop 2, Try 2
-            Assert.That(failover.TryNextCluster());
-            AssertCluster1(failover);
-            Assert.AreEqual(expectedCount, clusterChangedCount);
-            Assert.AreEqual(expectedCount, failover.CurrentTryCount);
-
-            // Loop 3-> spent all tries
-            Assert.False(failover.TryNextCluster());
-        }
-
-        [TestCase(true, 1)]
-        [TestCase(false, 1)]
-        public async Task TestClientCanFailover(bool smartRouting, int memberCount)
-        {
-            HConsole.Configure(options => options
-                .ConfigureDefaults(this)
-                .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
-            );
-
-            var states = new ConcurrentQueue<ClientState>();
-
-            var failoverOptions = new HazelcastFailoverOptionsBuilder()
-                 .With(fo =>
-                 {
-                     fo.TryCount = 2;
-
-                     // first cluster is the primary, and able to configure everything
-                     fo.Clients.Add(new HazelcastOptionsBuilder()
-                         .With(o =>
-                         {
-                             // this applies to this cluster only
-                             o.ClusterName = _cluster0.Id;
-                             o.Networking.Addresses.Clear();
-                             o.Networking.Addresses.Add(Cluster0Address);
-                             o.Networking.ReconnectMode = Hazelcast.Networking.ReconnectMode.ReconnectAsync;
-                             o.Networking.SmartRouting = smartRouting;
-
-                             // each single socket connection attempt has a 10s timeout
-                             // connection to a cluster has a total timeout of 20s
-                             o.Networking.ConnectionTimeoutMilliseconds = 10_000;
-                             o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 20_000;
-
-                             // this applies to all clusters
-                             o.AddSubscriber(events =>
-                                 events.StateChanged((sender, arg) =>
-                                 {
-                                     HConsole.WriteLine(this, $"State changed to: {arg.State}");
-                                     states.Enqueue(arg.State);
-                                 }));
-                         })
-                         .Build());
-
-                     // second cluster is alternate, can only configure network
-                     fo.Clients.Add(new HazelcastOptionsBuilder()
-                         .With(o =>
-                         {
-                             o.ClusterName = _cluster1.Id;
-                             o.Networking.Addresses.Add(Cluster1Address);
-                             o.Networking.SmartRouting = smartRouting; // that doesn't override primary
-                         })
-                         .Build());
-                 })
-                 .WithHConsoleLogger()
-                 .Build();
-
-            HConsole.WriteLine(this, "Start members of clusters 0 and 1");
-            var members0 = await StartMembersAsync(_cluster0, memberCount);
-            var members1 = await StartMembersAsync(_cluster1, memberCount);
-
-            HConsole.WriteLine(this, "Start failover client");
-            await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
-            var mapName = CreateUniqueName();
-            var map = await client.GetMapAsync<string, string>(mapName);
-            Assert.IsNotNull(map);
-
-            // first cluster should be 0
-            AssertState(states, ClientState.Starting);
-            AssertState(states, ClientState.Started);
-            AssertState(states, ClientState.Connected);
-            await AssertCluster(client, _cluster0.Id, map);
-
-            // stop cluster 0 members
-            HConsole.WriteLine(this, "Stop members of cluster 0");
-            await StopMembersAsync(_cluster0, members0);
-
-            // we should disconnect
-            await AssertStateEventually(states, ClientState.Disconnected);
-
-            // we should failover to cluster 1
-            await AssertStateEventually(states, ClientState.ClusterChanged);
-            await AssertStateEventually(states, ClientState.Connected);
-            await AssertCluster(client, _cluster1.Id, map);
-
-            // start cluster 0 members again
-            HConsole.WriteLine(this, "Start members of Cluster 0");
-            await StartMembersAsync(_cluster0, memberCount);
-
-            // stop cluster 1 members
-            HConsole.WriteLine(this, "Stop members of Cluster 1");
-            await StopMembersAsync(_cluster1, members1);
-
-            // we should disconnect
-            await AssertStateEventually(states, ClientState.Disconnected);
-
-            // we should failover to cluster 0
-            await AssertStateEventually(states, ClientState.ClusterChanged);
-            await AssertStateEventually(states, ClientState.Connected);
-            await AssertCluster(client, _cluster0.Id, map);
-        }
-
-        [TestCase(true, 1)]
-        [TestCase(false, 1)]
-        public async Task TestClientCanFailoverFirstClusterNotUp(bool smartRouting, int memberCount)
-        {
-            HConsole.Configure(options => options.ConfigureDefaults(this));
-
-            var states = new ConcurrentQueue<ClientState>();
-
-            var failoverOptions = new HazelcastFailoverOptionsBuilder()
-                .With(fo =>
-                {
-                    fo.TryCount = 2;
-
-                    // first cluster is the primary, and able to configure everything
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            // this applies to this cluster only
-                            o.ClusterName = _cluster0.Id;
-                            o.Networking.Addresses.Clear();
-                            o.Networking.Addresses.Add(Cluster0Address);
-                            o.Networking.ReconnectMode = Hazelcast.Networking.ReconnectMode.ReconnectAsync;
-                            o.Networking.SmartRouting = smartRouting;
-
-                            // each single socket connection attempt has a 10s timeout
-                            // connection to a cluster has a total timeout of 20s
-                            o.Networking.ConnectionTimeoutMilliseconds = 10_000;
-                            o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 20_000;
-
-                            // this applies to all clusters
-                            o.AddSubscriber(events =>
-                                events.StateChanged((sender, arg) =>
-                                {
-                                    HConsole.WriteLine(this, $"State changed to: {arg.State}");
-                                    states.Enqueue(arg.State);
-                                }));
-                        })
-                        .Build());
-
-                    // second cluster is alternate, can only configure network
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            o.ClusterName = _cluster1.Id;
-                            o.Networking.Addresses.Add(Cluster1Address);
-                            o.Networking.SmartRouting = smartRouting; // that doesn't override primary
-                        })
-                        .Build());
-                })
-                .WithHConsoleLogger()
-                .Build();
-
-            HConsole.WriteLine(this, "Start members of clusters 1");
-            var members1 = await StartMembersAsync(_cluster1, memberCount);
-
-            HConsole.WriteLine(this, "Start failover client");
-            await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
-            var mapName = CreateUniqueName();
-            var map = await client.GetMapAsync<string, string>(mapName);
-            Assert.IsNotNull(map);
-
-            // first cluster should be 1, since 0 is not up
-            AssertState(states, ClientState.Starting);
-            AssertState(states, ClientState.Started);
-            AssertState(states, ClientState.ClusterChanged); // and we failed over
-            AssertState(states, ClientState.Connected);
-            await AssertCluster(client, _cluster1.Id, map);
-
-            HConsole.WriteLine(this, "Start members of clusters 0");
-            var members0 = await StartMembersAsync(_cluster0, memberCount);
-
-            HConsole.WriteLine(this, "Stop members of cluster 1");
-            await StopMembersAsync(_cluster1, members1);
-
-            // we should failover to cluster 0
-            await AssertStateEventually(states, ClientState.Disconnected);
-            await AssertStateEventually(states, ClientState.ClusterChanged);
-            await AssertStateEventually(states, ClientState.Connected);
-            await AssertCluster(client, _cluster0.Id, map);
-
-            // and again...
-
-            HConsole.WriteLine(this, "Start members of clusters 1");
-            await StartMembersAsync(_cluster1, memberCount);
-
-            HConsole.WriteLine(this, "Stop members of cluster 0");
-            await StopMembersAsync(_cluster0, members0);
-
-            // we should failover to cluster 1
-            await AssertStateEventually(states, ClientState.Disconnected);
-            await AssertStateEventually(states, ClientState.ClusterChanged);
-            await AssertStateEventually(states, ClientState.Connected);
-            await AssertCluster(client, _cluster1.Id, map);
-        }
-
-        [Test]
-
-        public async Task TestClientThrowExceptionOnFailover()
-        {
-            HConsole.Configure(options => options
-                .ConfigureDefaults(this)
-                .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
-            );
-
-            var failoverOptions = new HazelcastFailoverOptionsBuilder()
-                .With(fo =>
-                {
-                    fo.TryCount = 2;
-
-                    // first cluster is the primary, and able to config everything
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            o.ClusterName = _cluster0.Id;
-                            o.Networking.Addresses.Clear();
-                            o.Networking.Addresses.Add(Cluster0Address);
-                            o.Networking.ReconnectMode = Hazelcast.Networking.ReconnectMode.ReconnectAsync;
-                            o.Networking.ConnectionTimeoutMilliseconds = 10_000;
-                            o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 10_000;
-                        })
-                        .Build());
-
-                    // cannot override load balancer, retry, heartbeat etc. just network info
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            o.ClusterName = _cluster1.Id;
-                            o.Networking.Addresses.Add(Cluster2Address);
-                        })
-                        .Build());
-                })
-                .WithHConsoleLogger()
-                .Build();
-
-            HConsole.WriteLine(this, "Creating Members");
-            var membersA = await StartMembersAsync(_cluster0, 1);
-
-            await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
-            var mapName = CreateUniqueName();
-
-            var map = await client.GetMapAsync<string, string>(mapName);
-            await map.PutAsync(Key0, Value0);
-
-            HConsole.WriteLine(this, $"SHUTDOWN: Members of Cluster A :{_cluster0.Id}");
-
-            // kill all members, client will try to fall over and eventually fail and shutdown
-            await StopMembersAsync(_cluster0, membersA);
-
-            await AssertEx.SucceedsEventually(async () =>
+            catch (Exception e)
             {
-                try
-                {
-                    await client.GetMapAsync<string, string>(Key0);
-                    throw new Exception("Expected GetMapAsync to fail.");
-                }
-                catch (ClientOfflineException)
-                {
-                    // expected
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(e);
-                    throw; // fail
-                }
-            }, 60_000, 500);
-        }
+                Console.WriteLine(e);
+                throw; // fail
+            }
+        }, 60_000, 500);
+    }
 
-        [Test]
-        public async Task TestClientCannotFailoverToDifferentPartitionCount()
-        {
-            HConsole.Configure(options => options
-                .ConfigureDefaults(this)
-                .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
-            );
+    [Test]
+    public async Task TestClientCannotFailoverToDifferentPartitionCount()
+    {
+        HConsole.Configure(options => options
+            .ConfigureDefaults(this)
+            .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
+        );
 
-            var states = new ConcurrentQueue<ClientState>();
+        var states = new ConcurrentQueue<ClientState>();
 
-            var failoverOptions = new HazelcastFailoverOptionsBuilder()
-                .With(fo =>
-                {
-                    fo.TryCount = 2;
-
-                    // first cluster is the primary, and able to configure everything
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            // this applies to this cluster only
-                            o.ClusterName = _cluster0.Id;
-                            o.Networking.Addresses.Clear();
-                            o.Networking.Addresses.Add(Cluster0Address);
-                            o.Networking.ReconnectMode = Hazelcast.Networking.ReconnectMode.ReconnectAsync;
-
-                            // each single socket connection attempt has a 10s timeout
-                            // connection to a cluster has a total timeout of 60s
-                            o.Networking.ConnectionTimeoutMilliseconds = 10_000;
-                            o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 10_000;
-
-                            // this applies to all clusters
-                            o.AddSubscriber(events =>
-                                events.StateChanged((sender, arg) =>
-                                {
-                                    HConsole.WriteLine(this, $"State changed to: {arg.State}");
-                                    states.Enqueue(arg.State);
-                                }));
-                        })
-                        .Build());
-
-                    // second cluster is alternate, can only configure network
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            o.ClusterName = _cluster1.Id;
-                            o.Networking.Addresses.Add(Cluster2Address);
-                        })
-                        .Build());
-                })
-                .WithHConsoleLogger()
-                .Build();
-
-            HConsole.WriteLine(this, "Start members of clusters 0 and 1");
-            var members0 = await StartMembersAsync(_cluster0, 1);
-            await StartMembersAsync(_cluster1, 1);
-
-            // Since connections are managed at the backend,
-            // cannot catch the exception with an simple assertion
-
-            HConsole.WriteLine(this, "Start failover client");
-            await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
-            var mapName = CreateUniqueName();
-            var map = await client.GetMapAsync<string, string>(mapName);
-            Assert.IsNotNull(map);
-
-            // first cluster should be 0
-            AssertState(states, ClientState.Starting);
-            AssertState(states, ClientState.Started);
-            AssertState(states, ClientState.Connected);
-            await AssertCluster(client, _cluster0.Id, map);
-
-            // stop cluster 0 members
-            HConsole.WriteLine(this, "Stop members of cluster 0");
-            await StopMembersAsync(_cluster0, members0);
-
-            // we should disconnect
-            await AssertStateEventually(states, ClientState.Disconnected);
-            Assert.AreEqual(ClientState.Disconnected, client.State);
-
-            // failover to cluster 1 is going to fail because of the different partition count
-            // options.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 10_000;
-            // so we need to wait for more than this to make sure we actually tried to failover,
-            // and are not simply still trying to reconnect to the original cluster 0 before
-            // failover - we test this because the ClusterChanged event *must* trigger here
-            HConsole.WriteLine(this, "Wait...");
-            await Task.Delay((int)(failoverOptions.Clients[0].Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds + 2_000));
-
-            // start cluster 0 members again
-            HConsole.WriteLine(this, "Start members of Cluster 0");
-            await StartMembersAsync(_cluster0, 1);
-
-            // we should reconnect to cluster 0
-            // *with* triggering ClusterChanged (failover occurred)
-            await AssertStateEventually(states, ClientState.ClusterChanged);
-            await AssertStateEventually(states, ClientState.Connected);
-            await AssertCluster(client, _cluster0.Id, map);
-        }
-
-        [Test]
-        public async Task TestClientRetryCurrentClusterBeforeFailover()
-        {
-            HConsole.Configure(options => options
-                .ConfigureDefaults(this)
-                .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
-            );
-
-            var states = new ConcurrentQueue<ClientState>();
-
-            var failoverOptions = new HazelcastFailoverOptionsBuilder()
-                .With(fo =>
-                {
-                    fo.TryCount = 2;
-
-                    // first cluster is the primary, and able to configure everything
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            // this applies to this cluster only
-                            o.ClusterName = _cluster0.Id;
-                            o.Networking.Addresses.Clear();
-                            o.Networking.Addresses.Add(Cluster0Address);
-
-                            // each single socket connection attempt has a 10s timeout
-                            // connection to a cluster has a total timeout of 60s
-                            o.Networking.ConnectionTimeoutMilliseconds = 10_000;
-                            o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 60_000;
-
-                            // this applies to all clusters
-                            o.AddSubscriber(events =>
-                                events.StateChanged((sender, arg) =>
-                                {
-                                    HConsole.WriteLine(this, $"State changed to: {arg.State}");
-                                    states.Enqueue(arg.State);
-                                }));
-                        })
-                        .Build());
-
-                    // second cluster is alternate, can only configure network
-                    fo.Clients.Add(new HazelcastOptionsBuilder()
-                        .With(o =>
-                        {
-                            o.ClusterName = _cluster1.Id;
-                            o.Networking.Addresses.Add(Cluster2Address);
-                        })
-                        .Build());
-                })
-                .WithHConsoleLogger()
-                .Build();
-
-            HConsole.WriteLine(this, "Start members of clusters 0 and 1");
-            var members0 = await StartMembersAsync(_cluster0, 1);
-            await StartMembersAsync(_cluster1, 1);
-
-            HConsole.WriteLine(this, "Start failover client");
-            await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
-            var mapName = CreateUniqueName();
-            var map = await client.GetMapAsync<string, string>(mapName);
-            Assert.IsNotNull(map);
-
-            // first cluster should be 0
-            AssertState(states, ClientState.Starting);
-            AssertState(states, ClientState.Started);
-            AssertState(states, ClientState.Connected);
-            await AssertCluster(client, _cluster0.Id, map);
-
-            // stop cluster 0 members
-            HConsole.WriteLine(this, "Stop members of cluster 0");
-            await StopMembersAsync(_cluster0, members0);
-
-            // we should disconnect
-            await AssertStateEventually(states, ClientState.Disconnected);
-            Assert.AreEqual(ClientState.Disconnected, client.State);
-
-            // cluster 1 is live - but we should first try to connect again to cluster 0
-            // within o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds
-            Assert.AreEqual(_cluster0.Id, client.ClusterName);
-            Assert.True(client.Members.Any(x=>
-                x.Member.Address.Host==members0[0].Host &&
-                x.Member.Address.Port==members0[0].Port)
-            );
-
-            // start cluster 0 members again
-            HConsole.WriteLine(this, "Start members of Cluster 0");
-            await StartMembersAsync(_cluster0, 1);
-
-            // we should reconnect to cluster 0
-            // *without* triggering ClusterChanged (no failover)
-            await AssertStateEventually(states, ClientState.Connected);
-            await AssertCluster(client, _cluster0.Id, map);
-        }
-
-        // assert that it's possible to immediately dequeue the expected state from the states queue
-        private static void AssertState(ConcurrentQueue<ClientState> states, ClientState expectedState)
-        {
-            Assert.That(states.TryDequeue(out var state));
-            Assert.That(state, Is.EqualTo(expectedState));
-        }
-
-        // assert that it's possible to eventually dequeue the expected state from the states queue
-        private static async Task AssertStateEventually(ConcurrentQueue<ClientState> states, ClientState expectedState)
-        {
-            var state = (ClientState) (-1);
-            await AssertEx.SucceedsEventually(() =>
+        var failoverOptions = new HazelcastFailoverOptionsBuilder()
+            .With(fo =>
             {
-                Assert.That(states.TryDequeue(out state));
-            }, 120_000, 1000);
-            Assert.That(state, Is.EqualTo(expectedState));
-        }
+                fo.TryCount = 2;
 
-        // assert that the client is connected to the expected cluster & can access the map
-        private async Task AssertCluster(IHazelcastClient client, string expectedClusterId, IHMap<string, string> map)
+                // first cluster is the primary, and able to configure everything
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        // this applies to this cluster only
+                        o.ClusterName = _cluster0.Id;
+                        o.Networking.Addresses.Clear();
+                        o.Networking.Addresses.Add(Cluster0Address);
+                        o.Networking.ReconnectMode = Hazelcast.Networking.ReconnectMode.ReconnectAsync;
+
+                        // each single socket connection attempt has a 10s timeout
+                        // connection to a cluster has a total timeout of 60s
+                        o.Networking.ConnectionTimeoutMilliseconds = 10_000;
+                        o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 10_000;
+
+                        // this applies to all clusters
+                        o.AddSubscriber(events =>
+                            events.StateChanged((sender, arg) =>
+                            {
+                                HConsole.WriteLine(this, $"State changed to: {arg.State}");
+                                states.Enqueue(arg.State);
+                            }));
+                    })
+                    .Build());
+
+                // second cluster is alternate, can only configure network
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        o.ClusterName = _cluster1.Id;
+                        o.Networking.Addresses.Add(Cluster2Address);
+                    })
+                    .Build());
+            })
+            .WithHConsoleLogger()
+            .Build();
+
+        HConsole.WriteLine(this, "Start members of clusters 0 and 1");
+        var members0 = await StartMembersAsync(_cluster0, 1);
+        await StartMembersAsync(_cluster1, 1);
+
+        // Since connections are managed at the backend,
+        // cannot catch the exception with an simple assertion
+
+        HConsole.WriteLine(this, "Start failover client");
+        await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
+        var mapName = CreateUniqueName();
+        var map = await client.GetMapAsync<string, string>(mapName);
+        Assert.IsNotNull(map);
+
+        // first cluster should be 0
+        AssertState(states, ClientState.Starting);
+        AssertState(states, ClientState.Started);
+        AssertState(states, ClientState.Connected);
+        await AssertCluster(client, _cluster0.Id, map);
+
+        // stop cluster 0 members
+        HConsole.WriteLine(this, "Stop members of cluster 0");
+        await StopMembersAsync(_cluster0, members0);
+
+        // we should disconnect
+        await AssertStateEventually(states, ClientState.Disconnected);
+        Assert.AreEqual(ClientState.Disconnected, client.State);
+
+        // failover to cluster 1 is going to fail because of the different partition count
+        // options.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 10_000;
+        // so we need to wait for more than this to make sure we actually tried to failover,
+        // and are not simply still trying to reconnect to the original cluster 0 before
+        // failover - we test this because the ClusterChanged event *must* trigger here
+        HConsole.WriteLine(this, "Wait...");
+        await Task.Delay((int)(failoverOptions.Clients[0].Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds + 2_000));
+
+        // start cluster 0 members again
+        HConsole.WriteLine(this, "Start members of Cluster 0");
+        await StartMembersAsync(_cluster0, 1);
+
+        // we should reconnect to cluster 0
+        // *with* triggering ClusterChanged (failover occurred)
+        await AssertStateEventually(states, ClientState.ClusterChanged);
+        await AssertStateEventually(states, ClientState.Connected);
+        await AssertCluster(client, _cluster0.Id, map);
+    }
+
+    [Test]
+    public async Task TestClientRetryCurrentClusterBeforeFailover()
+    {
+        HConsole.Configure(options => options
+            .ConfigureDefaults(this)
+            .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
+        );
+
+        var states = new ConcurrentQueue<ClientState>();
+
+        var failoverOptions = new HazelcastFailoverOptionsBuilder()
+            .With(fo =>
+            {
+                fo.TryCount = 2;
+
+                // first cluster is the primary, and able to configure everything
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        // this applies to this cluster only
+                        o.ClusterName = _cluster0.Id;
+                        o.Networking.Addresses.Clear();
+                        o.Networking.Addresses.Add(Cluster0Address);
+
+                        // each single socket connection attempt has a 10s timeout
+                        // connection to a cluster has a total timeout of 60s
+                        o.Networking.ConnectionTimeoutMilliseconds = 10_000;
+                        o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 60_000;
+
+                        // this applies to all clusters
+                        o.AddSubscriber(events =>
+                            events.StateChanged((sender, arg) =>
+                            {
+                                HConsole.WriteLine(this, $"State changed to: {arg.State}");
+                                states.Enqueue(arg.State);
+                            }));
+                    })
+                    .Build());
+
+                // second cluster is alternate, can only configure network
+                fo.Clients.Add(new HazelcastOptionsBuilder()
+                    .With(o =>
+                    {
+                        o.ClusterName = _cluster1.Id;
+                        o.Networking.Addresses.Add(Cluster2Address);
+                    })
+                    .Build());
+            })
+            .WithHConsoleLogger()
+            .Build();
+
+        HConsole.WriteLine(this, "Start members of clusters 0 and 1");
+        var members0 = await StartMembersAsync(_cluster0, 1);
+        await StartMembersAsync(_cluster1, 1);
+
+        HConsole.WriteLine(this, "Start failover client");
+        await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
+        var mapName = CreateUniqueName();
+        var map = await client.GetMapAsync<string, string>(mapName);
+        Assert.IsNotNull(map);
+
+        // first cluster should be 0
+        AssertState(states, ClientState.Starting);
+        AssertState(states, ClientState.Started);
+        AssertState(states, ClientState.Connected);
+        await AssertCluster(client, _cluster0.Id, map);
+
+        // stop cluster 0 members
+        HConsole.WriteLine(this, "Stop members of cluster 0");
+        await StopMembersAsync(_cluster0, members0);
+
+        // we should disconnect
+        await AssertStateEventually(states, ClientState.Disconnected);
+        Assert.AreEqual(ClientState.Disconnected, client.State);
+
+        // cluster 1 is live - but we should first try to connect again to cluster 0
+        // within o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds
+        Assert.AreEqual(_cluster0.Id, client.ClusterName);
+        Assert.True(client.Members.Any(x=>
+            x.Member.Address.Host==members0[0].Host &&
+            x.Member.Address.Port==members0[0].Port)
+        );
+
+        // start cluster 0 members again
+        HConsole.WriteLine(this, "Start members of Cluster 0");
+        await StartMembersAsync(_cluster0, 1);
+
+        // we should reconnect to cluster 0
+        // *without* triggering ClusterChanged (no failover)
+        await AssertStateEventually(states, ClientState.Connected);
+        await AssertCluster(client, _cluster0.Id, map);
+    }
+
+    /// <summary>
+    /// Asserts that it is possible to immediately dequeue the expected state from the states queue.
+    /// </summary>
+    public static void AssertState(ConcurrentQueue<ClientState> states, ClientState expectedState)
+    {
+        Assert.That(states.TryDequeue(out var state));
+        Assert.That(state, Is.EqualTo(expectedState));
+    }
+
+    /// <summary>
+    /// Asserts that it is possible to eventually dequeue the expected state from the states queue.
+    /// </summary>
+    public static async Task AssertStateEventually(ConcurrentQueue<ClientState> states, ClientState expectedState, int timeoutMillis = 120_000)
+    {
+        var state = (ClientState) (-1);
+        try
         {
-            Assert.AreEqual(expectedClusterId, client.ClusterName);
-
-            var isCluster0 = client.ClusterName == _cluster0.Id;
-            var key = isCluster0 ? Key0 : Key1;
-            var value = isCluster0 ? Value0 : Value1;
-            var otherKey = isCluster0 ? Key1 : Key0;
-            //var otherValue = isCluster0 ? ValueB : ValueA;
-
-            // can use the map
-            await map.PutAsync(key, value);
-            Assert.AreEqual(value, await map.GetAsync(key));
-
-            // cannot access other value
-            Assert.IsNull(await map.GetAsync(otherKey));
+            await AssertEx.SucceedsEventually(() => { Assert.That(states.TryDequeue(out state)); }, timeoutMillis, 1000);
         }
+        catch (Exception e)
+        {
+            throw new Exception($"Failed to get state {expectedState}, state did not change", e);
+        }
+        Assert.That(state, Is.EqualTo(expectedState));
+    }
+
+    /// <summary>
+    /// Asserts that the client is connected to the expected cluster & can access the specified map.
+    /// </summary>
+    private async Task AssertCluster(IHazelcastClient client, string expectedClusterName, IHMap<string, string> map)
+    {
+        Assert.AreEqual(expectedClusterName, client.ClusterName);
+
+        var isCluster0 = client.ClusterName == _cluster0.Id;
+        var key = isCluster0 ? Key0 : Key1;
+        var value = isCluster0 ? Value0 : Value1;
+        var otherKey = isCluster0 ? Key1 : Key0;
+        //var otherValue = isCluster0 ? ValueB : ValueA;
+
+        // can use the map
+        await map.PutAsync(key, value);
+        Assert.AreEqual(value, await map.GetAsync(key));
+
+        // cannot access other value
+        Assert.IsNull(await map.GetAsync(otherKey));
     }
 }

--- a/src/Hazelcast.Net.Tests/Clustering/FailoverTests2.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/FailoverTests2.cs
@@ -1,0 +1,487 @@
+﻿// Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hazelcast.Clustering;
+using Hazelcast.Core;
+using Hazelcast.DistributedObjects;
+using Hazelcast.Messaging;
+using Hazelcast.Models;
+using Hazelcast.Networking;
+using Hazelcast.Protocol.Codecs;
+using Hazelcast.Protocol.Models;
+using Hazelcast.Serialization;
+using Hazelcast.Testing;
+using Hazelcast.Testing.Logging;
+using Hazelcast.Testing.TestServer;
+using NUnit.Framework;
+
+namespace Hazelcast.Tests.Clustering;
+
+[TestFixture]
+public class FailoverTests2 : HazelcastTestBase
+{
+    private readonly Dictionary<string, (string Key, string Value)> _kv = new();
+
+    private class ServerState
+    {
+        private readonly Dictionary<string, Dictionary<IData, IData>> _maps = new();
+
+        public int Id { get; init; }
+
+        public bool SendMembershipEvents { get; set; } = true;
+
+        public Dictionary<IData, IData> CreateMap(string name)
+        {
+            return _maps.TryGetValue(name, out var map)
+                ? map
+                : _maps[name] = new();
+        }
+
+        public bool TryGetMap(string name, out Dictionary<IData, IData> map)
+            => _maps.TryGetValue(name, out map);
+    }
+
+    [Test]
+    public async Task TestClientCanFailover()
+    {
+        // this is equivalent to FailoverTests.TestClientCanFailover but with our custom server
+
+        var cluster0Id = Guid.NewGuid();
+        var cluster1Id = Guid.NewGuid();
+
+        _kv[cluster0Id.ToString()] = ("key0", "value0");
+        _kv[cluster1Id.ToString()] = ("key1", "value1");
+
+        var member0Address = NetworkAddress.Parse("127.0.0.1:5701");
+        var state0 = new ServerState { Id = 0 };
+        await using var member0 = new Server(member0Address)
+            .WithClusterId(cluster0Id)
+            .WithState(state0)
+            .HandleFallback(ServerHandler);
+
+        var member1Address = NetworkAddress.Parse("127.0.0.1:5711");
+        var state1 = new ServerState { Id = 1 };
+        await using var member1 = new Server(member1Address)
+            .WithClusterId(cluster1Id)
+            .WithState(state1)
+            .HandleFallback(ServerHandler);
+
+        HConsole.Configure(options => options
+                .ConfigureDefaults(this)
+                .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
+            );
+
+        var states = new ConcurrentQueue<ClientState>();
+
+        var failoverOptions = new HazelcastFailoverOptionsBuilder()
+             .With(fo =>
+             {
+                 fo.TryCount = 2;
+
+                 // first cluster is the primary, and able to configure everything
+                 fo.Clients.Add(new HazelcastOptionsBuilder()
+                     .With(o =>
+                     {
+                         // this applies to this cluster only
+                         o.ClusterName = cluster0Id.ToString();
+                         o.Networking.Addresses.Clear();
+                         o.Networking.Addresses.Add(member0Address.ToString());
+                         o.Networking.ReconnectMode = ReconnectMode.ReconnectAsync;
+                         o.Networking.SmartRouting = true;
+
+                         // each single socket connection attempt has a timeout
+                         // connection to a cluster has a total timeout
+                         o.Networking.ConnectionTimeoutMilliseconds = 4_000;
+                         o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 8_000;
+
+                         // this applies to all clusters
+                         o.AddSubscriber(events =>
+                             events.StateChanged((sender, arg) =>
+                             {
+                                 HConsole.WriteLine(this, $"State changed to: {arg.State}");
+                                 states.Enqueue(arg.State);
+                             }));
+                     })
+                     .Build());
+
+                 // second cluster is alternate, only need to configure network
+                 fo.Clients.Add(new HazelcastOptionsBuilder()
+                     .With(o =>
+                     {
+                         o.ClusterName = cluster1Id.ToString();
+                         o.Networking.Addresses.Clear();
+                         o.Networking.Addresses.Add(member1Address.ToString());
+                     })
+                     .Build());
+             })
+             .WithHConsoleLogger()
+             .Build();
+
+        HConsole.WriteLine(this, "Start members of clusters 0 and 1");
+        await member0.StartAsync();
+        await member1.StartAsync();
+
+        HConsole.WriteLine(this, "Start failover client");
+        await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
+        var mapName = CreateUniqueName();
+        var map = await client.GetMapAsync<string, string>(mapName);
+        Assert.IsNotNull(map);
+
+        // first cluster should be 0
+        FailoverTests.AssertState(states, ClientState.Starting);
+        FailoverTests.AssertState(states, ClientState.Started);
+        FailoverTests.AssertState(states, ClientState.Connected);
+        await AssertCluster(client, cluster0Id.ToString(), map);
+
+        // stop cluster 0 members
+        HConsole.WriteLine(this, "Stop members of cluster 0");
+        await member0.StopAsync();
+
+        // we should disconnect
+        await FailoverTests.AssertStateEventually(states, ClientState.Disconnected);
+
+        // we should failover to cluster 1
+        await FailoverTests.AssertStateEventually(states, ClientState.ClusterChanged);
+        await FailoverTests.AssertStateEventually(states, ClientState.Connected);
+        await AssertCluster(client, cluster1Id.ToString(), map);
+
+        // start cluster 0 members again
+        HConsole.WriteLine(this, "Start members of Cluster 0");
+        await member0.StartAsync();
+
+        // stop cluster 1 members
+        HConsole.WriteLine(this, "Stop members of Cluster 1");
+        await member1.StopAsync();
+
+        // we should disconnect
+        await FailoverTests.AssertStateEventually(states, ClientState.Disconnected);
+
+        // we should failover to cluster 0
+        await FailoverTests.AssertStateEventually(states, ClientState.ClusterChanged);
+        await FailoverTests.AssertStateEventually(states, ClientState.Connected);
+        await AssertCluster(client, cluster0Id.ToString(), map);
+    }
+
+    [Test]
+    public async Task TestClientCanFailoverWhenNoInitialMembershipEvent()
+    {
+        // this is equivalent to FailoverTests.TestClientCanFailover but with our custom server
+        // and, we tweak the server so it does *not* send initial membership event in time
+        // see https://github.com/hazelcast/hazelcast/pull/26009
+
+        var cluster0Id = Guid.NewGuid();
+        var cluster1Id = Guid.NewGuid();
+        var cluster2Id = Guid.NewGuid();
+
+        _kv[cluster0Id.ToString()] = ("key0", "value0");
+        _kv[cluster1Id.ToString()] = ("key1", "value1");
+        _kv[cluster2Id.ToString()] = ("key2", "value2");
+
+        var member0Address = NetworkAddress.Parse("127.0.0.1:5701");
+        var state0 = new ServerState { Id = 0 };
+        await using var member0 = new Server(member0Address)
+            .WithClusterId(cluster0Id)
+            .WithState(state0)
+            .HandleFallback(ServerHandler);
+
+        var member1Address = NetworkAddress.Parse("127.0.0.1:5711");
+        var state1 = new ServerState { Id = 1 };
+        await using var member1 = new Server(member1Address)
+            .WithClusterId(cluster1Id)
+            .WithState(state1)
+            .HandleFallback(ServerHandler);
+
+        var member2Address = NetworkAddress.Parse("127.0.0.1:5721");
+        var state2 = new ServerState { Id = 2 };
+        await using var member2 = new Server(member2Address)
+            .WithClusterId(cluster2Id)
+            .WithState(state2)
+            .HandleFallback(ServerHandler);
+
+        HConsole.Configure(options => options
+                .ConfigureDefaults(this)
+                .Configure<Failover>().SetPrefix("FAILOVER").SetMaxLevel()
+            );
+
+        var states = new ConcurrentQueue<ClientState>();
+
+        var failoverOptions = new HazelcastFailoverOptionsBuilder()
+             .With(fo =>
+             {
+                 fo.TryCount = 2;
+
+                 // first cluster is the primary, and able to configure everything
+                 fo.Clients.Add(new HazelcastOptionsBuilder()
+                     .With(o =>
+                     {
+                         // this applies to this cluster only
+                         o.ClusterName = cluster0Id.ToString();
+                         o.Networking.Addresses.Clear();
+                         o.Networking.Addresses.Add(member0Address.ToString());
+                         o.Networking.ReconnectMode = ReconnectMode.ReconnectAsync;
+                         o.Networking.SmartRouting = true;
+
+                         // each single socket connection attempt has a timeout
+                         // connection to a cluster has a total timeout
+                         o.Networking.ConnectionTimeoutMilliseconds = 4_000;
+                         o.Networking.ConnectionRetry.ClusterConnectionTimeoutMilliseconds = 8_000;
+
+                         // this applies to all clusters
+                         o.AddSubscriber(events =>
+                             events.StateChanged((sender, arg) =>
+                             {
+                                 HConsole.WriteLine(this, $"State changed to: {arg.State}");
+                                 states.Enqueue(arg.State);
+                             }));
+                     })
+                     .Build());
+
+                 // second cluster is alternate, only need to configure network
+                 fo.Clients.Add(new HazelcastOptionsBuilder()
+                     .With(o =>
+                     {
+                         o.ClusterName = cluster1Id.ToString();
+                         o.Networking.Addresses.Clear();
+                         o.Networking.Addresses.Add(member1Address.ToString());
+                     })
+                     .Build());
+                 fo.Clients.Add(new HazelcastOptionsBuilder()
+                     .With(o =>
+                     {
+                         o.ClusterName = cluster2Id.ToString();
+                         o.Networking.Addresses.Clear();
+                         o.Networking.Addresses.Add(member2Address.ToString());
+                     })
+                     .Build());
+             })
+             .WithHConsoleLogger()
+             .Build();
+
+        HConsole.WriteLine(this, "Start members of clusters 0, 1 and 2");
+        await member0.StartAsync();
+        await member1.StartAsync();
+        await member2.StartAsync();
+
+        HConsole.WriteLine(this, "Start failover client");
+        await using var client = await HazelcastClientFactory.StartNewFailoverClientAsync(failoverOptions);
+        var mapName = CreateUniqueName();
+        var map = await client.GetMapAsync<string, string>(mapName);
+        Assert.IsNotNull(map);
+
+        // first cluster should be 0
+        FailoverTests.AssertState(states, ClientState.Starting);
+        FailoverTests.AssertState(states, ClientState.Started);
+        FailoverTests.AssertState(states, ClientState.Connected);
+        await AssertCluster(client, cluster0Id.ToString(), map);
+
+        // test: we provoke a failover to cluster 1, but that cluster is not
+        // going to send the membership events, and then we're going to stop
+        // it - we should failover back to cluster 2.
+
+        state1.SendMembershipEvents = false;
+
+        // stop cluster 0 members
+        HConsole.WriteLine(this, "Stop members of cluster 0");
+        await member0.StopAsync();
+
+        // we should disconnect
+        await FailoverTests.AssertStateEventually(states, ClientState.Disconnected);
+
+        // we should failover to cluster 2, after failing to failover to cluster 1
+        await FailoverTests.AssertStateEventually(states, ClientState.ClusterChanged, 20_000);
+        await FailoverTests.AssertStateEventually(states, ClientState.Connected, 20_000);
+        await AssertCluster(client, cluster2Id.ToString(), map);
+    }
+
+    private IData NullData { get; } = new HeapData(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }); // NULL type id is zero
+
+    private async ValueTask ServerHandler(ClientRequest<ServerState> request)
+    {
+        const int partitionsCount = 2;
+        var address = request.Server.Address;
+        var memberId = request.Server.MemberId;
+
+        switch (request.Message.MessageType)
+        {
+            // must handle auth
+            case ClientAuthenticationServerCodec.RequestMessageType:
+                {
+                    HConsole.WriteLine(this, $"(server{request.State.Id}) Authentication");
+                    var authRequest = ClientAuthenticationServerCodec.DecodeRequest(request.Message);
+                    var authResponse = ClientAuthenticationServerCodec.EncodeResponse(
+                        0, address, memberId, SerializationService.SerializerVersion,
+                        "4.0", partitionsCount, request.Server.ClusterId, true);
+                    await request.RespondAsync(authResponse).CfAwait();
+                    break;
+                }
+
+            // must handle events
+            case ClientAddClusterViewListenerServerCodec.RequestMessageType:
+                {
+                    HConsole.WriteLine(this, $"(server{request.State.Id}) AddClusterViewListener");
+                    var addRequest = ClientAddClusterViewListenerServerCodec.DecodeRequest(request.Message);
+                    var addResponse = ClientAddClusterViewListenerServerCodec.EncodeResponse();
+                    await request.RespondAsync(addResponse).CfAwait();
+
+                    if (request.State.SendMembershipEvents)
+                        _ = Task.Run(async () =>
+                        {
+                            await Task.Delay(500).CfAwait();
+
+                            const int membersVersion = 1;
+                            var memberVersion = new MemberVersion(4, 0, 0);
+                            var memberAttributes = new Dictionary<string, string>();
+                            var membersEventMessage = ClientAddClusterViewListenerServerCodec.EncodeMembersViewEvent(membersVersion, new[]
+                            {
+                                    new MemberInfo(memberId, address, memberVersion, false, memberAttributes)
+                                });
+                            await request.RaiseAsync(membersEventMessage).CfAwait();
+
+                            await Task.Delay(500).CfAwait();
+
+                            const int partitionsVersion = 1;
+                            var partitionsEventMessage = ClientAddClusterViewListenerServerCodec.EncodePartitionsViewEvent(partitionsVersion, new[]
+                            {
+                                    new KeyValuePair<Guid, IList<int>>(memberId, new List<int> { 0 }),
+                                    new KeyValuePair<Guid, IList<int>>(memberId, new List<int> { 1 }),
+                                });
+                            await request.RaiseAsync(partitionsEventMessage).CfAwait();
+                        });
+
+                    break;
+                }
+
+            // ping
+            case ClientPingServerCodec.RequestMessageType:
+                {
+                    HConsole.WriteLine(this, $"(server{request.State.Id}) Ping");
+                    var pingRequest = ClientPingServerCodec.DecodeRequest(request.Message);
+
+                    // no response, will timeout
+
+                    break;
+                }
+
+            // create object
+            case ClientCreateProxyCodec.RequestMessageType:
+            {
+                HConsole.WriteLine(this, $"(server{request.State.Id}) CreateProxy");
+                var createProxyRequest = ClientCreateProxyServerCodec.DecodeRequest(request.Message);
+                var service = createProxyRequest.ServiceName;
+                if (service != ServiceNames.Map)
+                {
+                    await request.ErrorAsync(RemoteError.ServiceNotFound);
+                }
+                else
+                {
+                    var name = createProxyRequest.Name;
+                    request.State.CreateMap(name);
+                    await request.RespondAsync(ClientCreateProxyServerCodec.EncodeResponse());
+                }
+                break;
+            }
+
+            // create objects (when re-connecting)
+            case ClientCreateProxiesCodec.RequestMessageType:
+            {
+                HConsole.WriteLine(this, $"(server{request.State.Id}) CreateProxies");
+                var createProxiesRequest = ClientCreateProxiesServerCodec.DecodeRequest(request.Message);
+                // do nothing - will work anyways
+                await request.RespondAsync(ClientCreateProxiesServerCodec.EncodeResponse());
+                break;
+            }
+
+            // map put
+            case MapPutCodec.RequestMessageType:
+            {
+                HConsole.WriteLine(this, $"(server{request.State.Id}) MapPut");
+                var mapPutRequest = MapPutServerCodec.DecodeRequest(request.Message);
+                if (!request.State.TryGetMap(mapPutRequest.Name, out var map))
+                {
+                    map = request.State.CreateMap(mapPutRequest.Name);
+                }
+
+                var keyData = mapPutRequest.Key;
+                if (!map.TryGetValue(keyData, out var responseData))
+                    responseData = NullData;
+
+                var valueData = mapPutRequest.Value;
+                map[keyData] = valueData;
+
+                await request.RespondAsync(MapPutServerCodec.EncodeResponse(responseData));
+                break;
+            }
+
+            // map get
+            case MapGetCodec.RequestMessageType:
+            {
+                HConsole.WriteLine(this, $"(server{request.State.Id}) MapGet");
+                var mapGetRequest = MapGetServerCodec.DecodeRequest(request.Message);
+                if (!request.State.TryGetMap(mapGetRequest.Name, out var map))
+                {
+                    map = request.State.CreateMap(mapGetRequest.Name);
+                }
+
+                var keyData = mapGetRequest.Key;
+                if (!map.TryGetValue(keyData, out var responseData))
+                    responseData = NullData;
+
+                await request.RespondAsync(MapGetServerCodec.EncodeResponse(responseData));
+                break;
+            }
+
+            // unexpected message = error
+            default:
+                {
+                    // RemoteError.Hazelcast or RemoteError.RetryableHazelcast
+                    var messageName = MessageTypeConstants.GetMessageTypeName(request.Message.MessageType);
+                    await request.ErrorAsync(RemoteError.Hazelcast, $"MessageType {messageName} (0x{request.Message.MessageType:X}) not implemented.").CfAwait();
+                    break;
+                }
+        }
+    }
+
+    /// <summary>
+    /// Asserts that the client is connected to the expected cluster & can access the specified map.
+    /// </summary>
+    public async Task AssertCluster(IHazelcastClient client, string expectedClusterName, IHMap<string, string> map)
+    {
+        Assert.AreEqual(expectedClusterName, client.ClusterName);
+
+        var key = _kv[expectedClusterName].Key;
+        var value = _kv[expectedClusterName].Value;
+        var otherKey = "";
+        //var otherValue = "";
+        foreach (var kv in _kv) 
+        {
+            if (kv.Key != expectedClusterName)
+            {
+                otherKey = kv.Value.Key;
+                //otherValue = kv.Value.Value;
+            }
+        }
+
+        // can use the map
+        await map.PutAsync(key, value);
+        Assert.AreEqual(value, await map.GetAsync(key));
+
+        // cannot access other value
+        Assert.IsNull(await map.GetAsync(otherKey));
+    }
+
+}

--- a/src/Hazelcast.Net/Clustering/ClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterEvents.cs
@@ -790,6 +790,8 @@ namespace Hazelcast.Clustering
 #pragma warning restore CA1801
 #pragma warning restore IDE0060
         {
+            HConsole.WriteLine(this, $"Added connection {connection.Id.ToShortString()} to {connection.MemberId.ToShortString()} at {connection.Address}");
+
             // atomically add the connection and capture known subscriptions
             List<ClusterSubscription> subscriptions;
             lock (_mutex)
@@ -821,6 +823,8 @@ namespace Hazelcast.Clustering
         /// </summary>
         public ValueTask OnConnectionClosed(MemberConnection connection)
         {
+            HConsole.WriteLine(this, $"Removed connection {connection.Id.ToShortString()} to {connection.MemberId.ToShortString()} at {connection.Address}");
+
             // atomically remove the connection and capture known subscriptions
             List<ClusterSubscription> subscriptions;
             lock (_mutex)

--- a/src/Hazelcast.Net/Clustering/ClusterState.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterState.cs
@@ -322,8 +322,21 @@ namespace Hazelcast.Clustering
 
             ClientState state;
             HConsole.WriteLine(this, "Waiting for state change...");
-            try { state = await wait.Task.CfAwait(); } catch { state = 0; }
-            HConsole.WriteLine(this, $"State changed to {state}");
+            try
+            {
+                state = await wait.Task.CfAwait();
+                HConsole.WriteLine(this, $"State changed to {state}");
+            }
+            catch (OperationCanceledException)
+            {
+                state = 0;
+                HConsole.WriteLine(this, $"Connection operation was canceled");
+            }
+            catch (Exception ex)
+            {
+                state = 0;
+                HConsole.WriteLine(this, $"{ex.GetType().Name}: {ex.Message}");
+            }
 
             connection.RemoveClosed(OnConnectionClosed);
             return state == ClientState.Connected;

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -224,7 +224,8 @@ namespace Hazelcast.Clustering
         /// <returns>All <see cref="ClientMessageConnection"/> owned by this connection.</returns>
         public IEnumerable<ClientMessageConnection> GetMessageConnections()
         {
-            yield return _messageConnection;
+            if (_messageConnection != null)
+                yield return _messageConnection;
 
             var tpcConnections = _tpcConnections;
             if (tpcConnections == null) yield break;

--- a/src/Hazelcast.Net/Clustering/MemberConnection.cs
+++ b/src/Hazelcast.Net/Clustering/MemberConnection.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,6 +41,7 @@ namespace Hazelcast.Clustering
     /// <summary>
     /// Represents a connection to a cluster member.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay}")]
     internal partial class MemberConnection : IAsyncDisposable
     {
         internal static readonly byte[] ClientProtocolInitBytes = { 67, 80, 50 }; //"CP2";
@@ -100,6 +102,8 @@ namespace Hazelcast.Clustering
             MemberAddress = address; // may change after connection is established.
             HConsole.Configure(x => x.Configure<MemberConnection>().SetIndent(4).SetPrefix("MBR.CONN"));
         }
+
+        private string DebuggerDisplay => $"{Id.ToShortString()} to {MemberId.ToShortString()} at {Address}";
 
         #region Events
 

--- a/src/Hazelcast.Net/Clustering/RetryStrategy.cs
+++ b/src/Hazelcast.Net/Clustering/RetryStrategy.cs
@@ -79,7 +79,9 @@ namespace Hazelcast.Clustering
             _maxBackoffMilliseconds = maxBackOffMilliseconds;
             if (multiplier <= 0) throw new ConfigurationException("Multiplier must be greater than zero.");
             _multiplier = multiplier;
-            _timeoutMilliseconds = timeoutMilliseconds;
+            //var maxMilliseconds = (long) TimeSpan.MaxValue.TotalMilliseconds; // that would be the max millis in a timespan
+            const int maxMilliseconds = int.MaxValue; // but CancellationTokenSource is even more restrictive
+            _timeoutMilliseconds = Math.Min(timeoutMilliseconds, maxMilliseconds);
             if (jitter < 0 || jitter > 1) throw new ConfigurationException("Jitter must be between zero and one, inclusive.");
             _jitter = jitter;
 

--- a/src/Hazelcast.Net/Clustering/RetryStrategy.cs
+++ b/src/Hazelcast.Net/Clustering/RetryStrategy.cs
@@ -35,6 +35,7 @@ namespace Hazelcast.Clustering
         private readonly double _multiplier;
         private readonly long _timeoutMilliseconds;
         private readonly double _jitter;
+        private CancellationTokenSource _cancellation;
         private int _currentBackOffMilliseconds;
         private int _attempts;
         private DateTime _begin;
@@ -159,6 +160,17 @@ namespace Hazelcast.Clustering
             _attempts = 0;
             _currentBackOffMilliseconds = Math.Min(_maxBackoffMilliseconds, _initialBackoffMilliseconds);
             _begin = DateTime.UtcNow;
+            _cancellation?.Dispose();
+            _cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(_timeoutMilliseconds));
+        }
+
+        /// <inheritdoc />
+        public CancellationToken CancellationToken => _cancellation.Token;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _cancellation.Dispose();
         }
     }
 }

--- a/src/Hazelcast.Net/Core/ConnectionRetryOptions.cs
+++ b/src/Hazelcast.Net/Core/ConnectionRetryOptions.cs
@@ -55,6 +55,10 @@ namespace Hazelcast.Core
         /// <summary>
         /// Gets or sets the timeout in milliseconds.
         /// </summary>
+        /// <remarks>
+        /// <p>Use <code>-1</code> to indicate an infinite timeout.</p>
+        /// <p>This value must be smaller than <c>TimeSpan.MaxValue.TotalMilliseconds</c>.</p>
+        /// </remarks>
         public long ClusterConnectionTimeoutMilliseconds { get; set; } = -1; // infinite
 
         /// <summary>

--- a/src/Hazelcast.Net/Core/IRetryStrategy.cs
+++ b/src/Hazelcast.Net/Core/IRetryStrategy.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,7 +21,7 @@ namespace Hazelcast.Core
     /// <summary>
     /// Defines a retry strategy.
     /// </summary>
-    internal interface IRetryStrategy
+    internal interface IRetryStrategy : IDisposable
     {
         /// <summary>
         /// Determines whether it is possible to retry, optionally waiting for some time.
@@ -33,5 +34,11 @@ namespace Hazelcast.Core
         /// Restarts the strategy.
         /// </summary>
         void Restart();
+
+        /// <summary>
+        /// Gets the <see cref="CancellationToken"/> that will cancel when the timeout is reached.
+        /// </summary>
+        /// <returns>The <see cref="CancellationToken"/> that will cancel when the timeout is reached.</returns>
+        CancellationToken CancellationToken { get; }
     }
 }


### PR DESCRIPTION
This PR fixes #863 and introduces the following changes:
- Add the `FailoverTests2` test class that reproduces the tests from `FailoverTests` but works with mock clusters instead of actual clusters, so that we can tweak the behavior of the clusters, and reproduce a cluster not sending the members view event within a reasonable time
- Modify `HeartBeat` to ensure that the cancellation tokens are properly propagated down to the ping messages, which will then abort correctly in case the cluster goes down
- Modify `RetryStrategy` to expose a cancellation token corresponding to the cluster connection timeout, that can be used even before we have to retry, to detect that the timeout has been reached (for instance, while waiting for the member views event)
- Modify `ClusterConnections` to ensure that, should the connection opens but the member views event is never received, a timeout (based on the retry strategy timeout) is correctly detected, the connection is correctly teared down, and the next cluster (if any) is tried

The test `FailoverTests2.TestClientCanFailoverWhenNoInitialMembershipEvent` fails if executed without the above changes, and succeed with them. It connects the client to a first cluster, then stops that cluster, triggering failover to a second cluster that does not send members view events, thus triggering failover to a third cluster, which succeeds.

In addition, `RetryStrategy` was updated to ensure that the maximum cluster connection timeout does not exceed a value compatible with fitting it into a `TimeSpan` value and passing that value to a `CancellationTokenSource` - as some users (and one of our tests) may thing that `long.MaxValue` is safe to indicate "the longest timeout possible". We now simply and transparently trim their value to whatever is "the longest timeout we can support".

Changes to other files are cosmetic or there to improve testing and logging.