### PR TITLE
Clear Members Before Failover Over to New Cluster [API-2217]

### DIFF
--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -525,7 +525,7 @@ namespace Hazelcast.Clustering
             }
 
             // get known members' addresses
-            var addresses = _clusterMembers.GetMembers().Select(x => x.ConnectAddress);
+            var addresses = _clusterMembers.GetMembersForConnection().Select(x => x.ConnectAddress);
             foreach (var address in Distinct(addresses, distinct, shuffle))
                 yield return address;
 

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -80,6 +80,12 @@ namespace Hazelcast.Clustering
                     lock (_mutex) return _members.ContainsMember(x);
                 }, _clusterState.LoggerFactory);
             }
+
+            _clusterState.Failover.ClusterChanged += cluster =>
+            {
+                // Clear old member table since failover happened.
+                _members = new MemberTable();
+            };
         }
 
         // NOTES
@@ -370,6 +376,7 @@ namespace Hazelcast.Clustering
                 msg.Append(status);
                 msg.AppendLine();
             }
+
             msg.Append('}');
 
             //Print only if there is a change
@@ -793,10 +800,11 @@ namespace Hazelcast.Clustering
         /// <returns>The oldest active connection, or <c>null</c> if no connection is active.</returns>
         public MemberConnection GetOldestConnection()
         {
-            lock (_mutex) return _connections.Values
-                .Where(x => x.Active)
-                .OrderBy(x => x.ConnectTime)
-                .FirstOrDefault();
+            lock (_mutex)
+                return _connections.Values
+                    .Where(x => x.Active)
+                    .OrderBy(x => x.ConnectTime)
+                    .FirstOrDefault();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #834.