### PR TITLE
Install Environment on Build Release Action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -287,6 +287,14 @@ jobs:
 
     steps:
 
+      # Install our environment
+      - name: Install environment
+        uses: ./.github/actions/install
+        with:
+          os: ubuntu-latest
+          dotnet: true
+          java: false             
+
       # checkout the hazelcast/hazelcast-csharp-client repository
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
The `ubuntu-latest` doesn't contain .NET6 runtime anymore. I've encountered while [releasing ](https://github.com/hazelcast/hazelcast-csharp-client/actions/runs/15856493278/job/44707500159)the `5.5.1`. Included the install action on release building flow.