### PR TITLE
Fix GetMembers for `MultiMember` routing mode [API-2255]

### DIFF
--- a/src/Hazelcast.Net.Tests/Clustering/ConnectMembersTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/ConnectMembersTests.cs
@@ -49,7 +49,7 @@ namespace Hazelcast.Tests.Clustering
                 .AddFilter(level => true)
                 .AddHConsole());
             var logger = loggerFactory.CreateLogger("ConnectMembers");
-            var queue = new MemberConnectionQueue(x => true, loggerFactory);
+            var queue = new MemberConnectionQueue(x => true,x => true, loggerFactory);
 
             // background task that pretend to connect members
             var dequeuedRequests = 0;
@@ -208,7 +208,7 @@ namespace Hazelcast.Tests.Clustering
                 .AddFilter(level => true)
                 .AddHConsole());
             var logger = loggerFactory.CreateLogger("ConnectMembers");
-            var queue = new MemberConnectionQueue(x => true, loggerFactory);
+            var queue = new MemberConnectionQueue(x => true,x => true, loggerFactory);
             var memberCount = new Dictionary<Guid, int>();
 
             // background task that pretend to connect members

--- a/src/Hazelcast.Net.Tests/Clustering/MemberConnectionQueueTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberConnectionQueueTests.cs
@@ -38,7 +38,7 @@ public class MemberConnectionQueueTests
     [Test]
     public async Task Works()
     {
-        await using var queue = new MemberConnectionQueue(id => true, NullLoggerFactory.Instance);
+        await using var queue = new MemberConnectionQueue(id => true,id => true, NullLoggerFactory.Instance);
         queue.Resume(); // queue is initially suspended
 
         var id1 = Guid.NewGuid();
@@ -75,7 +75,7 @@ public class MemberConnectionQueueTests
     [Test]
     public async Task FailedRequestsAreQueuedAgain()
     {
-        await using var queue = new MemberConnectionQueue(id => true, NullLoggerFactory.Instance);
+        await using var queue = new MemberConnectionQueue(id => true, id => true, NullLoggerFactory.Instance);
         queue.Resume(); // queue is initially suspended
 
         var id1 = Guid.NewGuid();
@@ -103,7 +103,7 @@ public class MemberConnectionQueueTests
     [Test]
     public async Task SuspendWhileFree()
     {
-        await using var queue = new MemberConnectionQueue(id => true, NullLoggerFactory.Instance);
+        await using var queue = new MemberConnectionQueue(id => true, id => true, NullLoggerFactory.Instance);
         queue.Resume(); // queue is initially suspended
 
         var id1 = Guid.NewGuid();
@@ -127,7 +127,7 @@ public class MemberConnectionQueueTests
     [Test]
     public async Task SuspendWhileBusy([Values] bool success)
     {
-        await using var queue = new MemberConnectionQueue(id => true, NullLoggerFactory.Instance);
+        await using var queue = new MemberConnectionQueue(id => true, id => true, NullLoggerFactory.Instance);
         queue.Resume(); // queue is initially suspended
 
         var id1 = Guid.NewGuid();
@@ -154,7 +154,7 @@ public class MemberConnectionQueueTests
     [Test]
     public async Task EnforceOneEnumerator()
     {
-        await using var queue = new MemberConnectionQueue(id => true, NullLoggerFactory.Instance);
+        await using var queue = new MemberConnectionQueue(id => true, id => true, NullLoggerFactory.Instance);
         queue.Resume(); // queue is initially suspended
 
         // can get an enumerator

--- a/src/Hazelcast.Net.Tests/Clustering/MemberConnectionTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberConnectionTests.cs
@@ -202,19 +202,8 @@ namespace Hazelcast.Tests.Clustering
             void AssertMembers()
             {
                 var activeMemberIds = clusterMembers.GetMembers().Select(m => m.Id).ToList();
-
-                // filtered and current members must match in multi member mode
-                if (mode is RoutingModes.MultiMember)
-                {
-                    Assert.That(subsetMembers.GetSubsetMemberIds(), Is.EquivalentTo(activeMemberIds));
-                }
-                else
-                {
-                    // In the test, partition group is always a subset of the member list
-                    // So, it should never be equivalent to the member list in non multi member mode.
-                    Assert.That(subsetMembers.GetSubsetMemberIds(), Is.Not.EquivalentTo(activeMemberIds));
-                    Assert.That(refMemberList, Is.EquivalentTo(clusterMembers.GetMembers()));
-                }
+                Assert.That(subsetMembers.GetSubsetMemberIds(), Is.Not.EquivalentTo(activeMemberIds));
+                Assert.That(refMemberList, Is.EquivalentTo(clusterMembers.GetMembers()));
             }
 
             // Actual testing
@@ -229,7 +218,7 @@ namespace Hazelcast.Tests.Clustering
             // Partition Group changed
             partitionGroup = refMemberList.Skip(2).Select(m => m.Id).ToList();
             SetSubsetMembers(partitionGroup);
-            
+
             // This is event bound to Events.MemberPartitionGroupsUpdated on client level.
             // we mimic this behavior here.
             await clusterMembers.HandleMemberPartitionGroupsUpdated();

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -56,14 +56,19 @@ namespace Hazelcast.Tests.Clustering
             // Scale Up
             var member4 = await AddMember();
 
-            AssertClientOnlySees(client1, address1);
-            AssertClientOnlySees(client2, address2);
-            AssertClientOnlySees(client3, address3);
+            AssertClientOnlySees(client1, address1, 4);
+            AssertClientOnlySees(client2, address2, 4);
+            AssertClientOnlySees(client3, address3, 4);
 
             // Scale Down
             await RemoveMember(member4.Uuid);
 
-            AssertClientOnlySees(client1, address1);
+            // Scale down may take some time. So first assertion may occur few times.
+            await AssertEx.SucceedsEventually(() =>
+            {
+                AssertClientOnlySees(client1, address1);
+            }, 10_000, 500, "Client1 did not see the correct members");
+            
             AssertClientOnlySees(client2, address2);
             AssertClientOnlySees(client3, address3);
 
@@ -75,8 +80,12 @@ namespace Hazelcast.Tests.Clustering
             AssertClientOnlySees(client2, address2);
 
             await AssertEx.SucceedsEventually(()
-                    => Assert.That(client3.State, Is.EqualTo(ClientState.Disconnected)),
-                5000, 500);
+                    =>
+                {
+                    Assert.That(client3.Cluster.Connections.Count, Is.EqualTo(0));
+                    Assert.That(client3.State, Is.EqualTo(ClientState.Disconnected));
+                },
+                5_000, 500);
 
             Member member3;
             var nAddress3 = NetworkAddress.Parse(address3);
@@ -95,8 +104,8 @@ namespace Hazelcast.Tests.Clustering
 
             // Check if client1 is connected to the new member
             // cannot use the old member id since we can only either kill or create member
-            Assert.That(client3.Members.Count(), Is.EqualTo(1));
-            Assert.That(client3.Members.First().Member.ConnectAddress, Is.EqualTo(nAddress3));
+            Assert.That(client3.Cluster.Connections.Count, Is.EqualTo(1));
+            Assert.That(client3.Members.Select(p => p.Member.ConnectAddress), Contains.Item(nAddress3));
 
             AssertClientOnlySees(client1, address1);
             AssertClientOnlySees(client2, address2);
@@ -144,7 +153,7 @@ namespace Hazelcast.Tests.Clustering
             }, 10_000, 200);
         }
 
-        private void AssertClientOnlySees(HazelcastClient client, string address)
+        private void AssertClientOnlySees(HazelcastClient client, string address, int clusterSize = 3)
         {
             var member = RcMembers.Values.FirstOrDefault(m => address.Equals($"{m.Host}:{m.Port}"));
 
@@ -153,8 +162,9 @@ namespace Hazelcast.Tests.Clustering
             var members = client.Cluster.Members;
             var memberId = Guid.Parse(member.Uuid);
 
-            Assert.That(members.GetMembers().Count(), Is.EqualTo(1));
-            Assert.That(members.GetMembers().First().Uuid, Is.EqualTo(memberId));
+            Assert.That(members.GetMembers().Count(), Is.EqualTo(clusterSize));
+            Assert.That(client.Cluster.Connections.Count, Is.EqualTo(1));
+            Assert.True(client.Cluster.Connections.Contains(memberId), "Member is not connected");
             Assert.That(members.SubsetClusterMembers.GetSubsetMemberIds().Count(), Is.EqualTo(1));
             Assert.That(members.SubsetClusterMembers.GetSubsetMemberIds(), Contains.Item(memberId));
         }

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -68,9 +68,9 @@ namespace Hazelcast.Tests.Clustering
             {
                 AssertClientOnlySees(client1, address1);
             }, 10_000, 500, "Client1 did not see the correct members");
