### PR TITLE
Backport of Fix Missing Patch Version on Client Version Reporting [API-2245][HZG-327]

### DIFF
--- a/src/Hazelcast.Net.Tests/Core/ClientVersionTests.cs
+++ b/src/Hazelcast.Net.Tests/Core/ClientVersionTests.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Reflection;
+using Hazelcast.Clustering;
 using Hazelcast.Core;
 using NUnit.Framework;
 
@@ -26,7 +27,7 @@ namespace Hazelcast.Tests.Core
         public void WriteVersions()
         {
             Console.WriteLine(ClientVersion.Version);
-            Console.WriteLine(ClientVersion.MajorMinorVersion);
+            Console.WriteLine(ClientVersion.GetSemVerWithoutBuildingMetadata());
         }
 
 
@@ -50,15 +51,34 @@ namespace Hazelcast.Tests.Core
 
             // both present, ignores version
             Assert.That(ClientVersion.GetVersion(new AssemblyInformationalVersionAttribute("1.2.3"), new AssemblyVersionAttribute("4.5.6")), Is.EqualTo("1.2.3"));
+
+
+            Assert.That(Authenticator.ClientVersion, Is.EqualTo(ClientVersion.MajorMinorPatchVersion));
+            var assemblyVersion = typeof(ClientVersion).Assembly.GetName().Version;
+            Assert.That(Authenticator.ClientVersion, Is.EqualTo(assemblyVersion.Major + "." + assemblyVersion.Minor + "." + assemblyVersion.MajorRevision));
+            Assert.That(Authenticator.ClientVersion.Split('.').Length, Is.GreaterThanOrEqualTo(3));
         }
 
-        [TestCase("1.2.3", "1.2")]
-        [TestCase("1.2.3-preview.0", "1.2")]
-        [TestCase("1.2.3+ae12b5d9", "1.2")]
-        [TestCase("1.2.3-preview.0+ae12b5", "1.2")]
-        public void ClientVersionReturnsMajorMinorVersion(string semverVersion, string expectedVersion)
+
+        [TestCase("1.2.3", "1.2.3")]
+        [TestCase("1.2.3-preview.0", "1.2.3")]
+        [TestCase("1.2.3-SNAPSHOT", "1.2.3")]
+        [TestCase("1.2.3+ae12b5d9", "1.2.3")]
+        [TestCase("1.2.3-preview.0+ae12b5", "1.2.3")]
+        public void ClientVersionReturnsMajorMinorPatchVersion(string semverVersion, string expectedVersion)
         {
-            Assert.That(ClientVersion.GetMajorMinorVersion(semverVersion), Is.EqualTo(expectedVersion));
+            Assert.That(ClientVersion.GetMajorMinorPatchVersion(semverVersion), Is.EqualTo(expectedVersion));
         }
+
+        [TestCase("1.2.3", "1.2.3")]
+        [TestCase("1.2.3-SNAPSHOT", "1.2.3-SNAPSHOT")]
+        [TestCase("1.2.3-preview.0", "1.2.3-preview.0")]
+        [TestCase("1.2.3+ae12b5d9", "1.2.3")]
+        [TestCase("1.2.3-preview.0+ae12b5", "1.2.3-preview.0")]
+        public void TestGetSemVerWithoutBuildingMetadata(string semverVersion, string expectedVersion)
+        {
+            Assert.That(ClientVersion.GetSemVerWithoutBuildingMetadata(semverVersion), Is.EqualTo(expectedVersion));
+        }
+        
     }
 }

--- a/src/Hazelcast.Net.Tests/Remote/TpcLocalTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/TpcLocalTests.cs
@@ -794,7 +794,7 @@ internal class TpcLocalTests
                 0,
                 request.Server.Address, request.Server.MemberId,
                 SerializationService.SerializerVersion,
-                ClientVersion.MajorMinorVersion,
+                ClientVersion.Version,
                 1,
                 request.Server.ClusterId,
                 false,

--- a/src/Hazelcast.Net/Clustering/Authenticator.cs
+++ b/src/Hazelcast.Net/Clustering/Authenticator.cs
@@ -106,14 +106,12 @@ internal class Authenticator
         return true; // response is empty
     }
 
-    private static string ClientVersion
+    internal static string ClientVersion
     {
         get
         {
             if (_clientVersion != null) return _clientVersion;
-            var version = typeof(Authenticator).Assembly.GetName().Version;
-            _clientVersion = version.Major + "." + version.Minor;
-            if (version.Build > 0) _clientVersion += "." + version.Build;
+            _clientVersion = Hazelcast.Core.ClientVersion.GetSemVerWithoutBuildingMetadata();
             return _clientVersion;
         }
     }

--- a/src/Hazelcast.Net/Clustering/ClusterConnections.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterConnections.cs
@@ -864,7 +864,7 @@ namespace Hazelcast.Clustering
                                    " on connection {ConnectionId} from {LocalAddress}" +
                                    " to member {MemberId} at {Address}" +
                                    " of cluster '{ClusterName}' ({ClusterId}) running version {HazelcastServerVersion}.",
-                _clusterState.ClientName, _clusterState.ClientId.ToShortString(), ClientVersion.Version,
+                _clusterState.ClientName, _clusterState.ClientId.ToShortString(), ClientVersion.GetSemVerWithoutBuildingMetadata(),
                 connection.Id.ToShortString(), connection.LocalEndPoint,
                 result.MemberId.ToShortString(), address,
                 _clusterState.ClusterName, result.ClusterId.ToShortString(), result.ServerVersion);

