### PR TITLE
Replaces Moq with NSubsitute [API-2119]

### DIFF
--- a/src/Hazelcast.Net.Testing/Hazelcast.Net.Testing.csproj
+++ b/src/Hazelcast.Net.Testing/Hazelcast.Net.Testing.csproj
@@ -26,7 +26,11 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NuGet.Versioning" Version="6.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />

--- a/src/Hazelcast.Net.Testing/Linq/LinqTestingExtension.cs
+++ b/src/Hazelcast.Net.Testing/Linq/LinqTestingExtension.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using Hazelcast.Linq;
 using Hazelcast.Sql;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 
 namespace Hazelcast.Testing.Linq
 {
@@ -25,7 +25,7 @@ namespace Hazelcast.Testing.Linq
     {
         public static IAsyncQueryable<T> AsTestingAsyncQueryable<T>(this List<T> list)
         {
-            return new QueryableMap<T>(new QueryProvider(Mock.Of<ISqlService>(), typeof(T), NullLoggerFactory.Instance), typeof(T).Name);
+            return new QueryableMap<T>(new QueryProvider(Substitute.For<ISqlService>(), typeof(T), NullLoggerFactory.Instance), typeof(T).Name);
         }
     }
 }

--- a/src/Hazelcast.Net.Tests/Caching/HazelcastCacheTests.cs
+++ b/src/Hazelcast.Net.Tests/Caching/HazelcastCacheTests.cs
@@ -26,7 +26,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Caching;
@@ -98,10 +98,10 @@ public class HazelcastCacheTests : SingleMemberRemoteTestBase
     [Test]
     public void ProvidedCacheExceptions()
     {
-        Assert.Throws<ArgumentNullException>(() => _ = new ProvidedHazelcastCache(Mock.Of<IOptions<HazelcastOptions>>(), null!));
-        Assert.Throws<ArgumentNullException>(() => _ = new ProvidedHazelcastCache(null!, Mock.Of<IOptions<HazelcastCacheOptions>>()));
-        Assert.Throws<ArgumentNullException>(() => _ = new ProvidedHazelcastCacheWithFailover(Mock.Of<IOptions<HazelcastFailoverOptions>>(), null!));
-        Assert.Throws<ArgumentNullException>(() => _ = new ProvidedHazelcastCacheWithFailover(null!, Mock.Of<IOptions<HazelcastCacheOptions>>()));
+        Assert.Throws<ArgumentNullException>(() => _ = new ProvidedHazelcastCache(Substitute.For<IOptions<HazelcastOptions>>(), null!));
+        Assert.Throws<ArgumentNullException>(() => _ = new ProvidedHazelcastCache(null!, Substitute.For<IOptions<HazelcastCacheOptions>>()));
+        Assert.Throws<ArgumentNullException>(() => _ = new ProvidedHazelcastCacheWithFailover(Substitute.For<IOptions<HazelcastFailoverOptions>>(), null!));
+        Assert.Throws<ArgumentNullException>(() => _ = new ProvidedHazelcastCacheWithFailover(null!, Substitute.For<IOptions<HazelcastCacheOptions>>()));
     }
 
     [Test]

--- a/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/FailoverTests.cs
@@ -26,7 +26,7 @@ using Hazelcast.Testing;
 using Hazelcast.Testing.Logging;
 using Hazelcast.Testing.Remote;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 using Partitioner = Hazelcast.Partitioning.Partitioner;
 
@@ -151,7 +151,8 @@ internal class FailoverTests : RemoteTestBase
 
     private static ClusterState MockClusterState(HazelcastOptions options)
     {
-        return new ClusterState(options, "clusterName", "clientName", Mock.Of<Partitioner>(), new NullLoggerFactory());
+        var partitioner = Substitute.For<Partitioner>();
+        return new ClusterState(options, "clusterName", "clientName", partitioner, new NullLoggerFactory());
     }
 
     [Test]

--- a/src/Hazelcast.Net.Tests/Core/SingletonLoggerFactoryServiceFactoryTests.cs
+++ b/src/Hazelcast.Net.Tests/Core/SingletonLoggerFactoryServiceFactoryTests.cs
@@ -15,7 +15,7 @@
 using Hazelcast.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Core
@@ -43,7 +43,7 @@ namespace Hazelcast.Tests.Core
                 Creator = () => NullLoggerFactory.Instance
             };
 
