### PR TITLE
Fix Partition Group Selection on `ClusterView` Event [API-2259]

### DIFF
--- a/src/Hazelcast.Net.Testing/NoOpSubsetMembers.cs
+++ b/src/Hazelcast.Net.Testing/NoOpSubsetMembers.cs
@@ -22,9 +22,15 @@ namespace Hazelcast.Testing
 
         public IReadOnlyList<Guid> GetSubsetMemberIds()
             => throw new NotImplementedException();
+        HashSet<Guid> ISubsetClusterMembers.GetSubsetMemberIds()
+            => throw new NotImplementedException();
         public void SetSubsetMembers(MemberGroups newGroup)
         {
             throw new NotImplementedException();
+        }
+        public MemberGroups CurrentGroups
+        {
+            get;
         }
         public void RemoveSubsetMember(Guid memberId)
         {

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -130,11 +130,11 @@ namespace Hazelcast.Tests.Clustering
         {
             var address1 = "127.0.0.1:5701";
             var address2 = "127.0.0.1:5702";
-            var addreses = new string[] { address1, address2 };
+            var addresses = new string[] { address1, address2 };
             var keyCount = 3 * 271;
 
             // create a client with the given routing strategy for catching the events.
-            var client1 = await CreateClient(RoutingStrategy.PartitionGroups, addreses, "client1", routingMode);
+            var client1 = await CreateClient(RoutingStrategy.PartitionGroups, addresses, "client1", routingMode);
             var client1Count = 0;
             var mapName = $"map_{routingMode}";
             var map1 = await client1.GetMapAsync<int, int>(mapName);
@@ -149,7 +149,7 @@ namespace Hazelcast.Tests.Clustering
 
 
             // create a dummy client  for creating events
-            var client2 = await CreateClient(RoutingStrategy.PartitionGroups, addreses, "client2", RoutingModes.SingleMember);
+            var client2 = await CreateClient(RoutingStrategy.PartitionGroups, addresses, "client2", RoutingModes.SingleMember);
 
             var map2 = await client2.GetMapAsync<int, int>(map1.Name);
 

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -32,9 +32,18 @@ namespace Hazelcast.Tests.Clustering
         protected override string RcClusterConfiguration => Resources.ClusterPGEnabled;
 
         [OneTimeSetUp]
-        public async Task TearDown()
+        public async Task OneTimeSetUp()
         {
             await CreateCluster();
+        }
+
+        [SetUp]
+        public async Task TearUp()
+        {
+            var diff = 3 - RcMembers.Count;
+            if (diff is > 0 and < 3)
+                for (var i = 0; i < diff; i++)
+                    await AddMember();
         }
 
         [TestCase(RoutingStrategy.PartitionGroups)]

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -26,7 +26,7 @@ namespace Hazelcast.Tests.Clustering
 {
     [Category("enterprise")]
     [ServerCondition("5.5")]
-    [Timeout(30_000)]
+    [Timeout(60_000)]
     public class MemberPartitionGroupServerTests : MultiMembersRemoteTestBase
     {
         protected override string RcClusterConfiguration => Resources.ClusterPGEnabled;

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -123,20 +123,6 @@ namespace Hazelcast.Tests.Clustering
             AssertClientOnlySees(client3, address3);
         }
 
-        private async Task AddMemberFor(string connectedAddress)
-        {
-            Member member;
-            var nAddress3 = NetworkAddress.Parse(connectedAddress);
-            while (true)
-            {
-                member = await AddMember();
-                var created = new NetworkAddress(member.Host, member.Port);
-                if (created == nAddress3) break;
-
-                await RemoveMember(member.Uuid);
-            }
-        }
-
         [TestCase(RoutingModes.MultiMember)]
         [TestCase(RoutingModes.SingleMember)]
         [TestCase(RoutingModes.AllMembers)]

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -44,10 +44,12 @@ namespace Hazelcast.Tests.Clustering
             var address2 = "127.0.0.1:5702";
             var address3 = "127.0.0.1:5703";
 
+            var addreses = new string[] { address1, address2, address3 };
+
             // create a client with the given routing strategy
-            var client1 = await CreateClient(routingStrategy, address1);
-            var client2 = await CreateClient(routingStrategy, address2);
-            var client3 = await CreateClient(routingStrategy, address3);
+            var client1 = await CreateClient(routingStrategy, new string[] { address1 }, "client1");
+            var client2 = await CreateClient(routingStrategy, new string[] { address2 }, "client2");
+            var client3 = await CreateClient(routingStrategy, new string[] { address3 }, "client3");
 
             AssertClientOnlySees(client1, address1);
             AssertClientOnlySees(client2, address2);
@@ -68,7 +70,7 @@ namespace Hazelcast.Tests.Clustering
             {
                 AssertClientOnlySees(client1, address1);
             }, 10_000, 500, "Client1 did not see the correct members");
-            
+
             AssertClientOnlySees(client2, address2);
             AssertClientOnlySees(client3, address3);
 
@@ -79,37 +81,89 @@ namespace Hazelcast.Tests.Clustering
             AssertClientOnlySees(client1, address1);
             AssertClientOnlySees(client2, address2);
 
-            await AssertEx.SucceedsEventually(()
-                    =>
-                {
-                    Assert.That(client3.Cluster.Connections.Count, Is.EqualTo(0));
-                    Assert.That(client3.State, Is.EqualTo(ClientState.Disconnected));
-                },
-                15_000, 500);
-
-            Member member3;
-            var nAddress3 = NetworkAddress.Parse(address3);
-            while (true)
-            {
-                member3 = await AddMember();
-                var created = new NetworkAddress(member3.Host, member3.Port);
-                if (created == nAddress3) break;
-
-                await RemoveMember(member3.Uuid);
-            }
-
-            await AssertEx.SucceedsEventually(()
-                    => Assert.That(client3.State, Is.EqualTo(ClientState.Connected)),
-                10_000, 500);
+            var nAddress3 = await AssertClientReConnected(client3, address3);
 
             // Check if client1 is connected to the new member
             // cannot use the old member id since we can only either kill or create member
             Assert.That(client3.Cluster.Connections.Count, Is.EqualTo(1));
-            Assert.That(client3.Members.Select(p => p.Member.ConnectAddress), Contains.Item(nAddress3));
+            Assert.That(client3.Members.Where(p => p.IsConnected).Select(p => p.Member.ConnectAddress.ToString()), Contains.Item(address3));
 
             AssertClientOnlySees(client1, address1);
             AssertClientOnlySees(client2, address2);
             AssertClientOnlySees(client3, address3);
+        }
+
+
+        [TestCase(RoutingStrategy.PartitionGroups)]
+        public async Task TestMultiMemberRoutingConnectsNextGroupWhenDisconnected(RoutingStrategy routingStrategy)
+        {
+            var address1 = "127.0.0.1:5701";
+            var address2 = "127.0.0.1:5702";
+            var address3 = "127.0.0.1:5703";
+
+            var addreses = new string[] { address1, address2, address3 };
+
+            // create a client with the given routing strategy
+            var client = await CreateClient(routingStrategy, addreses, "client1");
+
+            // it should connect to first address
+            Assert.That(client.Cluster.Connections.Count, Is.EqualTo(1));
+
+            var connectedAddress = client.Members.First(p => p.IsConnected).Member.ConnectAddress.ToString();
+
+            AssertClientOnlySees(client, connectedAddress);
+
+            var effectiveMembers = client.Cluster.Members.GetMembersForConnection();
+            Assert.That(effectiveMembers.Count(), Is.EqualTo(1));
+            Assert.That(effectiveMembers.Select(p => p.ConnectAddress.ToString()), Contains.Item(connectedAddress));
+            // Kill the connected member so that client can go to next group
+            var connectedMember = RcMembers.Values.Where(m => connectedAddress.Equals($"{m.Host}:{m.Port}")).Select(m => m.Uuid).First();
+            RemoveMember(connectedMember);
+
+            await AssertEx.SucceedsEventually(() => Assert.That(client.State, Is.EqualTo(ClientState.Disconnected)), 10_000, 500);
+
+            await AssertEx.SucceedsEventually(() =>
+            {
+                Assert.That(client.Cluster.Connections.Count, Is.EqualTo(1));
+                Assert.That(client.State, Is.EqualTo(ClientState.Connected));
+            }, 20_000, 500);
+
+            var reConnectedAddress = client.Members.First(p => p.IsConnected).Member.ConnectAddress.ToString();
+            effectiveMembers = client.Cluster.Members.GetMembersForConnection();
+
+            Assert.That(reConnectedAddress, Is.Not.EqualTo(connectedAddress));
+            Assert.That(client.Cluster.Connections.Count, Is.EqualTo(1));
+            Assert.That(client.Members.Where(p => p.IsConnected).Select(p => p.Member.ConnectAddress.ToString()), Contains.Item(reConnectedAddress));
+            Assert.That(effectiveMembers.Count(), Is.EqualTo(1));
+            Assert.That(effectiveMembers.Select(p => p.ConnectAddress.ToString()), Contains.Item(reConnectedAddress));
+        }
+
+        private async Task<NetworkAddress> AssertClientReConnected(HazelcastClient client, string address, bool createMember = true)
+        {
+            await AssertEx.SucceedsEventually(()
+                    =>
+                {
+                    Assert.That(client.Cluster.Connections.Count, Is.EqualTo(0));
+                    Assert.That(client.State, Is.EqualTo(ClientState.Disconnected));
+                },
+                15_000, 500);
+
+            Member member;
+            var nAddress3 = NetworkAddress.Parse(address);
+            while (createMember)
+            {
+                member = await AddMember();
+                var created = new NetworkAddress(member.Host, member.Port);
+                if (created == nAddress3) break;
+
+                await RemoveMember(member.Uuid);
+            }
+
+            await AssertEx.SucceedsEventually(()
+                    => Assert.That(client.State, Is.EqualTo(ClientState.Connected)),
+                10_000, 500);
+
+            return nAddress3;
         }
 
         [TestCase(RoutingModes.MultiMember)]
@@ -119,10 +173,11 @@ namespace Hazelcast.Tests.Clustering
         {
             var address1 = "127.0.0.1:5701";
             var address2 = "127.0.0.1:5702";
+            var addreses = new string[] { address1, address2 };
             var keyCount = 3 * 271;
 
             // create a client with the given routing strategy for catching the events.
-            var client1 = await CreateClient(RoutingStrategy.PartitionGroups, address1, routingMode);
+            var client1 = await CreateClient(RoutingStrategy.PartitionGroups, addreses, "client1", routingMode);
             var client1Count = 0;
             var mapName = $"map_{routingMode}";
             var map1 = await client1.GetMapAsync<int, int>(mapName);
@@ -137,7 +192,7 @@ namespace Hazelcast.Tests.Clustering
 
 
             // create a dummy client  for creating events
-            var client2 = await CreateClient(RoutingStrategy.PartitionGroups, address2, RoutingModes.SingleMember);
+            var client2 = await CreateClient(RoutingStrategy.PartitionGroups, addreses, "client2", RoutingModes.SingleMember);
 
             var map2 = await client2.GetMapAsync<int, int>(map1.Name);
 
@@ -168,13 +223,17 @@ namespace Hazelcast.Tests.Clustering
             Assert.That(members.SubsetClusterMembers.GetSubsetMemberIds().Count(), Is.EqualTo(1));
             Assert.That(members.SubsetClusterMembers.GetSubsetMemberIds(), Contains.Item(memberId));
         }
-        private async Task<HazelcastClient> CreateClient(RoutingStrategy routingStrategy, string address, RoutingModes routingMode = RoutingModes.MultiMember)
+        private async Task<HazelcastClient> CreateClient(RoutingStrategy routingStrategy, string[] address, string clientName, RoutingModes routingMode = RoutingModes.MultiMember)
         {
             var options = new HazelcastOptionsBuilder()
                 .With(args =>
                 {
-                    args.ClientName = $"Client:{address}";
-                    args.Networking.Addresses.Add(address);
+                    for (int i = 0; i < address.Length; i++)
+                    {
+
+                        args.Networking.Addresses.Add(address[i]);
+                    }
+                    args.ClientName = clientName;
                     args.ClusterName = RcCluster.Id;
                     args.Networking.RoutingMode.Mode = routingMode;
                     args.Networking.RoutingMode.Strategy = routingStrategy;

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -163,7 +163,7 @@ namespace Hazelcast.Tests.Clustering
             var connectedMember = RcMembers.Values.Where(m => connectedAddress.Equals($"{m.Host}:{m.Port}")).Select(m => m.Uuid).First();
             await RemoveMember(connectedMember);
 
-            await AssertEx.SucceedsEventually(() => Assert.That(client.State, Is.EqualTo(ClientState.Disconnected)), 10_000, 500);
+            await AssertEx.SucceedsEventually(() => Assert.That(client.State, Is.EqualTo(ClientState.Disconnected)), 20_000, 500);
 
             await AssertEx.SucceedsEventually(() =>
             {

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -163,7 +163,7 @@ namespace Hazelcast.Tests.Clustering
             var connectedMember = RcMembers.Values.Where(m => connectedAddress.Equals($"{m.Host}:{m.Port}")).Select(m => m.Uuid).First();
             await RemoveMember(connectedMember);
 
-            await AssertEx.SucceedsEventually(() => Assert.That(client.State, Is.EqualTo(ClientState.Disconnected)), 20_000, 500);
+            await AssertEx.SucceedsEventually(() => Assert.That(client.State, Is.EqualTo(ClientState.Disconnected)), 60_000, 500);
 
             await AssertEx.SucceedsEventually(() =>
             {

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -177,7 +177,7 @@ namespace Hazelcast.Tests.Clustering
                 Assert.That(client.Members.Where(p => p.IsConnected).Select(p => p.Member.ConnectAddress.ToString()), Contains.Item(reConnectedAddress));
                 Assert.That(effectiveMembers.Count(), Is.EqualTo(1));
                 Assert.That(effectiveMembers.Select(p => p.ConnectAddress.ToString()), Contains.Item(reConnectedAddress));
-            }, 20_000, 500);
+            }, 60_000, 500);
 
         }
         private async Task AddMemberFor(string connectedAddress)

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.Core;
@@ -32,7 +33,7 @@ namespace Hazelcast.Tests.Clustering
         protected override string RcClusterConfiguration => Resources.ClusterPGEnabled;
 
         [SetUp]
-        public async Task OneTimeSetUp()
+        public async Task Setup()
         {
             await CreateCluster();
         }
@@ -58,7 +59,7 @@ namespace Hazelcast.Tests.Clustering
         [TestCase(RoutingStrategy.PartitionGroups)]
         public async Task TestMultiMemberRoutingWorks(RoutingStrategy routingStrategy)
         {
-            Assert.That(RcMembers.Count, Is.EqualTo(3));
+            await AssertEx.SucceedsEventually(() => Assert.That(RcMembers.Count, Is.EqualTo(3)), 30_000, 500);
             HConsole.Configure(c => c.ConfigureDefaults(this));
 
             var address1 = "127.0.0.1:5701";

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests2.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests2.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) 2008-2024, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Hazelcast.Networking;
+using Hazelcast.Testing;
+using Hazelcast.Testing.Conditions;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+namespace Hazelcast.Tests.Clustering
+{
+    [Category("enterprise")]
+    [ServerCondition("5.5")]
+    [Timeout(60_000)]
+    public class MemberPartitionGroupServerTests2 : MultiMembersRemoteTestBase
+    {
+        protected override string RcClusterConfiguration => Resources.ClusterPGEnabled;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            await CreateCluster();
+        }
+        [TearDown]
+        public async Task TearDown()
+        {
+            await MembersOneTimeTearDown();
+        }
+
+        [TestCase(RoutingStrategy.PartitionGroups)]
+        public async Task TestMultiMemberRoutingConnectsNextGroupWhenDisconnected(RoutingStrategy routingStrategy)
+        {
+            var address1 = "127.0.0.1:5701";
+            var address2 = "127.0.0.1:5702";
+            var address3 = "127.0.0.1:5703";
+
+            var addreses = new string[] { address1, address2, address3 };
+
+            // create a client with the given routing strategy
+            var client = await CreateClient(routingStrategy, addreses, "client1");
+
+            // it should connect to first address
+            Assert.That(client.Cluster.Connections.Count, Is.EqualTo(1));
+
+            var connectedAddress = client.Members.First(p => p.IsConnected).Member.ConnectAddress.ToString();
+
+            AssertClientOnlySees(client, connectedAddress);
+
+            var effectiveMembers = client.Cluster.Members.GetMembersForConnection();
+            Assert.That(effectiveMembers.Count(), Is.EqualTo(1));
+            Assert.That(effectiveMembers.Select(p => p.ConnectAddress.ToString()), Contains.Item(connectedAddress));
+            // Kill the connected member so that client can go to next group
+            var connectedMember = RcMembers.Values.Where(m => connectedAddress.Equals($"{m.Host}:{m.Port}")).Select(m => m.Uuid).First();
+            await RemoveMember(connectedMember);
+
+            await AssertEx.SucceedsEventually(() => Assert.That(client.State, Is.EqualTo(ClientState.Disconnected)), 60_000, 500);
+
+            await AssertEx.SucceedsEventually(() =>
+            {
+                Assert.That(client.Cluster.Connections.Count, Is.EqualTo(1));
+                Assert.That(client.State, Is.EqualTo(ClientState.Connected));
+                var reConnectedAddress = client.Members.First(p => p.IsConnected).Member.ConnectAddress.ToString();
+                effectiveMembers = client.Cluster.Members.GetMembersForConnection();
+
+                Assert.That(reConnectedAddress, Is.Not.EqualTo(connectedAddress));
+                Assert.That(client.Cluster.Connections.Count, Is.EqualTo(1));
+                Assert.That(client.Members.Where(p => p.IsConnected).Select(p => p.Member.ConnectAddress.ToString()), Contains.Item(reConnectedAddress));
+                Assert.That(effectiveMembers.Count(), Is.EqualTo(1));
+                Assert.That(effectiveMembers.Select(p => p.ConnectAddress.ToString()), Contains.Item(reConnectedAddress));
+            }, 60_000, 500);
+
+        }
+
+        private void AssertClientOnlySees(HazelcastClient client, string address, int clusterSize = 3)
+        {
+            var member = RcMembers.Values.FirstOrDefault(m => address.Equals($"{m.Host}:{m.Port}"));
+
+            Assert.IsNotNull(member);
+
+            var members = client.Cluster.Members;
+            var memberId = Guid.Parse(member.Uuid);
+
+            Assert.That(members.GetMembers().Count(), Is.EqualTo(clusterSize), "Current cluster size " + RcMembers.Count);
+            Assert.That(client.Cluster.Connections.Count, Is.EqualTo(1));
+            Assert.True(client.Cluster.Connections.Contains(memberId), "Member is not connected");
+            Assert.That(members.SubsetClusterMembers.GetSubsetMemberIds().Count(), Is.EqualTo(1));
+            Assert.That(members.SubsetClusterMembers.GetSubsetMemberIds(), Contains.Item(memberId));
+        }
+        private async Task<HazelcastClient> CreateClient(RoutingStrategy routingStrategy, string[] address, string clientName, RoutingModes routingMode = RoutingModes.MultiMember)
+        {
+            var options = new HazelcastOptionsBuilder()
+                .With(args =>
+                {
+                    for (int i = 0; i < address.Length; i++)
+                    {
+
+                        args.Networking.Addresses.Add(address[i]);
+                    }
+                    args.ClientName = clientName;
+                    args.ClusterName = RcCluster.Id;
+                    args.Networking.RoutingMode.Mode = routingMode;
+                    args.Networking.RoutingMode.Strategy = routingStrategy;
+                    args.Networking.ReconnectMode = ReconnectMode.ReconnectSync;
+
+                    args.AddSubscriber(on => on.StateChanged((client, eventArgs) =>
+                    {
+                        Console.WriteLine(eventArgs.State);
+                    }));
+
+                    args.LoggerFactory.Creator = () => Microsoft.Extensions.Logging.LoggerFactory.Create(
+                        conf => conf.AddConsole().SetMinimumLevel(LogLevel.Debug));
+
+                })
+                .Build();
+
+            var client = (HazelcastClient) await HazelcastClientFactory.StartNewClientAsync(options);
+            return client;
+        }
+        private async Task CreateCluster(int size = 3)
+        {
+            for (int i = 0; i < size; i++)
+            {
+                await AddMember();
+            }
+        }
+    }
+}

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests2.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests2.cs
@@ -23,6 +23,7 @@ namespace Hazelcast.Tests.Clustering
 {
     [Category("enterprise")]
     [ServerCondition("5.5")]
+    [Explicit("This test is not working as expected. It is failing on the GitHub Actions due to resource consumption.")]
     [Timeout(60_000)]
     public class MemberPartitionGroupServerTests2 : MultiMembersRemoteTestBase
     {

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTestsNightly.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTestsNightly.cs
@@ -21,11 +21,10 @@ using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 namespace Hazelcast.Tests.Clustering
 {
-    [Category("enterprise")]
+    [Category("enterprise,nightly")]
     [ServerCondition("5.5")]
-    [Explicit("This test is not working as expected. It is failing on the GitHub Actions due to resource consumption.")]
     [Timeout(60_000)]
-    public class MemberPartitionGroupServerTests2 : MultiMembersRemoteTestBase
+    public class MemberPartitionGroupServerTestsNightly : MultiMembersRemoteTestBase
     {
         protected override string RcClusterConfiguration => Resources.ClusterPGEnabled;
 

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupTests.cs
@@ -14,7 +14,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.Aggregation;
@@ -557,10 +556,6 @@ namespace Hazelcast.Tests.Clustering
             }
         }
 
-
-
-
-
         public static object[] MemberGroupCases =
         {
             // Case 1: New version wins.
@@ -622,7 +617,7 @@ namespace Hazelcast.Tests.Clustering
                     },
                     1,
                     Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
-                    Guid.Empty),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
 
                 Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
                 1, // Expected version
@@ -668,7 +663,7 @@ namespace Hazelcast.Tests.Clustering
                     },
                     1,
                     Guid.Parse("a810df4f-a54c-437d-a945-99218688cf31"),
-                    Guid.Empty),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
 
                 Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
                 1, // Expected version
@@ -714,7 +709,7 @@ namespace Hazelcast.Tests.Clustering
                     },
                     1,
                     Guid.Parse("a810df4f-a54c-437d-a945-99218688cf31"),
