### PR TITLE
Revert "Install Environment on Build Release Action"

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -287,14 +287,6 @@ jobs:
 
     steps:
 
-      # Install our environment
-      - name: Install environment
-        uses: ./.github/actions/install
-        with:
-          os: ubuntu-latest
-          dotnet: true
-          java: false             
-
       # checkout the hazelcast/hazelcast-csharp-client repository
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Reverts hazelcast/hazelcast-csharp-client#978. The installation step is already there but .NET6 is still missing.