-            var mockProvider = Mock.Of<IMyProvider>();
+            var mockProvider = Substitute.For<IMyProvider>();
             
             f.AddProvider(mockProvider);
 

--- a/src/Hazelcast.Net.Tests/Events/EventHandlers.cs
+++ b/src/Hazelcast.Net.Tests/Events/EventHandlers.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 using Hazelcast.Events;
 using Hazelcast.Models;
 using Hazelcast.Networking;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Events
@@ -41,7 +41,7 @@ namespace Hazelcast.Tests.Events
                 return new ValueTask();
             });
 
-            var client = Mock.Of<IHazelcastClient>();
+            var client = Substitute.For<IHazelcastClient>();
             var args = new StateChangedEventArgs(ClientState.Connected);
             await handler.HandleAsync(client, args);
 
@@ -64,7 +64,7 @@ namespace Hazelcast.Tests.Events
                 return new ValueTask();
             });
 
-            var client = Mock.Of<IHazelcastClient>();
+            var client = Substitute.For<IHazelcastClient>();
             var memberInfo = new MemberInfo(Guid.NewGuid(), NetworkAddress.Parse("127.0.0.1:88"), new MemberVersion(1, 1, 1), false, new Dictionary<string, string>());
             var args = new PartitionLostEventArgs(12, 13, true, memberInfo);
             await handler.HandleAsync(client, args);
@@ -88,7 +88,7 @@ namespace Hazelcast.Tests.Events
                 return default;
             });
 
-            var client = Mock.Of<IHazelcastClient>();
+            var client = Substitute.For<IHazelcastClient>();
             var args = new ConnectionOpenedEventArgs(null, false);
             await handler.HandleAsync(client, args);
 

--- a/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
+++ b/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
@@ -34,7 +34,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NuGet.Versioning" Version="6.4.0" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/CompactOptionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/CompactOptionsTests.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using Hazelcast.Configuration;
 using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact
@@ -90,7 +90,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             options.SetTypeName<DifferentThing>("thing");
 
             // but then an explicit serializer is required
-            options.ReflectionSerializer = Mock.Of<ICompactSerializer<object>>();
+            options.ReflectionSerializer = Substitute.For<ICompactSerializer<object>>();
             Assert.Throws<ConfigurationException>(() => options.GetRegistrations().ToList());
 
             // indeed,
@@ -158,7 +158,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             options.SetSchema<DifferentThing>(SchemaBuilder.For("thing").Build(), false);
 
             // but then an explicit serializer is required
-            options.ReflectionSerializer = Mock.Of<ICompactSerializer<object>>();
+            options.ReflectionSerializer = Substitute.For<ICompactSerializer<object>>();
             Assert.Throws<ConfigurationException>(() => options.GetRegistrations().ToList());
 
             // with an explicit serializer, it works
@@ -168,7 +168,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             options.SetTypeName<Thing>(serializer.TypeName);
             options.SetTypeName<DifferentThing>(serializer.TypeName);
             options.AddSerializer<IThing, Thing>(serializer);
-            options.ReflectionSerializer = Mock.Of<ICompactSerializer<object>>();
+            options.ReflectionSerializer = Substitute.For<ICompactSerializer<object>>();
 
             var registrations = options.GetRegistrations().ToList();
             Assert.That(registrations.Count, Is.EqualTo(2));
