### PR TITLE
Backport fixes for `5.2.x` [API-2214]

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -1288,15 +1288,6 @@ function ensure-java {
             `
             "--add-opens",   "java.base/java.io=ALL-UNNAMED" `
         )
-
-        # "Scripting is currently unsupported for Java 15 and newer. These versions
-        #  of Java do not come with a JavaScript engine, which is necessary for this
-        #  feature to work."
-        $pos = $javaVersion.IndexOf('.')
-        $javaMajor = $javaVersion.SubString(0, $pos)
-        if (-not ($javaVersion -lt "12") ) {
-            Die "Java version >11 not supported (JavaScript scripting not supported)"
-        }
 	}
 }
 

--- a/hz.ps1
+++ b/hz.ps1
@@ -144,6 +144,10 @@ $params = @(
     },
     @{ name = "yolo";            type = [switch]; default = $false;
        desc = "confirms excution of sensitive actions"
+    },
+    @{
+        name="copy-files-source"; type = [string];  default = $null;
+        desc = "source folder to be copied"
     }
 )
 
@@ -275,6 +279,10 @@ $actions = @(
     @{ name = "getfwks-json";
        desc = "get frameworks";
        internal = $true; uniq = $true; outputs = $true
+    },
+    @{
+        name = "copy-files";
+        desc= "copies from given --copy-files-source to current solution folder by reflecting the folder structure.";        
     }
 )
 
@@ -346,6 +354,7 @@ if (-not [System.String]::IsNullOrWhiteSpace($options.version)) {
 # set versions and configure
 $serverVersion = $options.server # use specified value by default
 $isSnapshot = $options.server.Contains("SNAPSHOT") -or $options.server -eq "master"
+$isBeta = $options.server.Contains("BETA") 
 $hzRCVersion = "0.8-SNAPSHOT" # use appropriate version
 #$hzRCVersion = "0.5-SNAPSHOT" # for 3.12.x
 
@@ -548,6 +557,12 @@ function determine-server-version {
     # set the actual server version
     # this will be updated below if required
     $script:serverVersion = $version
+
+    # BETA versions should be build and places under temp/lib.
+    if($isBeta){
+        Write-Output "Server: version $version is BETA, using this version"
+        return       
+    }
 
     if (-not $isSnapshot) {
         Write-Output "Server: version $version is not a -SNAPSHOT, using this version"
@@ -812,6 +827,19 @@ function ensure-server-files {
             $found = $true
         }
 
+        # special beta case
+        if ($isBeta) {
+            $url = "https://raw.githubusercontent.com/hazelcast/hazelcast/$v/hazelcast/src/main/resources/hazelcast-default.xml"
+            $dest = "$libDir/hazelcast-$serverVersion.xml"
+            $response = invoke-web-request $url $dest
+            if ($response.StatusCode -ne 200) {
+                if (test-path $dest) { rm $dest }
+                Die "Error: failed to download hazelcast-default.xml ($($response.StatusCode)) from branch $v"
+            }
+            Write-Output "Found hazelcast-default.xml from branch $v"
+            $found = $true
+        }   
+        
         if (-not $found) {
             # try tag eg 'v4.2.1' or 'v4.3'
             $url = "https://raw.githubusercontent.com/hazelcast/hazelcast/v$v/hazelcast/src/main/resources/hazelcast-default.xml"
@@ -2513,6 +2541,30 @@ function hz-getfwks-json {
     #else { Die "err: Invalid platform '$platform'" }
 
     ConvertTo-Json -InputObject $frameworks -Compress
+}
+
+## Copies files from given path to project folder with respect to source hierarhcy.
+function hz-copy-files (){
+
+    $source = $options.'copy-files-source'
+
+    if(-not (test-path -path $source)){
+        Die "$($source) is not exist."
+    }
+
+    $currentPath = $slnRoot
+    $count = 0
+    foreach ($file in get-childItem -path $source -recurse){
+
+        if(Test-Path -path $file -pathType Leaf){
+            $subPath = "$($file.Directory)".Replace($source,"")    
+            $dest = join-path $currentPath $subPath $file.name
+            Write-Output "-$($dest)"            
+            copy-item $file -destination $dest
+            if($?){$count += 1}
+        }
+    }
+    Write-Output "$($count) item(s) copied."
 }
 
 # ########

--- a/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
+++ b/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="NuGet.Versioning" Version="6.4.0" />
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslMutualAuthTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslMutualAuthTests.cs
@@ -34,7 +34,6 @@ namespace Hazelcast.Tests.Networking
         [TestCase(false, true, false, true)]
         [TestCase(false, false, true, false)]
         [TestCase(false, false, false, true)]
-
         public async Task MutualAuth(bool required, bool knowsClient, bool withCert, bool succeeds)
         {
             async ValueTask TryStartClientAsync()
@@ -51,6 +50,7 @@ namespace Hazelcast.Tests.Networking
                     validateCertificateName: false,
                     clientCertificatePath: clientCertPath,
                     clientCertificatePassword: ClientCertificatePassword,
+                    serverCertificateName: ServerCertificateValidName,
                     failFast: !succeeds // when we expect to fail, reduce timeouts, no point retrying
                 );
             }
@@ -70,7 +70,6 @@ namespace Hazelcast.Tests.Networking
         [TestCase(true, false)]
         [TestCase(false, true)]
         [TestCase(false, false)]
-
         public async Task MutualAuthDisabled(bool knowsClient, bool withCert)
         {
             var clientCertNumber = knowsClient ? 1 : 2;
@@ -83,6 +82,7 @@ namespace Hazelcast.Tests.Networking
                 enableSsl: true,
                 validateCertificateChain: true,
                 validateCertificateName: null,
+                serverCertificateName: withCert ? ServerCertificateValidName : ServerCertificateInvalidName,
                 clientCertificatePath: clientCertPath,
                 clientCertificatePassword: ClientCertificatePassword);
         }

--- a/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
+++ b/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
@@ -95,7 +95,7 @@ namespace Hazelcast.Tests.Networking
 
 #if SSLCERTS_JAVA
         public const string ServerCertificateValidName = "foobar.hazelcast.com";
-        public const string ServerCertificateInvalidName = "meh";
+        public const string ServerCertificateInvalidName = "meh.meh";
         public const string ClientCertificatePassword = "password";
         public const string ClientCertificatePath = "Certificates";
         public const string ClientCertificatePrefix = "java.";
@@ -111,7 +111,7 @@ namespace Hazelcast.Tests.Networking
 
 #if SSLCERTS_MIXED
         public const string ServerCertificateValidName = "foobar.hazelcast.com";
-        public const string ServerCertificateInvalidName = "meh";
+        public const string ServerCertificateInvalidName = "meh.meh";
         public const string ClientCertificatePassword = "123456";
         public const string ClientCertificatePath = "temp:certs/clients";
         public const string ClientCertificatePrefix = "";
@@ -127,7 +127,7 @@ namespace Hazelcast.Tests.Networking
 
 #if SSLCERTS_CUSTOM
         public const string ServerCertificateValidName = "hz-2ef34a78.net";
-        public const string ServerCertificateInvalidName = "meh";
+        public const string ServerCertificateInvalidName = "meh.meh";
         public const string ClientCertificatePassword = "123456";
         public const string ClientCertificatePath = "temp:certs";
         public const string ClientCertificatePrefix = "";


### PR DESCRIPTION
PR includes fixes for invalid certificate name error on Java side, removing Java version check on `hz.ps1` and nunit adapter upgrade. All changes are on testing. No production code changed.