-                    Guid.Empty),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
 
                 Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
                 1, // Expected version
@@ -762,7 +757,7 @@ namespace Hazelcast.Tests.Clustering
                     },
                     2,
                     Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
-                    Guid.Empty),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
                 Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
                 2, // Expected version
                 2 // Expected group size
@@ -812,7 +807,7 @@ namespace Hazelcast.Tests.Clustering
                     },
                     2,
                     Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
-                    Guid.Empty),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
                 Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
                 2, // Expected version
                 5 // Expected group size
@@ -862,7 +857,7 @@ namespace Hazelcast.Tests.Clustering
                     },
                     2,
                     Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
-                    Guid.Empty),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
                 Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
                 2, // Expected version
                 1 // Expected group size

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupTests.cs
@@ -122,12 +122,15 @@ namespace Hazelcast.Tests.Clustering
 
             ISubsetClusterMembers memberPartitionGroup = new MemberPartitionGroup(new NetworkingOptions(), NullLogger.Instance);
 
-            memberPartitionGroup.SetSubsetMembers(group1);
-            if (group2.Version != MemberPartitionGroup.InvalidVersion)
+            for (int i = 0; i < 2; i++)
             {
-                memberPartitionGroup.SetSubsetMembers(group2);
+                memberPartitionGroup.SetSubsetMembers(group1);
+                if (group2.Version != MemberPartitionGroup.InvalidVersion)
+                {
+                    memberPartitionGroup.SetSubsetMembers(group2);
+                }    
             }
