### PR TITLE
Fix issue 868

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -53,6 +53,7 @@ runs:
           5.0.x
           6.0.x
           7.0.x
+          8.0.x
 
     # Install Java
     - name: Install JDK
@@ -60,4 +61,4 @@ runs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'

--- a/hz.ps1
+++ b/hz.ps1
@@ -1968,6 +1968,10 @@ function stop-remote-controller() {
 	}
     else {
         Write-Output "Remote controller is not running."
+        Write-Output "STDOUT:"
+        cat $tmpDir/rc/stdout-$serverVersion.log
+        Write-Output "STDERR:"
+        cat $tmpDir/rc/stderr-$serverVersion.log
 	}
 }
 

--- a/src/Hazelcast.Net.Tests/Support/Issue868.cs
+++ b/src/Hazelcast.Net.Tests/Support/Issue868.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Remoting;
+using System.Threading.Tasks;
+using Hazelcast.Core;
+using Hazelcast.Query;
+using Hazelcast.Serialization.Compact;
+using Hazelcast.Testing;
+using NUnit.Framework;
+
+namespace Hazelcast.Tests.Support;
+
+[TestFixture]
+public class Issue868 : SingleMemberClientRemoteTestBase
+{
+    internal class Thing
+    {
+        // need a parameter-less constructor
+        public Thing()
+        { }
+
+        public Thing(string name)
+        {
+            Name = name;
+        }
+
+        // need to be publicly settable
+        public string Name { get; set; }
+
+        public override string ToString()
+            => $"Thing {{ Name=\"{Name}\" }}";
+    }
+
+    [Test]
+    public async Task Test()
+    {
+        // the Thing class will be serialized with compact serialization, no better alternative
+        await using var map = await Client.GetMapAsync<int, Thing>(CreateUniqueName());
+        for (var i = 0; i < 10; i++) await map.SetAsync(i, new Thing(i.ToString()));
+
+        var schemas0 = Client
+            .MustBe<HazelcastClient>().SerializationService.CompactSerializer.Schemas
+            .MustBe<Schemas>().SchemaCache;
+
+        // just to be sure: a schema has been created indeed
+        Assert.That(schemas0.Count, Is.EqualTo(1));
+        var schema = schemas0.First().Value;
+        Assert.That(schema.Schema.TypeName, Is.EqualTo("Hazelcast.Tests.Support.Issue868+Thing, Hazelcast.Net.Tests"));
+
+        // the new client does not know about the Thing compact schema, yet
+        await using var client1 = await HazelcastClientFactory.StartNewClientAsync(CreateHazelcastOptions());
+
+        var schemas1 = client1
+            .MustBe<HazelcastClient>().SerializationService.CompactSerializer.Schemas
+            .MustBe<Schemas>().SchemaCache;
+
+        // just to be sure: no schema so far
+        Assert.That(schemas1.Count, Is.EqualTo(0));
+
+        // go fetch entries
+        // reproduced: this indeed throws because the schema is not known during UpdateAnchors
+        // fixed: GetEntriesAsync modified, now works
+        // FIXME can we be sure that *all* anchors are going to be part of the result?
+        // what's an anchor really?
+        // node client says that anchor is 'the last value object on the previous page'
+        var predicate = Predicates.Page(2);
+        var entries = await map.GetEntriesAsync(predicate);
+        Assert.That(entries.Count, Is.EqualTo(2));
+
+        var n = 0;
+        foreach (var (key, value) in entries)
+            Console.WriteLine($"RESULT [{n++}] {key}: {value}");
+
+        foreach (var (pageNo, (key, value)) in predicate.MustBe<PagingPredicate>().AnchorList)
+            Console.WriteLine($"ANCHOR [{pageNo}] {key}: {value}");
+
+        // moving on to the next page... 
+        // result contains id 2 and 3, anchors are 1 and 3
+        // => there *is* an anchor that is not a value
+        predicate.NextPage();
+        entries = await map.GetEntriesAsync(predicate);
+        Assert.That(entries.Count, Is.EqualTo(2));
+
+        n = 0;
+        foreach (var (key, value) in entries)
+            Console.WriteLine($"RESULT [{n++}] {key}: {value}");
+
+        foreach (var (pageNo, (key, value)) in predicate.MustBe<PagingPredicate>().AnchorList)
+            Console.WriteLine($"ANCHOR [{pageNo}] {key}: {value}");
+    }
+}

--- a/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Getting.cs
+++ b/src/Hazelcast.Net/DistributedObjects/Impl/HMap.Getting.cs
@@ -212,7 +212,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 var requestMessage = MapEntriesWithPagingPredicateCodec.EncodeRequest(Name, pagingPredicateHolder);
                 var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
                 var response = MapEntriesWithPagingPredicateCodec.DecodeResponse(responseMessage);
-                pagingPredicate.UpdateAnchors(response.AnchorDataList.AsAnchorIterator(SerializationService));
+                await pagingPredicate.UpdateAnchors(response.AnchorDataList.AsAnchorAsyncIterator(SerializationService));
                 var result = new ReadOnlyLazyDictionary<TKey, TValue>(SerializationService);
                 await result.AddAsync(response.Response).CfAwait();
                 return result;
