### PR TITLE
Remove Unnecessary Assertion on Client Version Tests & Upgrade Server Test Version

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -15,7 +15,7 @@
 ## Hazelcast.NET Build Script
 
 # constant
-$defaultServerVersion="5.5.0"
+$defaultServerVersion="5.5.7"
 
 # PowerShell errors can *also* be a pain
 # see https://stackoverflow.com/questions/10666035

--- a/src/Hazelcast.Net.Tests/Core/ClientVersionTests.cs
+++ b/src/Hazelcast.Net.Tests/Core/ClientVersionTests.cs
@@ -53,14 +53,14 @@ namespace Hazelcast.Tests.Core
 
 
             Assert.That(Authenticator.ClientVersion, Is.EqualTo(ClientVersion.MajorMinorPatchVersion));
-            var assemblyVersion = typeof(ClientVersion).Assembly.GetName().Version;
-            Assert.That(Authenticator.ClientVersion, Is.EqualTo(assemblyVersion.Major + "." + assemblyVersion.Minor + "." + assemblyVersion.MajorRevision));
             Assert.That(Authenticator.ClientVersion.Split('.').Length, Is.GreaterThanOrEqualTo(3));
         }
 
 
         [TestCase("1.2.3", "1.2.3")]
+        [TestCase("1.2.0", "1.2.0")]
         [TestCase("1.2.3-preview.0", "1.2.3")]
+        [TestCase("1.2.0-preview.0", "1.2.0")]
         [TestCase("1.2.3-SNAPSHOT", "1.2.3")]
         [TestCase("1.2.3+ae12b5d9", "1.2.3")]
         [TestCase("1.2.3-preview.0+ae12b5", "1.2.3")]


### PR DESCRIPTION
The removed assertion was checking the version in a wrong way since `Authenticator.ClientVersion` may return additional tags, like `1.2.3+preview.0` but assertion was neglecting these properties. Hence, in case of any additinal version steps fail. `TestGetSemVerWithoutBuildingMetadata` is already checking removed assertion intention in a proper way.

Also, upgraded the server version to latest released which is `5.5.7`.