### PR TITLE
Migrate GitHub actions from AdoptOpenJDK to Eclipse Temurin [HZ-4195]

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -59,5 +59,5 @@ runs:
       if: inputs.java == 'true'
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '11'

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -57,7 +57,7 @@ runs:
     # Install Java
     - name: Install JDK
       if: inputs.java == 'true'
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'


### PR DESCRIPTION
The `setup-java` [documentation highlights that AdoptOpenJDK no longer receives security updates](https://github.com/actions/setup-java#:~:text=NOTE%3A%20AdoptOpenJDK%20got%20moved%20to%20Eclipse%20Temurin), and instead the Eclipse Temurin JDK should be used.

Fixes [HZ-4195](https://hazelcast.atlassian.net/browse/HZ-4195)

[HZ-4195]: https://hazelcast.atlassian.net/browse/HZ-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