-
+            
             Assert.AreEqual(expectedVersion, ((MemberPartitionGroup) memberPartitionGroup).CurrentGroups.Version);
             Assert.That(memberPartitionGroup.GetSubsetMemberIds(), Contains.Item(expectedMemberId));
             Assert.That(((MemberPartitionGroup) memberPartitionGroup).CurrentGroups.SelectedGroup.Count, Is.EqualTo(expectedGroupSize));
@@ -150,7 +153,9 @@ namespace Hazelcast.Tests.Clustering
             // Prepare the member partition group
             ISubsetClusterMembers memberPartitionGroup = new MemberPartitionGroup(new NetworkingOptions(), NullLogger.Instance);
 
-            var clusterMembers = For<ClusterMembers>(For<ClusterState>(new HazelcastOptions(), null, null, For<Partitioner>(), NullLoggerFactory.Instance), For<TerminateConnections>(NullLoggerFactory.Instance), memberPartitionGroup);
+            var clusterMembers = For<ClusterMembers>(For<ClusterState>(new HazelcastOptions(),
+                    null, null, For<Partitioner>(), NullLoggerFactory.Instance),
+                For<TerminateConnections>(NullLoggerFactory.Instance), memberPartitionGroup);
 
             memberPartitionGroup.SetSubsetMembers(group1);
 
