### PR TITLE
HZC-7235: change-cloud-url

### DIFF
--- a/src/Hazelcast.Net.Tests/Configuration/HazelcastOptionsTests.cs
+++ b/src/Hazelcast.Net.Tests/Configuration/HazelcastOptionsTests.cs
@@ -325,7 +325,7 @@ namespace Hazelcast.Tests.Configuration
             Assert.AreEqual("token", cloudOptions.DiscoveryToken);
 
             // constant
-            Assert.AreEqual(new Uri("https://api.viridian.hazelcast.com"), cloudOptions.Url);
+            Assert.AreEqual(new Uri("https://api.cloud.hazelcast.com"), cloudOptions.Url);
 
             var socketOptions = options.Socket;
             Assert.AreEqual(1000, socketOptions.BufferSizeKiB);

--- a/src/Hazelcast.Net/Networking/CloudOptions.cs
+++ b/src/Hazelcast.Net/Networking/CloudOptions.cs
@@ -49,7 +49,7 @@ namespace Hazelcast.Networking
         /// <summary>
         /// Gets or sets the cloud url base.
         /// </summary>
-        public Uri Url { get; set; } = new Uri("https://api.viridian.hazelcast.com");
+        public Uri Url { get; set; } = new Uri("https://api.cloud.hazelcast.com");
 
         /// <summary>
         /// Clones the options.


### PR DESCRIPTION
chore: update cloud url to api.cloud.hazelcast.com to part of deprecation of using viridian