### PR TITLE
[API-2196] Add a note about naming of the terminated/onClose event in Reliable Topic

### DIFF
--- a/doc/dev/doc/distributed-objects/hreliabletopic.md
+++ b/doc/dev/doc/distributed-objects/hreliabletopic.md
@@ -44,7 +44,7 @@ In addition,
 
 * The `Terminated` event is raised when the subscription terminates, either because of a non-canceled exception (see above), or when anything goes wrong with the underlying buffer (overload, loss...), or when it is actively terminated by e.g. disposing the reliable topic instance. Finally, the behavior of the subscription can be configured via the `ReliableTopicEventHandlerOptions`.
 
-   
+>[!NOTE] Other Hazelcast Clients lately started to support `Terminated` event as `onClose`.   
 
 ```csharp
 var id = await topic.SubscribeAsync(events => events


### PR DESCRIPTION
`OnClose` event is already supported in .Net client as `Terminated` from day `ReliableTopic` is implemented. Due to different naming between Hazelcast clients. I added a note to the docs.