### PR TITLE
Fix `codecov-action` [DI-520]

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -179,7 +179,7 @@ jobs:
       # publish to codecov - if build&test was successful
       # see https://github.com/marketplace/actions/codecov
       - name: Publish to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./temp/artifacts/test-coverage/cover-net8.0.xml

--- a/.github/workflows/create-checks.yml
+++ b/.github/workflows/create-checks.yml
@@ -239,8 +239,9 @@ jobs:
       # see https://github.com/marketplace/actions/codecov
       - name: Publish to Codecov
         if: inputs.coverage && inputs.conclusion == 'success' && (steps.unzip.outputs.coverage == 'true' || steps.move.outputs.coverage == 'true')
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./temp/test-coverage/windows/cover-net8.0.xml
           override_commit: ${{ inputs.head_sha }} # required since report runs on 'master'
+          fail_ci_if_error: true


### PR DESCRIPTION
The C++ coverage action has been [silently failing](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/15610247637/attempts/1).

Updated all usages to:
- supply a token to properly authenticate (the reason for the failure)
- fail the step if the upload fails (to avoid the error going unreported)
- use the latest version (consistency)

Fixes: [DI-520](https://hazelcast.atlassian.net/browse/DI-520)

[DI-520]: https://hazelcast.atlassian.net/browse/DI-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