@@ -334,7 +334,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         public void GetRegistrations()
         {
             var options = new CompactOptions();
-            options.ReflectionSerializer = Mock.Of<ICompactSerializer<object>>();
+            options.ReflectionSerializer = Substitute.For<ICompactSerializer<object>>();
 
             Assert.That(options.GetRegistrations(), Is.Empty);
 
@@ -343,14 +343,14 @@ namespace Hazelcast.Tests.Serialization.Compact
 
             options = new CompactOptions
             {
-                ReflectionSerializer = Mock.Of<ICompactSerializer<object>>()
+                ReflectionSerializer = Substitute.For<ICompactSerializer<object>>()
             };
             options.SetSchema(SchemaBuilder.For("System.Object").Build(), true);
             Assert.That(options.GetRegistrations().Count(), Is.EqualTo(1));
 
             options = new CompactOptions
             {
-                ReflectionSerializer = Mock.Of<ICompactSerializer<object>>()
+                ReflectionSerializer = Substitute.For<ICompactSerializer<object>>()
             };
             options.AddType<object>();
             Assert.That(options.GetRegistrations().Count(), Is.EqualTo(1));

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/CompactReaderTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/CompactReaderTests.cs
@@ -15,7 +15,7 @@
 using Hazelcast.Core;
 using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact
@@ -26,7 +26,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableAsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.Int8).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -46,7 +46,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableBooleanAsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.Boolean).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -66,7 +66,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableNotNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.NullableInt8).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -86,7 +86,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableNotNullBooleanAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.NullableBoolean).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -106,7 +106,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.NullableInt8).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -126,7 +126,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableNullBooleanAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.NullableBoolean).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -146,7 +146,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableArrayOfBooleanAsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfBoolean).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -171,7 +171,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableArrayOfBooleanNotNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableBoolean).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -196,7 +196,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableArrayOfBooleanNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableBoolean).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -216,7 +216,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableArrayOfInt8AsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfInt8).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -241,7 +241,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableArrayOfInt8NotNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableInt8).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -266,7 +266,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableArrayOfInt8NullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableInt8).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -286,7 +286,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableArrayOfInt16AsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfInt16).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -311,7 +311,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableArrayOfInt16NotNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableInt16).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -336,7 +336,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableArrayOfInt16NullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableInt16).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -356,7 +356,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableArrayOfInt32AsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfInt32).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -381,7 +381,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableArrayOfInt32NotNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableInt32).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -406,7 +406,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableArrayOfInt32NullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableInt32).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -426,7 +426,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableArrayOfInt64AsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfInt64).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -451,7 +451,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableArrayOfInt64NotNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableInt64).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -476,7 +476,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableArrayOfInt64NullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableInt64).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -496,7 +496,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableArrayOfFloat32AsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfFloat32).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -521,7 +521,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableArrayOfFloat32NotNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableFloat32).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -546,7 +546,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableArrayOfFloat32NullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableFloat32).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -566,7 +566,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNonNullableArrayOfFloat64AsNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfFloat64).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -591,7 +591,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullableArrayOfFloat64NotNullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableFloat64).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -616,7 +616,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotReadNullableArrayOfFloat64NullAsNonNullable()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.ArrayOfNullableFloat64).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -636,7 +636,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanReadNullArrays()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type")
                 .WithField("field0", FieldKind.ArrayOfBoolean)
@@ -671,7 +671,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void Exceptions()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.String).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);
@@ -698,7 +698,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void FieldNameAndKind()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             var schema = SchemaBuilder.For("type").WithField("field", FieldKind.String).Build();
             var output = new ObjectDataOutput(1024, orw, Endianness.LittleEndian);

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/CompactSerializerTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/CompactSerializerTests.cs
@@ -18,7 +18,7 @@ using Hazelcast.Messaging;
 using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact
@@ -55,7 +55,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             options.Compact.SetSchema<Thing>(thingSchema, false);
 
             // create the entire serialization service
-            var messaging = Mock.Of<IClusterMessaging>();
+            var messaging = Substitute.For<IClusterMessaging>();
             var service = HazelcastClientFactory.CreateSerializationService(options, messaging, new NullLoggerFactory());
 
             // and then, create a Thing instance, serialize it to data, and de-serialize it back to object
@@ -129,7 +129,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             options.Compact.AddSerializer(new ThingNestCompactSerializer());
             options.Compact.SetSchema<ThingNest>(thingNestSchema, false);
 
-            var messaging = Mock.Of<IClusterMessaging>();
+            var messaging = Substitute.For<IClusterMessaging>();
             var service = HazelcastClientFactory.CreateSerializationService(options, messaging, new NullLoggerFactory());
 
             var nest = new ThingNest
