### PR TITLE
Fix CP Group Name in CP Objects [API-2252]

### DIFF
--- a/src/Hazelcast.Net.Tests/CP/AtomicLongTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/AtomicLongTests.cs
@@ -22,14 +22,40 @@ using NUnit.Framework;
 namespace Hazelcast.Tests.CP
 {
     [TestFixture]
-    public class AtomicLongTests : SingleMemberClientRemoteTestBase
+    public class AtomicLongTests : MultiMembersRemoteTestBase
     {
+        protected override string RcClusterConfiguration => TestFiles.ReadAllText(this, "Cluster/cp.xml");
+
+        protected IHazelcastClient Client;
+        
+        [SetUp]
+        public async Task SetUp()
+        {
+            // CP-subsystem wants at least 3 members
+            for (var i = 0; i < 3; i++) await AddMember();
+            
+            Client = await CreateAndStartClientAsync();
+        }
+        
         [Test]
         public async Task Get()
         {
             var cpSubSystem = (CPSubsystem) Client.CPSubsystem;
             await using var along = await cpSubSystem.GetAtomicLongAsync(CreateUniqueName());
 
+            Assert.That(await along.GetAsync(), Is.EqualTo(0));
+
+            await along.DestroyAsync();
+        }
+        
+        [Test]
+        public async Task GetWithGroup()
+        {
+            var groupName = CreateUniqueName();
+            var objectName = CreateUniqueName() + "@"+ groupName;
+            await using var along = await Client.CPSubsystem.GetAtomicLongAsync(objectName);
+
+            Assert.That(along.GroupId.Name, Is.EqualTo(groupName));
             Assert.That(await along.GetAsync(), Is.EqualTo(0));
 
             await along.DestroyAsync();

--- a/src/Hazelcast.Net.Tests/CP/AtomicLongTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/AtomicLongTests.cs
@@ -28,7 +28,7 @@ namespace Hazelcast.Tests.CP
 
         protected IHazelcastClient Client;
         
-        [SetUp]
+        [OneTimeSetUp]
         public async Task SetUp()
         {
             // CP-subsystem wants at least 3 members

--- a/src/Hazelcast.Net.Tests/CP/AtomicReferenceTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/AtomicReferenceTests.cs
@@ -28,7 +28,7 @@ namespace Hazelcast.Tests.CP
 
         protected IHazelcastClient Client;
         
-        [SetUp]
+        [OneTimeSetUp]
         public async Task SetUp()
         {
             // CP-subsystem wants at least 3 members
@@ -54,10 +54,7 @@ namespace Hazelcast.Tests.CP
             var groupName = CreateUniqueName();
             var objectName = CreateUniqueName() + "@"+ groupName;
             await using var atomicReference = await Client.CPSubsystem.GetAtomicReferenceAsync<string>(objectName);
-
             Assert.That(atomicReference.GroupId.Name, Is.EqualTo(groupName));
-            Assert.That(await atomicReference.GetAsync(), Is.EqualTo(0));
-
             await atomicReference.DestroyAsync();
         }
 

--- a/src/Hazelcast.Net.Tests/CP/AtomicReferenceTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/AtomicReferenceTests.cs
@@ -22,8 +22,21 @@ using NUnit.Framework;
 namespace Hazelcast.Tests.CP
 {
     [TestFixture]
-    public class AtomicReferenceTests: SingleMemberClientRemoteTestBase
+    public class AtomicReferenceTests : MultiMembersRemoteTestBase
     {
+        protected override string RcClusterConfiguration => TestFiles.ReadAllText(this, "Cluster/cp.xml");
+
+        protected IHazelcastClient Client;
+        
+        [SetUp]
+        public async Task SetUp()
+        {
+            // CP-subsystem wants at least 3 members
+            for (var i = 0; i < 3; i++) await AddMember();
+            
+            Client = await CreateAndStartClientAsync();
+        }
+        
         [Test]
         public async Task TestName()
         {
@@ -33,6 +46,19 @@ namespace Hazelcast.Tests.CP
             Assert.That(aref.Name, Is.EqualTo(name));
 
             await aref.DestroyAsync();
+        }
+        
+        [Test]
+        public async Task GetWithGroup()
+        {
+            var groupName = CreateUniqueName();
+            var objectName = CreateUniqueName() + "@"+ groupName;
+            await using var atomicReference = await Client.CPSubsystem.GetAtomicReferenceAsync<string>(objectName);
+
+            Assert.That(atomicReference.GroupId.Name, Is.EqualTo(groupName));
+            Assert.That(await atomicReference.GetAsync(), Is.EqualTo(0));
+
+            await atomicReference.DestroyAsync();
         }
 
         [Test]

--- a/src/Hazelcast.Net.Tests/CP/CPMapTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/CPMapTests.cs
@@ -53,6 +53,17 @@ public class CPMapTests : MultiMembersRemoteTestBase
     {
         Assert.ThrowsAsync<ArgumentException>(() => Client.CPSubsystem.GetMapAsync<int, int>(null));
     }
+    [Test]
+    public async Task GetWithGroup()
+    {
+        var groupName = CreateUniqueName();
+        var objectName = CreateUniqueName() + "@" + groupName;
+        await using var cpMap = await Client.CPSubsystem.GetMapAsync<string, string>(objectName);
+
+        Assert.That(cpMap.GroupId.Name, Is.EqualTo(groupName));
+
+        await cpMap.DestroyAsync();
+    }
 
     [Test]
     public async Task TestGetCPMap()
@@ -66,7 +77,7 @@ public class CPMapTests : MultiMembersRemoteTestBase
         Assert.AreEqual(ServiceNames.CPMap, doBase.ServiceName);
         Assert.AreEqual(_defaultMapName, doBase.Name);
         Assert.IsNull(doBase.PartitionKey);
-        
+
         Assert.AreEqual(CPSubsystem.DefaultGroupName, map.GroupId.Name);
     }
 

--- a/src/Hazelcast.Net.Tests/CP/CountDownLatchTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/CountDownLatchTests.cs
@@ -20,8 +20,34 @@ using NUnit.Framework;
 namespace Hazelcast.Tests.CP;
 
 [TestFixture]
-public class CountDownLatchTests : SingleMemberClientRemoteTestBase
+public class CountDownLatchTests : MultiMembersRemoteTestBase
 {
+    protected override string RcClusterConfiguration => TestFiles.ReadAllText(this, "Cluster/cp.xml");
+
+    protected IHazelcastClient Client;
+        
+    [SetUp]
+    public async Task SetUp()
+    {
+        // CP-subsystem wants at least 3 members
+        for (var i = 0; i < 3; i++) await AddMember();
+            
+        Client = await CreateAndStartClientAsync();
+    }
+    
+    [Test]
+    public async Task GetWithGroup()
+    {
+        var groupName = CreateUniqueName();
+        var objectName = CreateUniqueName() + "@"+ groupName;
+        await using var countDownLatch = await Client.CPSubsystem.GetCountDownLatchAsync(objectName);
+
+        Assert.That(countDownLatch.GroupId.Name, Is.EqualTo(groupName));
+
+        await countDownLatch.DestroyAsync();
+    }
+    
+    
     [Test]
     public async Task NormalTest()
     {

--- a/src/Hazelcast.Net.Tests/CP/CountDownLatchTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/CountDownLatchTests.cs
@@ -26,7 +26,7 @@ public class CountDownLatchTests : MultiMembersRemoteTestBase
 
     protected IHazelcastClient Client;
         
-    [SetUp]
+    [OneTimeSetUp]
     public async Task SetUp()
     {
         // CP-subsystem wants at least 3 members

--- a/src/Hazelcast.Net.Tests/CP/FencedLockTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/FencedLockTests.cs
@@ -97,6 +97,7 @@ namespace Hazelcast.Tests.CP
             var cpSubSystem = (CPSubsystem) Client.CPSubsystem;
             _lock = await cpSubSystem.GetLockAsync(lockName);
 
+            Assert.That(_lock.GroupId.Name, Is.EqualTo("group1"));
             var lockContext = new LockContext();
             await _lock.LockAsync(lockContext);
             await _lock.LockAsync(lockContext);

--- a/src/Hazelcast.Net.Tests/CP/SemaphoreTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/SemaphoreTests.cs
@@ -73,6 +73,17 @@ public class SemaphoreTests : MultiMembersRemoteTestBase
         _groups.Add(semaphore.GroupId); // make sure we close the corresponding session when tearing down
         return semaphore;
     }
+    
+    public async Task GetWithGroup()
+    {
+        var groupName = CreateUniqueName();
+        var objectName = CreateUniqueName() + "@" + groupName;
+        await using var semaphore = await _client.CPSubsystem.GetSemaphore(objectName);
+
+        Assert.That(semaphore.GroupId.Name, Is.EqualTo(groupName));
+
+        await semaphore.DestroyAsync();
+    }
 
     [Test]
     public async Task CanGetSemaphore([Values] bool sessionLess)

--- a/src/Hazelcast.Net.Tests/Resources/Cluster/cp.xml
+++ b/src/Hazelcast.Net.Tests/Resources/Cluster/cp.xml
@@ -43,8 +43,7 @@
 
   <cp-subsystem>
     <base-dir>/custom-cp-dir</base-dir>
-    <cp-member-count>3</cp-member-count>
-    <group-size>3</group-size>
+    <cp-member-count>3</cp-member-count>   
 
     <!-- 
     Duration for a CP session to be kept alive after the last received heartbeat. A CP 

--- a/src/Hazelcast.Net/CP/CPSubsystem.cs
+++ b/src/Hazelcast.Net/CP/CPSubsystem.cs
@@ -74,8 +74,8 @@ namespace Hazelcast.CP
         /// <inheritdoc />
         public async Task<ISemaphore> GetSemaphore(string name)
         {
-            var (groupName, objectName, _) = ParseName(name);
-            var groupId = await GetGroupIdAsync(groupName).CfAwait();
+            var (groupName, objectName, fullName) = ParseName(name);
+            var groupId = await GetGroupIdAsync(fullName).CfAwait();
             var requestMessage = SemaphoreGetSemaphoreTypeCodec.EncodeRequest(objectName);
             var responseMessage = await _cluster.Messaging.SendAsync(requestMessage);
             var noSession = SemaphoreGetSemaphoreTypeCodec.DecodeResponse(responseMessage).Response;
@@ -89,7 +89,7 @@ namespace Hazelcast.CP
         public async Task<IAtomicLong> GetAtomicLongAsync(string name)
         {
             var (groupName, objectName, _) = ParseName(name);
-            var groupId = await GetGroupIdAsync(groupName).CfAwait();
+            var groupId = await GetGroupIdAsync(name).CfAwait();
 
             return new AtomicLong(objectName, groupId, _cluster, _serializationService);
         }
@@ -97,8 +97,8 @@ namespace Hazelcast.CP
         /// <inheritdoc />
         public async Task<IAtomicReference<T>> GetAtomicReferenceAsync<T>(string name)
         {
-            var (groupName, objectName, _) = ParseName(name);
-            var groupId = await GetGroupIdAsync(groupName).CfAwait();
+            var (groupName, objectName, fullName) = ParseName(name);
+            var groupId = await GetGroupIdAsync(fullName).CfAwait();
 
             return new AtomicReference<T>(objectName, groupId, _cluster, _serializationService);
         }
@@ -107,7 +107,7 @@ namespace Hazelcast.CP
         public async Task<IFencedLock> GetLockAsync(string name)
         {
             var (groupName, objectName, fullName) = ParseName(name);
-            var groupId = await GetGroupIdAsync(groupName).CfAwait();
+            var groupId = await GetGroupIdAsync(name).CfAwait();
 
             // note: make sure to use the fully qualified fullName as a dictionary key
 
@@ -145,14 +145,14 @@ namespace Hazelcast.CP
                 if (fencedLock.GroupId.Equals(groupId))
                     return fencedLock;
 
-                groupId = await GetGroupIdAsync(groupName).CfAwait();
+                groupId = await GetGroupIdAsync(fullName).CfAwait();
             }
         }
         
         public async Task<ICPMap<TKey, TValue>> GetMapAsync<TKey, TValue>([NotNull] string name)
         {
             var (groupName, objectName, fullName) = ParseName(name);
-            var groupId = await GetGroupIdAsync(groupName).CfAwait();
+            var groupId = await GetGroupIdAsync(fullName).CfAwait();
 
             return new CPMap<TKey, TValue>(ServiceNames.CPMap, objectName, _cluster,
                 _serializationService, groupId);
@@ -160,8 +160,8 @@ namespace Hazelcast.CP
 
         public async Task<ICountDownLatch> GetCountDownLatchAsync(string name)
         {
-            var (groupName, objectName, _) = ParseName(name);
-            var groupId = await GetGroupIdAsync(groupName).CfAwait();
+            var (groupName, objectName, fullName) = ParseName(name);
+            var groupId = await GetGroupIdAsync(fullName).CfAwait();
 
             return new CountDownLatch(objectName, groupId, _cluster, _serializationService);
         }

--- a/src/Hazelcast.Net/CP/CPSubsystem.cs
+++ b/src/Hazelcast.Net/CP/CPSubsystem.cs
@@ -88,8 +88,8 @@ namespace Hazelcast.CP
         /// <inheritdoc />
         public async Task<IAtomicLong> GetAtomicLongAsync(string name)
         {
-            var (groupName, objectName, _) = ParseName(name);
-            var groupId = await GetGroupIdAsync(name).CfAwait();
+            var (groupName, objectName, fullName) = ParseName(name);
+            var groupId = await GetGroupIdAsync(fullName).CfAwait();
 
             return new AtomicLong(objectName, groupId, _cluster, _serializationService);
         }
@@ -107,7 +107,7 @@ namespace Hazelcast.CP
         public async Task<IFencedLock> GetLockAsync(string name)
         {
             var (groupName, objectName, fullName) = ParseName(name);
-            var groupId = await GetGroupIdAsync(name).CfAwait();
+            var groupId = await GetGroupIdAsync(fullName).CfAwait();
 
             // note: make sure to use the fully qualified fullName as a dictionary key
 


### PR DESCRIPTION
The PR fixes wrong usage of CP groups. Before the introduced fix, the client was sending the CP group creation requests in wrong format. This was resulting that all CP objects created in `default` CP group. Now, it's fixed.