@@ -261,7 +261,7 @@ namespace Hazelcast.DistributedObjects.Impl
                 var requestMessage = MapKeySetWithPagingPredicateCodec.EncodeRequest(Name, pagingPredicateHolder);
                 var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
                 var response = MapKeySetWithPagingPredicateCodec.DecodeResponse(responseMessage);
-                pagingPredicate.UpdateAnchors(response.AnchorDataList.AsAnchorIterator(SerializationService));
+                await pagingPredicate.UpdateAnchors(response.AnchorDataList.AsAnchorAsyncIterator(SerializationService));
                 var result = new ReadOnlyLazyList<TKey>(SerializationService);
                 await result.AddAsync(response.Response).CfAwait();
                 return result;
@@ -310,9 +310,15 @@ namespace Hazelcast.DistributedObjects.Impl
                 var requestMessage = MapValuesWithPagingPredicateCodec.EncodeRequest(Name, pagingPredicateHolder);
                 var responseMessage = await Cluster.Messaging.SendAsync(requestMessage, cancellationToken).CfAwait();
                 var response = MapValuesWithPagingPredicateCodec.DecodeResponse(responseMessage);
-                pagingPredicate.UpdateAnchors(response.AnchorDataList.AsAnchorIterator(SerializationService));
+
+                // async - ensure we can deserialize
+                await pagingPredicate.UpdateAnchors(response.AnchorDataList.AsAnchorAsyncIterator(SerializationService));
+
+                // that is something else
+                // we add 'async' because we ensure that we can deserialize
                 var result = new ReadOnlyLazyList<TValue>(SerializationService);
                 await result.AddAsync(response.Response).CfAwait();
+
                 return result;
             }
 

--- a/src/Hazelcast.Net/Protocol/Models/AnchorDataListHolder.cs
+++ b/src/Hazelcast.Net/Protocol/Models/AnchorDataListHolder.cs
@@ -45,5 +45,24 @@ namespace Hazelcast.Protocol.Models
                 yield return new KeyValuePair<int, KeyValuePair<object, object>>(pageNumber, entry);
             }
         }
+
+        internal async IAsyncEnumerable<KeyValuePair<int, KeyValuePair<object, object>>> AsAnchorAsyncIterator(SerializationService serializationService)
+        {
+            using var dataEntryIterator = AnchorDataList.GetEnumerator();
+            foreach (var pageNumber in AnchorPageList)
+            {
+                dataEntryIterator.MoveNext();
+
+                var (keyData, valueData) = dataEntryIterator.Current;
+
+                if (!serializationService.TryToObject<object>(keyData, out var key, out var keyToObjectState))
+                    key = await serializationService.ToObjectAsync<object>(keyData, keyToObjectState);
+                if (!serializationService.TryToObject<object>(valueData, out var value, out var valueToObjectState))
+                    key = await serializationService.ToObjectAsync<object>(valueData, valueToObjectState);
+
+                var entry = new KeyValuePair<object, object>(key, value);
+                yield return new KeyValuePair<int, KeyValuePair<object, object>>(pageNumber, entry);
+            }
+        }
     }
 }

--- a/src/Hazelcast.Net/Query/PagingPredicate.cs
+++ b/src/Hazelcast.Net/Query/PagingPredicate.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading.Tasks;
 using Hazelcast.Serialization;
 
 namespace Hazelcast.Query
@@ -121,6 +122,13 @@ namespace Hazelcast.Query
             _anchorList ??= new List<KeyValuePair<int, KeyValuePair<object, object>>>();
             _anchorList.Clear();
             _anchorList.AddRange(anchors);
+        }
+
+        internal async Task UpdateAnchors(IAsyncEnumerable<KeyValuePair<int, KeyValuePair<object, object>>> anchors)
+        {
+            _anchorList ??= new List<KeyValuePair<int, KeyValuePair<object, object>>>();
+            _anchorList.Clear();
+            await foreach (var anchor in anchors) _anchorList.Add(anchor);
         }
 
         /// <inheritdoc />

--- a/src/Hazelcast.Net/Serialization/Compact/Schemas.cs
+++ b/src/Hazelcast.Net/Serialization/Compact/Schemas.cs
@@ -62,11 +62,14 @@ internal class Schemas : ISchemas
         _replicationDelay = options.SchemaReplicationDelay;
     }
 
+    // internal for tests
+    internal ConcurrentDictionary<long, SchemaInfo> SchemaCache => _schemas;
+
     /// <inheritdoc />
     public void Dispose()
     { }
 
-    private class SchemaInfo
+    internal class SchemaInfo
     {
         public SchemaInfo(Schema schema, bool isPublished = false)
         {


### PR DESCRIPTION
This PR fixes issue #868 by ensuring that `PagingPredicate` anchors can be deserialized, including if they are compact-serialized and a schema needs to be fetched.