### PR TITLE
Relocate `hazelcast-remote-controller` [DI-639]

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -364,10 +364,9 @@ $hzRCVersion = "0.8-SNAPSHOT" # use appropriate version
 #$hzRCVersion = "0.5-SNAPSHOT" # for 3.12.x
 
 # determine java code repositories for tests
-$mvnOssPublicRepo = "https://oss.sonatype.org/content/repositories/snapshots"
 $mvnOssSnapshotRepo = "https://repository.hazelcast.com/snapshot-internal"
 $mvnEntSnapshotRepo = "https://repository.hazelcast.com/snapshot"
-$mvnOssReleaseRepo = "https://repo1.maven.org/maven2"
+$mvnOssReleaseRepo = "https://repo.maven.org/maven2"
 $mvnEntReleaseRepo = "https://repository.hazelcast.com/release"
 
 if ($isSnapshot) {
@@ -848,7 +847,7 @@ function ensure-server-files {
     if (-not (verify-server-files)) { determine-server-version }
 
     # ensure we have the remote controller + hazelcast test jar
-    ensure-jar "hazelcast-remote-controller-${hzRCVersion}.jar" $mvnOssPublicRepo "com.hazelcast:hazelcast-remote-controller:${hzRCVersion}"
+    ensure-jar "hazelcast-remote-controller-${hzRCVersion}.jar" $mvnEntSnapshotRepo "com.hazelcast:hazelcast-remote-controller:${hzRCVersion}"
     
     if ($options.enterprise) {
 

--- a/hz.ps1
+++ b/hz.ps1
@@ -366,7 +366,7 @@ $hzRCVersion = "0.8-SNAPSHOT" # use appropriate version
 # determine java code repositories for tests
 $mvnOssSnapshotRepo = "https://repository.hazelcast.com/snapshot-internal"
 $mvnEntSnapshotRepo = "https://repository.hazelcast.com/snapshot"
-$mvnOssReleaseRepo = "https://repo.maven.org/maven2"
+$mvnOssReleaseRepo = "https://repo.maven.apache.org/maven2"
 $mvnEntReleaseRepo = "https://repository.hazelcast.com/release"
 
 if ($isSnapshot) {


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-remote-controller/pull/75, `hazelcast-remote-controller` is deployed to a different repository to address build issues. Update the paths to suit.

Also updated Maven central URL as per https://github.com/hazelcast/hazelcast-mono/pull/4897

Fixes: [DI-639](https://hazelcast.atlassian.net/browse/DI-639)

[DI-639]: https://hazelcast.atlassian.net/browse/DI-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