@@ -595,7 +600,7 @@ namespace Hazelcast.Tests.Clustering
                     },
                     1,
                     Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
-                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
+                    Guid.Empty),
 
                 Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
                 1, // Expected version
@@ -608,10 +613,15 @@ namespace Hazelcast.Tests.Clustering
                 // Group 1
                 new MemberGroups(new List<IList<Guid>>()
                     {
-                        new List<Guid>() { Guid.Parse("efdb670f-d0d5-4482-84eb-0354e4278112"), Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6") },
                         new List<Guid>()
                         {
-                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9")
+                            Guid.Parse("efdb670f-d0d5-4482-84eb-0354e4278112"),
+                            Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6")
+                        },
+                        new List<Guid>()
+                        {
+                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"),
+                            Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9")
                         }
                     },
                     1,
@@ -624,46 +634,15 @@ namespace Hazelcast.Tests.Clustering
                         // Selected Group
                         new List<Guid>()
                         {
-                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9"),
+                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"),
+                            Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9"),
                             Guid.Parse("03d9a78b-6380-49c8-9bf3-8044f2cfa75d")
                         },
-                        new List<Guid>() { Guid.Parse("dd8803e6-16ae-4d62-921e-ffe4f5c8ce49"), Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6") }
-                    },
-                    1,
-                    Guid.Parse("a810df4f-a54c-437d-a945-99218688cf31"),
-                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
-
-                Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
-                1, // Expected version
-                3 // Expected group size
-            },
-
-            // Case 2: Biggest wins
-            new object[]
-            {
-                // Group 1
-                new MemberGroups(new List<IList<Guid>>()
-                    {
-                        new List<Guid>() { Guid.Parse("efdb670f-d0d5-4482-84eb-0354e4278112"), Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6") },
                         new List<Guid>()
                         {
-                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9")
+                            Guid.Parse("dd8803e6-16ae-4d62-921e-ffe4f5c8ce49"),
+                            Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6")
                         }
-                    },
-                    1,
-                    Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
-                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
-
-                // Group 2
-                new MemberGroups(new List<IList<Guid>>()
-                    {
-                        // Selected Group
-                        new List<Guid>()
-                        {
-                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9"),
-                            Guid.Parse("03d9a78b-6380-49c8-9bf3-8044f2cfa75d")
-                        },
-                        new List<Guid>() { Guid.Parse("dd8803e6-16ae-4d62-921e-ffe4f5c8ce49"), Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6") }
                     },
                     1,
                     Guid.Parse("a810df4f-a54c-437d-a945-99218688cf31"),
@@ -674,6 +653,148 @@ namespace Hazelcast.Tests.Clustering
                 3 // Expected group size
             },
 
+            // Case 3: Biggest wins
+            new object[]
+            {
+                // Group 1
+                new MemberGroups(new List<IList<Guid>>()
+                    {
+                        new List<Guid>()
+                        {
+                            Guid.Parse("efdb670f-d0d5-4482-84eb-0354e4278112"),
+                            Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6")
+                        },
+                        new List<Guid>()
+                        {
+                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"),
+                            Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9")
+                        }
+                    },
+                    1,
+                    Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
+
+                // Group 2
+                new MemberGroups(new List<IList<Guid>>()
+                    {
+                        // Selected Group
+                        new List<Guid>()
+                        {
+                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"),
+                            Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9"),
+                            Guid.Parse("03d9a78b-6380-49c8-9bf3-8044f2cfa75d")
+                        },
+                        new List<Guid>()
+                        {
+                            Guid.Parse("dd8803e6-16ae-4d62-921e-ffe4f5c8ce49"),
+                            Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6")
+                        }
+                    },
+                    1,
+                    Guid.Parse("a810df4f-a54c-437d-a945-99218688cf31"),
+                    Guid.Empty),
+
+                Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
+                1, // Expected version
+                3 // Expected group size
+            },
+
+            // Case 4: PG Group not changing after auth.
+            new object[]
+            {
+                // Group 1
+                new MemberGroups(new List<IList<Guid>>()
+                    {
+                        new List<Guid>()
+                        {
+                            Guid.Parse("efdb670f-d0d5-4482-84eb-0354e4278112"),
+                            Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6"),
+                            Guid.Parse("d8ee9c15-ac9a-4357-9698-ade761ced554")
+                        },
+                        // Selected Group
+                        new List<Guid>()
+                        {
+                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"),
+                            Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9")
+                        }
+                    },
+                    1,
+                    Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
+
+                // Group 2
+                new MemberGroups(new List<IList<Guid>>()
+                    {
+                        new List<Guid>()
+                        {
+                            Guid.Parse("efdb670f-d0d5-4482-84eb-0354e4278112"),
+                            Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6"),
+                            Guid.Parse("d8ee9c15-ac9a-4357-9698-ade761ced554"),
+                            Guid.Parse("79d63bcf-339d-449b-aa55-a2cb4f3bad8b")
+                        },
+                        new List<Guid>()
+                        {
+                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"),
+                            Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9")
+                        }
+                    },
+                    2,
+                    Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
+                    Guid.Empty),
+                Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
+                2, // Expected version
+                2 // Expected group size
+            },
+            
+            // Case 5: Bigger overlap with auth group wins.
+            new object[]
+            {
+                // Group 1
+                new MemberGroups(new List<IList<Guid>>()
+                    {
+                        new List<Guid>()
+                        {
+                            Guid.Parse("efdb670f-d0d5-4482-84eb-0354e4278112"),
+                            Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6"),
+                            Guid.Parse("d8ee9c15-ac9a-4357-9698-ade761ced554")
+                        },
+                        // Selected Group
+                        new List<Guid>()
+                        {
+                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"),
+                            Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9")
+                        }
+                    },
+                    1,
+                    Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
+                    Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e")),
+
+                // Group 2
+                new MemberGroups(new List<IList<Guid>>()
+                    {
+                        new List<Guid>()
+                        {
+                            Guid.Parse("efdb670f-d0d5-4482-84eb-0354e4278112"),
+                            Guid.Parse("6965aaa2-d6eb-483a-bb6c-99388c348bc6"),
+                            Guid.Parse("d8ee9c15-ac9a-4357-9698-ade761ced554"),
+                            Guid.Parse("79d63bcf-339d-449b-aa55-a2cb4f3bad8b")
+                        },
+                        new List<Guid>()
+                        {
+                            Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"),
+                            Guid.Parse("d3c34048-a055-4025-8c00-c70b2dcd47b9"),
+                            Guid.Parse("6878f2be-5153-4b7a-8896-edab76011c9c"),
+                            Guid.Parse("7bff264d-426d-44e3-928e-a6200a0a5271"),
+                            Guid.Parse("ce74ca59-3061-47c4-b56b-ddf5727fa312")
+                        }
+                    },
+                    2,
+                    Guid.Parse("81b1ac67-1238-42d6-84b7-ef869e60f262"),
+                    Guid.Empty),
+                Guid.Parse("64082773-bc1b-408c-8ea6-1150c3c6477e"), // Expected group member
+                2, // Expected version
+                5 // Expected group size
+            },
 
         };
     }

--- a/src/Hazelcast.Net/Clustering/Authenticator.cs
+++ b/src/Hazelcast.Net/Clustering/Authenticator.cs
@@ -233,7 +233,7 @@ internal class Authenticator
     /// </summary>
     internal MemberGroups ParsePartitionMemberGroups(ClientAuthenticationCodec.ResponseParameters response)
     {
-        var emptyMemberGroups = new MemberGroups(new List<IList<Guid>>(0), MemberPartitionGroup.InvalidVersion, response.ClusterId, response.MemberUuid);
+        var emptyMemberGroups = new MemberGroups(new List<HashSet<Guid>>(0), MemberPartitionGroup.InvalidVersion, response.ClusterId, response.MemberUuid);
 
         if (!response.IsKeyValuePairsExists)
             return emptyMemberGroups;
@@ -245,7 +245,7 @@ internal class Authenticator
             return emptyMemberGroups;
         }
 
-        var partitionGroups = new List<IList<Guid>>();
+        var partitionGroups = new List<HashSet<Guid>>();
         var version = MemberPartitionGroup.InvalidVersion;
         try
         {
@@ -262,7 +262,7 @@ internal class Authenticator
                 {
                     group.Add(Guid.Parse(member.ToString()));
                 }
-                partitionGroups.Add(group.ToList());
+                partitionGroups.Add(group);
             }
         }
         catch (Exception e)

--- a/src/Hazelcast.Net/Clustering/ClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterEvents.cs
@@ -706,10 +706,9 @@ namespace Hazelcast.Clustering
         {
             _logger.IfDebug()?.LogDebug("Handle MemberGroups event for cluster {ClusterId} and member {MemberId}. Received version:{Version} Member Groups: [{Groups}]",
                 clusterId, memberId, version, (memberGroups == null ? "null" : string.Join(", ", memberGroups.Select(x => $"[{string.Join(", ", x)}]"))));
-            // Received memberId is Guid.Empty because we don't want to change the current member
-            // group of the member that received the event during auth.
+            
             _clusterMembers.SubsetClusterMembers
-                .SetSubsetMembers(new MemberGroups(memberGroups, version, clusterId, Guid.Empty));
+                .SetSubsetMembers(new MemberGroups(memberGroups, version, clusterId, memberId));
             await _memberPartitionGroupsUpdated.AwaitEach().CfAwait();
         }
 

--- a/src/Hazelcast.Net/Clustering/ClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMembers.cs
@@ -903,7 +903,7 @@ namespace Hazelcast.Clustering
         /// <returns>Members allowed to connect</returns>
         public IEnumerable<MemberInfo> GetMembersForConnection()
         {
-            return _members.Version == InvalidMemberTableVersion ? Enumerable.Empty<MemberInfo>() : _filteredMembersToConnect.Members;
+            return _filteredMembersToConnect.Version == InvalidMemberTableVersion ? Enumerable.Empty<MemberInfo>() : _filteredMembersToConnect.Members;
         }
 
         /// <summary>

--- a/src/Hazelcast.Net/Clustering/ISubsetClusterMembers.cs
+++ b/src/Hazelcast.Net/Clustering/ISubsetClusterMembers.cs
@@ -18,9 +18,11 @@ namespace Hazelcast.Clustering
 {
     internal interface ISubsetClusterMembers
     {
-        IReadOnlyList<Guid> GetSubsetMemberIds();
+        HashSet<Guid> GetSubsetMemberIds();
 
         void SetSubsetMembers(MemberGroups newGroup);
+        
+        MemberGroups CurrentGroups { get; }
         
         void RemoveSubsetMember(Guid memberId);
     }

--- a/src/Hazelcast.Net/Clustering/MemberPartitionGroup.cs
+++ b/src/Hazelcast.Net/Clustering/MemberPartitionGroup.cs
@@ -125,8 +125,7 @@ namespace Hazelcast.Clustering
         }
 
 #endregion
-
-        // internal for testing
+        
         public MemberGroups CurrentGroups
         {
             get

--- a/src/Hazelcast.Net/Clustering/MemberPartitionGroup.cs
+++ b/src/Hazelcast.Net/Clustering/MemberPartitionGroup.cs
@@ -181,8 +181,16 @@ namespace Hazelcast.Clustering
 
                     var newGroup = new MemberGroups(clearedGroup, _currentGroups.Version, _currentGroups.ClusterId, _currentGroups.MemberReceivedFrom);
                     var old = _currentGroups;
-                    _currentGroups = newGroup.SelectedGroup.Count > 0 ? newGroup : new MemberGroups(new List<IList<Guid>>(0), MemberPartitionGroup.InvalidVersion, Guid.Empty, Guid.Empty);
-                    _logger.IfDebug()?.LogDebug("Removed Member[{MemberId}] and updated member partition group. Old group: {OldGroup} New group: {PickedGroup}", memberId, old, _currentGroups);
+                    _currentGroups = newGroup.SelectedGroup.Count > 0 
+                                     && newGroup.SelectedGroup.Contains(_currentGroups.MemberReceivedFrom)
+                        ? newGroup 
+                        : new MemberGroups(new List<IList<Guid>>(0),
+                            MemberPartitionGroup.InvalidVersion,
+                            Guid.Empty,
+                            Guid.Empty);
+                    
+                    _logger.IfDebug()?.LogDebug("Removed Member[{MemberId}] and updated member partition group. " +
+                                                "Old group: {OldGroup} New group: {PickedGroup}", memberId, old, _currentGroups);
                 }
             }
             finally

--- a/src/Hazelcast.Net/Clustering/MemberPartitionGroup.cs
+++ b/src/Hazelcast.Net/Clustering/MemberPartitionGroup.cs
@@ -180,8 +180,9 @@ namespace Hazelcast.Clustering
                     }
 
                     var newGroup = new MemberGroups(clearedGroup, _currentGroups.Version, _currentGroups.ClusterId, _currentGroups.MemberReceivedFrom);
-
+                    var old = _currentGroups;
                     _currentGroups = newGroup.SelectedGroup.Count > 0 ? newGroup : new MemberGroups(new List<IList<Guid>>(0), MemberPartitionGroup.InvalidVersion, Guid.Empty, Guid.Empty);
+                    _logger.IfDebug()?.LogDebug("Removed Member[{MemberId}] and updated member partition group. Old group: {OldGroup} New group: {PickedGroup}", memberId, old, _currentGroups);
                 }
             }
             finally

--- a/src/Hazelcast.Net/Models/MemberGroups.cs
+++ b/src/Hazelcast.Net/Models/MemberGroups.cs
@@ -19,28 +19,31 @@ namespace Hazelcast.Models
 {
     internal class MemberGroups
     {
+        public MemberGroups(IList<IList<Guid>> groups, int version, Guid clusterId, Guid memberReceivedFrom) :
+            this(groups.Select(group => new HashSet<Guid>(group)).ToList(), version, clusterId, memberReceivedFrom)
+        { }
 
-        public MemberGroups(IList<IList<Guid>> groups, int version, Guid clusterId, Guid memberReceivedFrom)
+        public MemberGroups(IList<HashSet<Guid>> groups, int version, Guid clusterId, Guid memberReceivedFrom)
         {
-            Groups = groups ?? Enumerable.Empty<IList<Guid>>().ToList();
+            Groups = groups ?? Enumerable.Empty<HashSet<Guid>>().ToList();
             Version = version;
             ClusterId = clusterId;
             MemberReceivedFrom = memberReceivedFrom;
             SelectedGroup = GetGroupOf(MemberReceivedFrom);
         }
-        public IList<IList<Guid>> Groups { get; }
+        public IList<HashSet<Guid>> Groups { get; }
         public int Version { get; }
         public Guid ClusterId { get; }
         public Guid MemberReceivedFrom { get; }
 
         /// Group of the member that group information received from.
-        public IReadOnlyList<Guid> SelectedGroup { get; }
+        public HashSet<Guid> SelectedGroup { get; }
 
         // internal for testing
-        public IReadOnlyList<Guid> GetGroupOf(Guid memberId)
+        public HashSet<Guid> GetGroupOf(Guid memberId)
         {
             // Find given member's group.
-            return (Groups.FirstOrDefault(group => group.Contains(memberId)) ?? Enumerable.Empty<Guid>()).ToList();
+            return Groups.FirstOrDefault(group => group.Contains(memberId)) ?? new HashSet<Guid>();
         }
 
         public override string ToString()

--- a/src/Hazelcast.Net/Polyfills/CollectionExtensions.cs
+++ b/src/Hazelcast.Net/Polyfills/CollectionExtensions.cs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 // ReSharper disable once CheckNamespace
+using System.Diagnostics.Tracing;
 namespace System.Collections.Generic;
 
 #if NETSTANDARD2_0
-
 internal static class CollectionExtensions
 {
     /// <summary>Tries to add the specified <paramref name="key" /> and <paramref name="value" /> to the <paramref name="dictionary" />.</summary>
@@ -40,6 +40,20 @@ internal static class CollectionExtensions
             return false;
         dictionary.Add(key, value);
         return true;
+    }
+
+    /// <summary>
+    /// Creates a HashSet<T> from an IEnumerable<T>.
+    /// </summary>
+    /// <param name="source">An IEnumerable<T> to create a HashSet<T> from.</param>
+    /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+    /// <returns>A HashSet<T> that contains values of type TSource selected from the input sequence.</returns>
+    public static System.Collections.Generic.HashSet<TSource> ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source)
+    {
+        var set = new HashSet<TSource>();
+        foreach (var item in source)
+            set.Add(item);
+        return set;
     }
 }
 


### PR DESCRIPTION
The partition group for `MultiMember` routing was changing on `ClusterView` updates based on version comparison. However, later updates should be done by considering first authenticated member id in the partition group. This PR fixes unwanted parition group changing on later `ClusterView` events.