### PR TITLE
Fix missing .Net6 on windows-latest

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -58,7 +58,7 @@ runs:
    
     - name: Install .NET on Windows
       if: inputs.dotnet == 'true' && inputs.os == 'windows-latest'
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '6.0.x'
 

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -56,6 +56,11 @@ runs:
         sudo apt-get install -y dotnet-sdk-6.0
         sudo apt-get install -y dotnet-sdk-8.0
    
+    - name: Install .NET on Windows
+      if: inputs.dotnet == 'true' && inputs.os == 'windows-latest'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
 
     # Install Java
     - name: Install JDK

--- a/hz.ps1
+++ b/hz.ps1
@@ -861,7 +861,7 @@ function ensure-server-files {
             # after 5.4.0, patch release become ee only.
             ensure-jar "hazelcast-enterprise-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${serverVersion}"
 
-            # but check if it's snapshot, then downloand from os repo
+            # but check if it's snapshot, then download from os repo
             $repo = if ($isSnapshot) { $mvnOssRepo } else { $mvnEntRepo }
 
             ensure-jar "hazelcast-sql-${serverVersion}.jar" $repo "com.hazelcast:hazelcast-sql:${serverVersion}"

--- a/hz.ps1
+++ b/hz.ps1
@@ -861,8 +861,8 @@ function ensure-server-files {
             # after 5.4.0, patch release become ee only.
             Write-Output "Download from enterprise repo"
             ensure-jar "hazelcast-enterprise-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${serverVersion}"
-            ensure-jar "hazelcast-sql-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-sql:${serverVersion}"
-            ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnEntRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
+            ensure-jar "hazelcast-sql-${serverVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-sql:${serverVersion}"
+            ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnOssRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
         }
         else {
             ensure-jar "hazelcast-enterprise-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${serverVersion}"

--- a/hz.ps1
+++ b/hz.ps1
@@ -857,12 +857,21 @@ function ensure-server-files {
             ensure-jar "hazelcast-enterprise-all-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise-all:${serverVersion}"
             ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnOssRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
         }
-        elseif ($serverVersion -cge "5.4.0") {
+        elseif ($serverVersion -cge "5.4.0") {            
             # after 5.4.0, patch release become ee only.
-            Write-Output "Download from enterprise repo"
             ensure-jar "hazelcast-enterprise-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${serverVersion}"
-            ensure-jar "hazelcast-sql-${serverVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-sql:${serverVersion}"
-            ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnOssRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
+
+            # but check if it's snapshot, then downloand from os repo
+            if ($isSnapshot)
+            {
+                ensure-jar "hazelcast-sql-${serverVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-sql:${serverVersion}"
+                ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnOssRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
+            }
+            else
+            {
+                ensure-jar "hazelcast-sql-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-sql:${serverVersion}"
+                ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnEntRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
+            }
         }
         else {
             ensure-jar "hazelcast-enterprise-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${serverVersion}"

--- a/hz.ps1
+++ b/hz.ps1
@@ -857,7 +857,7 @@ function ensure-server-files {
             ensure-jar "hazelcast-enterprise-all-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise-all:${serverVersion}"
             ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnOssRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
         }
-        elseif ($serverVersion -cge "5.4.0") {            
+        elseif ($serverVersion -cge "5.4.0") {
             # after 5.4.0, patch release become ee only.
             ensure-jar "hazelcast-enterprise-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${serverVersion}"
 

--- a/hz.ps1
+++ b/hz.ps1
@@ -862,16 +862,10 @@ function ensure-server-files {
             ensure-jar "hazelcast-enterprise-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${serverVersion}"
 
             # but check if it's snapshot, then downloand from os repo
-            if ($isSnapshot)
-            {
-                ensure-jar "hazelcast-sql-${serverVersion}.jar" $mvnOssRepo "com.hazelcast:hazelcast-sql:${serverVersion}"
-                ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnOssRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
-            }
-            else
-            {
-                ensure-jar "hazelcast-sql-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-sql:${serverVersion}"
-                ensure-jar "hazelcast-${serverVersion}-tests.jar" $mvnEntRepo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
-            }
+            $repo = if ($isSnapshot) { $mvnOssRepo } else { $mvnEntRepo }
+
+            ensure-jar "hazelcast-sql-${serverVersion}.jar" $repo "com.hazelcast:hazelcast-sql:${serverVersion}"
+            ensure-jar "hazelcast-${serverVersion}-tests.jar" $repo "com.hazelcast:hazelcast:${serverVersion}:jar:tests"
         }
         else {
             ensure-jar "hazelcast-enterprise-${serverVersion}.jar" $mvnEntRepo "com.hazelcast:hazelcast-enterprise:${serverVersion}"

--- a/hz.ps1
+++ b/hz.ps1
@@ -15,7 +15,7 @@
 ## Hazelcast.NET Build Script
 
 # constant
-$defaultServerVersion="5.5.6"
+$defaultServerVersion="5.6.0-SNAPSHOT"
 
 # PowerShell errors can *also* be a pain
 # see https://stackoverflow.com/questions/10666035


### PR DESCRIPTION
.Net6 is out of support and removed from `windows-latest`. Added a manual installation step. Also, upgraded target server version.