@@ -165,7 +165,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         public void Adapter_Exceptions()
         {
             Assert.Throws<ArgumentNullException>(() => CompactSerializerAdapter.Create(null));
-            Assert.Throws<ArgumentException>(() => CompactSerializerAdapter.Create(Mock.Of<ICompactSerializer>()));
+            Assert.Throws<ArgumentException>(() => CompactSerializerAdapter.Create(Substitute.For<ICompactSerializer>()));
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         public void Extensions_Exceptions()
         {
             Assert.Throws<ArgumentNullException>(() => ((ICompactSerializer)null).GetSerializedType());
-            Assert.Throws<ArgumentException>(() => Mock.Of<ICompactSerializer>().GetSerializedType());
+            Assert.Throws<ArgumentException>(() => Substitute.For<ICompactSerializer>().GetSerializedType());
 
             Assert.Throws<ArgumentNullException>(() => ((ICompactSerializer)null).IsICompactSerializerOfTSerialized(out _));
             Assert.Throws<ArgumentNullException>(() => ((Type)null).IsICompactSerializerOfTSerialized(out _));
@@ -192,7 +192,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             options.Compact.AddSerializer(new ThingCompactSerializer()); // Thing is explicit
 
             // create the entire serialization service
-            var messaging = Mock.Of<IClusterMessaging>();
+            var messaging = Substitute.For<IClusterMessaging>();
             var service = HazelcastClientFactory.CreateSerializationService(options, messaging, new NullLoggerFactory());
 
             var inner = new Thing
@@ -222,7 +222,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             options.Compact.AddSerializer(new ThingNestCompactSerializer()); // ThingNest is explicit
 
             // create the entire serialization service
-            var messaging = Mock.Of<IClusterMessaging>();
+            var messaging = Substitute.For<IClusterMessaging>();
             var service = HazelcastClientFactory.CreateSerializationService(options, messaging, new NullLoggerFactory());
 
             var inner = new Thing

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/CompactWriterTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/CompactWriterTests.cs
@@ -17,7 +17,7 @@ using Hazelcast.Core;
 using Hazelcast.Models;
 using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact
@@ -28,7 +28,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotWriteOnceCompleted()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             var output = new ObjectDataOutput(0, orw, Endianness.BigEndian);
             var schema = new Schema();
             var writer = new CompactWriter(orw, output, schema);
@@ -40,7 +40,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void OkToCompleteMultipleTimes()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             var output = new ObjectDataOutput(0, orw, Endianness.BigEndian);
             var schema = new Schema();
             var writer = new CompactWriter(orw, output, schema);
@@ -54,7 +54,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void TimeStampWithTimeZonePrecision()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             var output = new ObjectDataOutput(0, orw, Endianness.BigEndian);
             var schema = SchemaBuilder.For("type").WithField("name", FieldKind.TimeStampWithTimeZone).Build();
             var writer = new CompactWriter(orw, output, schema);
@@ -67,7 +67,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void Exceptions()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             var output = new ObjectDataOutput(0, orw, Endianness.BigEndian);
             var schema = SchemaBuilder.For("type").WithField("name", FieldKind.String).Build();
             var writer = new CompactWriter(orw, output, schema);
@@ -78,7 +78,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CanWriteArrayOfCompactOfSameType()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             var output = new ObjectDataOutput(0, orw, Endianness.BigEndian);
             var schema = SchemaBuilder.For("array").WithField("array", FieldKind.ArrayOfCompact).Build();
             var writer = new CompactWriter(orw, output, schema);
@@ -91,7 +91,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotWriteArrayOfCompactOfDifferentTypes()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             var output = new ObjectDataOutput(0, orw, Endianness.BigEndian);
             var schema = SchemaBuilder.For("array").WithField("array", FieldKind.ArrayOfCompact).Build();
             var writer = new CompactWriter(orw, output, schema);
@@ -104,7 +104,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public void CannotWriteArrayOfCompactOfDerivedTypes()
         {
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             var output = new ObjectDataOutput(0, orw, Endianness.BigEndian);
             var schema = SchemaBuilder.For("array").WithField("array", FieldKind.ArrayOfCompact).Build();
             var writer = new CompactWriter(orw, output, schema);

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/GenericRecordTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/GenericRecordTests.cs
@@ -23,7 +23,7 @@ using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
 using Hazelcast.Testing;
 using Hazelcast.Testing.Conditions;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact;
@@ -77,7 +77,7 @@ public class GenericRecordTests : SingleMemberClientRemoteTestBase
         Assert.Throws<SerializationException>(() => rec2.NewBuilderWithClone().SetInt32("other", 567).Build());
 
         Assert.Throws<ArgumentException>(() =>
-            GenericRecordBuilder.Compact("xxx").SetGenericRecord("xxx", Mock.Of<IGenericRecord>()).Build());
+            GenericRecordBuilder.Compact("xxx").SetGenericRecord("xxx", Substitute.For<IGenericRecord>()).Build());
     }
 
     [Test]
@@ -283,7 +283,7 @@ public class GenericRecordTests : SingleMemberClientRemoteTestBase
         Assert.Throws<ArgumentException>(() =>
             recordBuilder.SetArrayOfGenericRecord("field-x", new[]
             {
-                Mock.Of<IGenericRecord>()
+                Substitute.For<IGenericRecord>()
             }));
 
         // can set all fields once

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/ReaderWriterTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/ReaderWriterTests.cs
@@ -18,7 +18,7 @@ using System;
 using Hazelcast.Core;
 using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact
@@ -29,7 +29,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         private static byte[] Write(Schema schema, Endianness endianness, Action<ICompactWriter> write)
         {
             // should not be invoked, a dummy mock is all we need
-            var objectsReaderWriter = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var objectsReaderWriter = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
 
             const int initialBufferSize = 1024;
 
@@ -42,7 +42,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         private static void Read(Schema schema, Endianness endianness, byte[] bytes, Action<ICompactReader> read)
         {
             // should not be invoked, a dummy mock is all we need
-            var objectsReaderWriter = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var objectsReaderWriter = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             
             var input = new ObjectDataInput(bytes, objectsReaderWriter, endianness);
             var reader = new CompactReader(objectsReaderWriter, input, schema, typeof(object));

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/ReflectionSerializerTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/ReflectionSerializerTests.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 using Hazelcast.Core;
 using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact
@@ -471,10 +471,10 @@ namespace Hazelcast.Tests.Serialization.Compact
 
             Assert.Throws<ArgumentNullException>(() => serializer.Write(null!, null!));
 
-            var notCompactReader = Mock.Of<ICompactReader>();
+            var notCompactReader = Substitute.For<ICompactReader>();
             Assert.Throws<ArgumentException>(() => serializer.Read(notCompactReader));
 
-            var orw = Mock.Of<IReadWriteObjectsFromIObjectDataInputOutput>();
+            var orw = Substitute.For<IReadWriteObjectsFromIObjectDataInputOutput>();
             var compactReader = new CompactReader(
                 orw,
                 new ObjectDataInput(Array.Empty<byte>(), orw, Endianness.BigEndian),

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/SchemasRemoteTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/SchemasRemoteTests.cs
@@ -26,7 +26,7 @@ using Hazelcast.Serialization.Compact;
 using Hazelcast.Testing;
 using Hazelcast.Testing.Conditions;
 using Hazelcast.Tests.Serialization.Compact.SchemasRemoteTestsLocal;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact
@@ -94,7 +94,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             var obj = new SomeClass { Value = 12 };
 
             var options = new CompactOptions();
-            var messaging = Mock.Of<IClusterMessaging>();
+            var messaging = Substitute.For<IClusterMessaging>();
             var schemas = new Schemas(messaging, options);
             const Endianness endianness = Endianness.LittleEndian;
             var ss = new CompactSerializationSerializer(options, schemas, endianness);
@@ -134,7 +134,7 @@ namespace Hazelcast.Tests.Serialization.Compact
             var obj = new SomeClass { Value = 12 };
 
             var options = new CompactOptions();
-            var messaging = Mock.Of<IClusterMessaging>();
+            var messaging = Substitute.For<IClusterMessaging>();
             var schemas = new Schemas(messaging, options);
             const Endianness endianness = Endianness.LittleEndian;
             var ss = new CompactSerializationSerializer(options, schemas, endianness);

--- a/src/Hazelcast.Net.Tests/Serialization/SerializationServiceBuilderTest.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/SerializationServiceBuilderTest.cs
@@ -22,7 +22,7 @@ using Hazelcast.Serialization.Compact;
 using Hazelcast.Serialization.ConstantSerializers;
 using Hazelcast.Tests.Serialization.Objects;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization
@@ -50,7 +50,7 @@ namespace Hazelcast.Tests.Serialization
                     false,
                     new NullPartitioningStrategy(),
                     1024,
-                    Mock.Of<ISchemas>(),
+                    Substitute.For<ISchemas>(),
                     new NullLoggerFactory()
                 )
             );


### PR DESCRIPTION
This PR replaces the Moq library that we used for mocking in tests, with the NSubstitute library. As documented in issue #850 Moq has a problematic attitude with regards to privacy (see [moq/issues/1372](https://github.com/moq/moq/issues/1372)) and we'd rather avoid using it.