### PR TITLE
Relabel `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT` [CTT-504]

### DIFF
--- a/src/Hazelcast.Net.Tests/Resources.Designer.cs
+++ b/src/Hazelcast.Net.Tests/Resources.Designer.cs
@@ -294,7 +294,7 @@ namespace Hazelcast.Tests {
         ///&lt;hazelcast xmlns=&quot;http://www.hazelcast.com/schema/config&quot;
         ///           xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
         ///           xsi:schemaLocation=&quot;http://www.hazelcast.com/schema/config
-        ///           http://www.hazelcast.com/schema/config/hazelcast-config-6.0.xsd&quot;&gt;
+        ///           http://www.hazelcast.com/schema/config/hazelcast-config-5.6.xsd&quot;&gt;
         ///
         ///  &lt;properties&gt;
         ///    &lt;property name=&quot;hazelcast.map.invalidation.batch.enabled&quot;&gt;false&lt;/property&gt;

--- a/src/Hazelcast.Net.Tests/Resources/Cluster/vector.xml
+++ b/src/Hazelcast.Net.Tests/Resources/Cluster/vector.xml
@@ -2,7 +2,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-6.0.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.6.xsd">
 
   <properties>
     <property name="hazelcast.map.invalidation.batch.enabled">false</property>


### PR DESCRIPTION
Renames the version on `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT`.

Supports https://github.com/hazelcast/hazelcast-mono/pull/4852

Fixes: [CTT-504](https://hazelcast.atlassian.net/browse/CTT-504)

[CTT-504]: https://hazelcast.atlassian.net/browse/CTT-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