### PR TITLE
Backport of Fix `RoutingModes` Enum Values [API-2266] [HZG-224] (#934)

### DIFF
--- a/src/Hazelcast.Net.Tests/Remote/UnisocketTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/UnisocketTests.cs
@@ -148,7 +148,7 @@ namespace Hazelcast.Tests.Remote
         }
         
         [Test]
-        [ServerCondition("[5.0,6.0)")]
+        [ServerCondition("[5.5.0,6.0)")]
         public async Task TestRoutingModesInOrderWithServerWithPreviousPackage()
         {
             var script = @"result = com.hazelcast.client.impl.connection.tcp.RoutingMode.SINGLE_MEMBER.getId() +

--- a/src/Hazelcast.Net/Networking/RoutingModes.cs
+++ b/src/Hazelcast.Net/Networking/RoutingModes.cs
@@ -24,11 +24,6 @@ namespace Hazelcast.Networking
         SingleMember = 0,
 
         /// <summary>
-        /// Connects only to selected group of members in the cluster based on selected grouping strategy.
-        /// </summary>
-        MultiMember = 1,
-
-        /// <summary>
         /// Connects to all members in the cluster. The client will receive
         /// member list updates and connect to all members.
         /// <para>Client will route the key based operations to owner of
@@ -36,7 +31,12 @@ namespace Hazelcast.Networking
         /// <para>Note that it however does not guarantee that the operation will always be
         /// executed on the owner, as the member table is only updated every 10 seconds.</para>
         /// </summary>
-        AllMembers = 2
+        AllMembers = 1,
+
+        /// <summary>
+        /// Connects only to selected group of members in the cluster based on selected grouping strategy.
+        /// </summary>
+        MultiMember = 2,
     }
 
     /// <summary>


### PR DESCRIPTION
Introduced a fix to sync enum values with Java implementation. Hence, connection mode the reporting to the cluster is corrected.