### PR TITLE
Fix Missing Globalization option for Ubuntu based ENV on Github Builds on Powershell script

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -391,7 +391,7 @@ if ($isWindows) { $userHome = $env:USERPROFILE }
 else { 
     $userHome = $env:HOME
     # required for Ubuntu https://github.com/dotnet/core/issues/2186#issuecomment-671105420
-    export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+    $env:DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 }
 
 # nuget packages

--- a/hz.ps1
+++ b/hz.ps1
@@ -387,7 +387,12 @@ $outDir = [System.IO.Path]::GetFullPath("$slnRoot/temp/output")
 $docDir = [System.IO.Path]::GetFullPath("$slnRoot/doc")
 $libDir = [System.IO.Path]::GetFullPath("$slnRoot/temp/lib")
 
-if ($isWindows) { $userHome = $env:USERPROFILE } else { $userHome = $env:HOME }
+if ($isWindows) { $userHome = $env:USERPROFILE } 
+else { 
+    $userHome = $env:HOME
+    # required for Ubuntu https://github.com/dotnet/core/issues/2186#issuecomment-671105420
+    export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+}
 
 # nuget packages
 $nugetPackages = "$userHome/.nuget"


### PR DESCRIPTION

The issue is `dotcover` tools fails due to undetected globalization
while running the tests.
```
Couldn't find a valid ICU package installed on the system. Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.
``` 
This PR only touches the `hz.ps1` building scripts. It needs to be
forced to merge since tests on Ubuntu will fail.