-            
+
             AssertClientOnlySees(client2, address2);
-            AssertClientOnlySees(client3, address3);
+            AssertClientOnlySees(client3, address3, 4);
 
             // Kill a member and check if clients are still connected correct members
             var memberId3 = RcMembers.Values.Where(m => address3.Equals($"{m.Host}:{m.Port}")).Select(m => m.Uuid).First();
@@ -79,13 +79,13 @@ namespace Hazelcast.Tests.Clustering
             AssertClientOnlySees(client1, address1);
             AssertClientOnlySees(client2, address2);
 
-            await AssertEx.SucceedsEventually(()
-                    =>
+            await AssertEx.SucceedsEventually(
+                () =>
                 {
                     Assert.That(client3.Cluster.Connections.Count, Is.EqualTo(0));
                     Assert.That(client3.State, Is.EqualTo(ClientState.Disconnected));
                 },
-                5_000, 500);
+                15_000, 500);
 
             Member member3;
             var nAddress3 = NetworkAddress.Parse(address3);

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -68,9 +68,9 @@ namespace Hazelcast.Tests.Clustering
             {
                 AssertClientOnlySees(client1, address1);
             }, 10_000, 500, "Client1 did not see the correct members");
-
+            
             AssertClientOnlySees(client2, address2);
-            AssertClientOnlySees(client3, address3, 4);
+            AssertClientOnlySees(client3, address3);
 
             // Kill a member and check if clients are still connected correct members
             var memberId3 = RcMembers.Values.Where(m => address3.Equals($"{m.Host}:{m.Port}")).Select(m => m.Uuid).First();