--- a/src/Hazelcast.Net/Core/ClientVersion.cs
+++ b/src/Hazelcast.Net/Core/ClientVersion.cs
@@ -23,7 +23,7 @@ namespace Hazelcast.Core
     internal static class ClientVersion
     {
         private static string _clientVersion;
-        private static string _clientVersionPure;
+        private static string _clientMajorMinorPatchVersion;
 
         /// <summary>
         /// (for tests only)
@@ -57,29 +57,67 @@ namespace Hazelcast.Core
         }
 
         /// <summary>
+        /// Returns the SemVer-compliant version without the build metadata.
+        /// Ex: 5.1.2-preview.0+ab16ec43 -> 5.1.2-preview.0
+        /// </summary>
+        /// /// <param name="version">The SemVer-compliant version.</param>
+        internal static string GetSemVerWithoutBuildingMetadata(string version)
+        {
+            var pos = version.IndexOf('+', StringComparison.OrdinalIgnoreCase);
+            return pos > 0 ? version[..pos] : version;
+        }
+        
+        /// <summary>
+        /// Returns the SemVer-compliant version without the build metadata.
+        /// </summary>
+        internal static string GetSemVerWithoutBuildingMetadata()
+        {
+            return GetSemVerWithoutBuildingMetadata(Version);
+        }
+        
+        /// <summary>
         /// (for tests only)
         /// Gets the major.minor version of a SemVer-compliant version.
-        /// Outside of tests, prefer the <see cref="MajorMinorVersion"/> property.
+        /// Outside of tests, prefer the <see cref="MajorMinorPatchMajorMinorPatchVersion"/> property.
         /// </summary>
         /// <param name="version">The SemVer-compliant version.</param>
         /// <returns>The "pure" version corresponding to the specified <paramref name="version"/>.</returns>
-        internal static string GetMajorMinorVersion(string version)
+        internal static string GetMajorMinorPatchVersion(string version)
         {
+            // one single dot = major.minor[+whatever]
+            // remove the +whatever part if any
+            var pos = version.IndexOf('+', StringComparison.OrdinalIgnoreCase);
+            if (pos >= 0) version = version[..pos];
+            
             var pos0 = version.IndexOf('.', StringComparison.OrdinalIgnoreCase);
             var pos1 = version.IndexOf('.', pos0 + 1);
-            if (pos1 >= 0)
+            var pos2 = -1;
+            
+            // Check the patch version segment, expecting max 2 digits
+            if (pos1 + 1 < version.Length && int.TryParse(version[pos1 + 1] + "", out _))
             {
-                // two dots = major.minor.whatever
-                // take everything until the second '.' = major.minor
+                pos2 = pos1 + 1; 
+
+                if (pos2 + 1 < version.Length && int.TryParse(version[pos2 + 1] + "", out _))
+                {
+                    pos2 = pos2 + 1;
+                }
+
+                pos2++; // because splitting excludes the last index
+            }
+
+            if (pos2 >= 0)
+            {
+                // two dots = major.minor.patch
+                // take everything until the second '.' = major.minor.patch
+                version = version[..pos2];
+            }
+            else if (pos1 >= 0)
+            {
+                // major.minor
                 version = version[..pos1];
             }
-            else
-            {
-                // one single dot = major.minor[+whatever]
-                // remove the +whatever part if any
-                var pos = version.IndexOf('+', StringComparison.OrdinalIgnoreCase);
-                if (pos >= 0) version = version[..pos];
-            }
+            
             return version;
         }
 
@@ -110,6 +148,14 @@ namespace Hazelcast.Core
         /// <remarks>
         /// <para>Returns the pure version, ie major.minor.</para>
         /// </remarks>
-        internal static string MajorMinorVersion => _clientVersionPure ??= GetMajorMinorVersion(Version);
+        internal static string MajorMinorPatchVersion
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(_clientMajorMinorPatchVersion)) return _clientMajorMinorPatchVersion;
+                _clientMajorMinorPatchVersion = GetMajorMinorPatchVersion(GetSemVerWithoutBuildingMetadata());
+                return _clientMajorMinorPatchVersion;
+            }
+        }
     }
 }

--- a/src/Hazelcast.Net/Metrics/ClientMetricSource.cs
+++ b/src/Hazelcast.Net/Metrics/ClientMetricSource.cs
@@ -89,7 +89,7 @@ namespace Hazelcast.Metrics
 
             yield return MetricDescriptors.Enterprise.WithValue(false);
             yield return MetricDescriptors.ClientType.WithValue(clientType);
-            yield return MetricDescriptors.ClientVersion.WithValue(ClientVersion.MajorMinorVersion);
+            yield return MetricDescriptors.ClientVersion.WithValue(ClientVersion.GetSemVerWithoutBuildingMetadata());
             yield return MetricDescriptors.ClientName.WithValue(_cluster.ClientName);
             yield return MetricDescriptors.ClusterConnectionTimestamp.WithValue(Clock.ToEpoch(connection.ConnectTime.UtcDateTime)); // TODO: ToEpoch supports DateTimeOffset
             yield return MetricDescriptors.ClientAddress.WithValue(connection.LocalEndPoint.Address.ToString());


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-csharp-client/pull/933 to `5.5.z`