### PR TITLE
Make `git` branch resolution in script more more tolerant

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -1541,7 +1541,12 @@ function hz-build {
         $options.constants = $options.constants.Replace(";", "%3B") # escape ';'
     }
 
-    $branchName = git name-rev --name-only HEAD
+    try {
+        $branchName = git symbolic-ref --short HEAD
+    } catch {
+        # In the case of a detached branch
+        $branchName = ""
+    }
     $isReleaseBranch = $branchName.StartsWith("release/")
 
     Write-Output "Build"

--- a/hz.ps1
+++ b/hz.ps1
@@ -1541,7 +1541,7 @@ function hz-build {
         $options.constants = $options.constants.Replace(";", "%3B") # escape ';'
     }
 
-    $branchName = git symbolic-ref --short HEAD
+    $branchName = git name-rev --name-only HEAD
     $isReleaseBranch = $branchName.StartsWith("release/")
 
     Write-Output "Build"


### PR DESCRIPTION
The script queries if the branch name starts with `release`, using the `git symbolic-ref` command.

[While testing the `client-compatibility-suites`](https://github.com/hazelcast/client-compatibility-suites/actions/runs/9908837208/job/27376177353), it was noticed that for detached branches, [this command throws an error (`fatal: ref HEAD is not a symbolic ref`) and stops the script](https://stackoverflow.com/a/45028375).