@@ -79,8 +79,8 @@ namespace Hazelcast.Tests.Clustering
             AssertClientOnlySees(client1, address1);
             AssertClientOnlySees(client2, address2);
 
-            await AssertEx.SucceedsEventually(
-                () =>
+            await AssertEx.SucceedsEventually(()
+                    =>
                 {
                     Assert.That(client3.Cluster.Connections.Count, Is.EqualTo(0));
                     Assert.That(client3.State, Is.EqualTo(ClientState.Disconnected));

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupTests.cs
@@ -235,7 +235,7 @@ namespace Hazelcast.Tests.Clustering
 
             var address0 = NetworkAddress.Parse("127.0.0.1:11005");
             var address1 = NetworkAddress.Parse("127.0.0.1:11006");
-
+            var clusterSize = 2;
             var memberId0 = Guid.NewGuid();
             var memberId1 = Guid.NewGuid();
             var clusterId = Guid.NewGuid();
@@ -318,7 +318,7 @@ namespace Hazelcast.Tests.Clustering
                 Assert.That(client.Cluster.Members.SubsetClusterMembers.GetSubsetMemberIds().Count, Is.EqualTo(1), "Subset Members count");
                 Assert.That(client.Cluster.Members.SubsetClusterMembers.GetSubsetMemberIds(), Contains.Item(memberId0));
                 Assert.That(client.ClusterVersion, Is.EqualTo(newClusterVersions));
-                Assert.That(client.Cluster.Members.GetMembers().Count(), Is.EqualTo(1), "Members count");
+                Assert.That(client.Cluster.Members.GetMembers().Count(), Is.EqualTo(clusterSize), "Members count");
 
             }, 20_000, 200);
         }

--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -338,6 +338,13 @@ namespace Hazelcast.Clustering
         /// Gets the number of open connections to members.
         /// </summary>
         public int Count => _connections.Count;
+        
+        /// <summary>
+        /// Whether given member is connected or not.
+        /// </summary>
+        /// <param name="memberId">Member UUID</param>
+        /// <returns>true if memberId has connection.</returns>
+        internal bool Contains(Guid memberId) => _connections.ContainsKey(memberId);
 
         #endregion
 

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -897,9 +897,13 @@ namespace Hazelcast.Clustering
             return liteOnly ? members.Where(x => x.IsLiteMember).ToList() : members;
         }
 
+        /// <summary>
+        /// Gets members can be connected. If subset cluster members is set, returns only subset members.
+        /// </summary>
+        /// <returns>Members allowed to connect</returns>
         public IEnumerable<MemberInfo> GetMembersForConnection()
         {
-            return _members.Version == InvalidMemberTableVersion ? Enumerable.Empty<MemberInfo>() : GetMembers();
+            return _members.Version == InvalidMemberTableVersion ? Enumerable.Empty<MemberInfo>() : _filteredMembersToConnect.Members;
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/Clustering/MemberPartitionGroup.cs
+++ b/src/Hazelcast.Net/Clustering/MemberPartitionGroup.cs
@@ -145,7 +145,7 @@ namespace Hazelcast.Clustering
                 _mutex.EnterWriteLock();
                 var old = _currentGroups;
                 _currentGroups = pickedGroup;
-                _logger.IfDebug()?.LogDebug("Updated member partition group. Old group: {OldGroup} \n New group: {PickedGroup}", old, pickedGroup);
+                _logger.IfDebug()?.LogDebug("Updated member partition group. Old group: {OldGroup} New group: {PickedGroup}", old, pickedGroup);
             }
             finally
             {

--- a/src/Hazelcast.Net/Models/MemberGroups.cs
+++ b/src/Hazelcast.Net/Models/MemberGroups.cs
@@ -48,7 +48,8 @@ namespace Hazelcast.Models
             return $"MemberGroups[Version: {Version}," +
                    $" ClusterId: {ClusterId.ToShortString()}," +
                    $" MemberReceivedFrom: {MemberReceivedFrom.ToShortString()}," +
-                   $" Groups: {string.Join(",\n", Groups.Select(group => $"[{string.Join(", ", group.Select(id => id.ToShortString()))}]"))}";
+                   $" Groups: {string.Join(",", Groups.Select(group => $"[{string.Join(", ", group.Select(id => id.ToShortString()))}]"))}" +
+                   "]";
         }
 
     }


### PR DESCRIPTION
In `MultiMember` routing mode, the `GetMembers` was returining only connected members. It must return the last known all members in the cluster.

