### PR TITLE
Drop Net7 Support [API-2249]

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net48;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net6.0;net8.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
     

--- a/doc/dev/doc/network.md
+++ b/doc/dev/doc/network.md
@@ -46,7 +46,7 @@ Please note that server should support this routing mode which is available with
 In all members mode, the clients connect to each cluster member. Since each data partition uses the well known and consistent hashing algorithm, each client can send an operation to the relevant cluster member, which increases the overall throughput and efficiency. This mode is the default mode.
 
 ### Send CP Requests Directly To the Leader
-This `@Hazelcast.NetworkingOptions.CPDirectToLeaderEnabled` option allows to redirect CP related requests to the leader of the CP group. This option is only available for CP Subsystem enabled clusters. By default, this option is disabled.
+This `@Hazelcast.NetworkingOptions.CPDirectToLeaderEnabled` option allows to CP related requests to be sent directly to the leader of the CP group. This option is only available for CP Subsystem enabled clusters which have the `AVANCED_CP` license component. By default, this option is disabled.
 
 
 ## Reconnect Mode

--- a/doc/versions.md
+++ b/doc/versions.md
@@ -38,17 +38,20 @@ Versions lifecycle and support period follows the Hazelcast [Version Support Win
 
 The following table defines the .NET versions that were active and supported by each version of the Hazelcast .NET Client, at the time it was released. The Hazelcast .NET Client remains supported on these .NET versions for as long as they have not reached their end of support from Microsoft.
 
-|Version|.NET Framework<br/>4.5-4.6.1|.NET Framework<br/>4.6.2-4.8|.NET Core<br/>2.1|.NET Core<br/>3.1 (LTS)|.NET<br/>5.0|.NET<br/>6.0 (LTS)|.NET<br/>7.0|
-|-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-|5.2|No|Yes|No|**No** (note)|**No** (note)|Yes|**Yes**|
-|5.1|No|Yes|No|Yes|Yes|**Yes**|No|
-|5.0|No|Yes|**No** (note)|Yes|**Yes**|No|No|
-|4.x|**No** (note)|Yes|Yes|Yes|No|No|No|
-|3.x|Yes|Yes|No|No|No|No|No|
+| Version |.NET Framework<br/>4.5-4.6.1|.NET Framework<br/>4.6.2-4.8|.NET Core<br/>2.1|.NET Core<br/>3.1 (LTS)|.NET<br/>5.0|.NET<br/>6.0 (LTS)| .NET<br/>7.0 | .NET<br/>8.0 (LTS) |
+|---------|:-:|:-:|:-:|:-:|:-:|:-:|:------------:|:------------------:|
+| 5.5     |No|Yes|No|**No** (note)|**No** (note)|Yes|    **No**    |        Yes         |
+| 5.4     |No|Yes|No|**No** (note)|**No** (note)|Yes|   **Yes**    |        Yes         |
+| 5.3     |No|Yes|No|**No** (note)|**No** (note)|Yes|   **Yes**    |         No         |
+| 5.2     |No|Yes|No|**No** (note)|**No** (note)|Yes|   **Yes**    |         No         |
+| 5.1     |No|Yes|No|Yes|Yes|**Yes**|      No      |         No         |
+| 5.0     |No|Yes|**No** (note)|Yes|**Yes**|No|      No      |         No         |
+| 4.x     |**No** (note)|Yes|Yes|Yes|No|No|      No      |         No         |
+| 3.x     |Yes|Yes|No|No|No|No|      No      |         No         |
 
 Note that .NET Framework runs on Windows exclusively, whereas .NET Core and .NET 5.0+ run on Windows, Linux and MacOS.
 
 > [!NOTE]
 > As per Microsoft's **.NET Framework** [Support Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework), versions 4.5.2, 4.6, and 4.6.1 will reach end of support on April 26, 2022. We do *not* support these versions starting with Hazelcast 4. We recommend that all Hazelcast 3 users migrate to at least .NET Framework 4.6.2, and ideally to .NET Framework 4.8.
 >
-> As per Microsoft's **.NET and .NET Core** [Support Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core) and [LifeCycle](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core), versions 2.1 to 5.0 are not supported anymore. We recommend that all users use versions of .NET supported by Microsoft.
+> As per Microsoft's **.NET and .NET Core** [Support Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core) and [LifeCycle](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core), versions 2.1 to 5.0 and 7.0 are not supported anymore. We recommend that all users use versions of .NET supported by Microsoft.

--- a/hz.ps1
+++ b/hz.ps1
@@ -1044,12 +1044,10 @@ function require-dotnet ( $full ) {
     $result = @{ validSdks = $true; sdkInfos = "  SDKs:" }
 
     # note:
-    # - net6.0 end of support is nov 12, 2024
-    # - net7.0 end of support is may 14, 2024
+    # - net6.0 end of support is nov 12, 2024    
     # - net8.0 end of support is nov 10, 2026
 
-    require-dotnet-version $result $sdks "6.0" $frameworks "net6.0" "6.0.x" $true $allowPrerelease
-    require-dotnet-version $result $sdks "7.0" $frameworks "net7.0" "7.0.x" $true $allowPrerelease
+    require-dotnet-version $result $sdks "6.0" $frameworks "net6.0" "6.0.x" $true $allowPrerelease    
     require-dotnet-version $result $sdks "8.0" $frameworks "net8.0" "8.0.x" $true $allowPrerelease
 
     # report
@@ -2420,7 +2418,7 @@ function hz-verify-version {
 # runs an example
 function hz-run-example {
 
-    if ($options.framework -ne $null) { $f = $options.framework } else { $f = "net7.0" }
+    if ($options.framework -ne $null) { $f = $options.framework } else { $f = "net8.0" }
     $ext = ""
     if ($isWindows) { $ext = ".exe" }
     $hx = "$srcDir/Hazelcast.Net.Examples/bin/$($options.configuration)/$f/hx$ext"

--- a/src/Hazelcast.Net.Caching/Hazelcast.Net.Caching.csproj
+++ b/src/Hazelcast.Net.Caching/Hazelcast.Net.Caching.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
         <RootNamespace>Hazelcast.Caching</RootNamespace>
         <!--<ImplicitUsings>enable</ImplicitUsings>-->
         <Nullable>enable</Nullable>

--- a/src/Hazelcast.Net.DependencyInjection/Hazelcast.Net.DependencyInjection.csproj
+++ b/src/Hazelcast.Net.DependencyInjection/Hazelcast.Net.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Hazelcast.DependencyInjection</RootNamespace>
   </PropertyGroup>
 

--- a/src/Hazelcast.Net.Examples/Hazelcast.Net.Examples.csproj
+++ b/src/Hazelcast.Net.Examples/Hazelcast.Net.Examples.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net462;net48;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Hazelcast.Net.Linq.Async/Hazelcast.Net.Linq.Async.csproj
+++ b/src/Hazelcast.Net.Linq.Async/Hazelcast.Net.Linq.Async.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
         <RootNamespace>Hazelcast.Linq</RootNamespace>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
+++ b/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net462;net48;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Hazelcast.Net.Win32/Hazelcast.Net.Win32.csproj
+++ b/src/Hazelcast.Net.Win32/Hazelcast.Net.Win32.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Hazelcast</RootNamespace>
   </PropertyGroup>
 

--- a/src/Hazelcast.Net/Hazelcast.Net.csproj
+++ b/src/Hazelcast.Net/Hazelcast.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Hazelcast</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
.Net 7 support ended at May 14, 2024. We also drop support in Hazelcast .Net client.