### PR TITLE
Drop .NET6 Support [API-2286]

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net48;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net8.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
     
@@ -20,7 +20,7 @@
 
         For .NET Framework (net462, net48) we use the dotCover.exe which comes with the CommandLineTools package, we
         cannot use the .NET Core approach because 'dotnet' does not support .NET Framework.
-        For .NET Core+ (netcoreapp3.1, net5.0, net6.0, net7.0) we use 'dotnet dotcover' which relies on the DotNetCliTool, and that
+        For .NET Core+ (netcoreapp3.1, net7.0) we use 'dotnet dotcover' which relies on the DotNetCliTool, and that
         works cross-platform, both on Windows and Linux.
 
         Therefore, we need to restore both.

--- a/hz.ps1
+++ b/hz.ps1
@@ -1064,11 +1064,9 @@ function require-dotnet ( $full ) {
 
     $result = @{ validSdks = $true; sdkInfos = "  SDKs:" }
 
-    # note:
-    # - net6.0 end of support is nov 12, 2024    
-    # - net8.0 end of support is nov 10, 2026
-
-    require-dotnet-version $result $sdks "6.0" $frameworks "net6.0" "6.0.x" $true $allowPrerelease    
+    # note:        
+    # - net8.0 end of support is nov 10, 2026    
+    
     require-dotnet-version $result $sdks "8.0" $frameworks "net8.0" "8.0.x" $true $allowPrerelease
 
     # report

--- a/src/Hazelcast.Net.Caching/Hazelcast.Net.Caching.csproj
+++ b/src/Hazelcast.Net.Caching/Hazelcast.Net.Caching.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <RootNamespace>Hazelcast.Caching</RootNamespace>
         <!--<ImplicitUsings>enable</ImplicitUsings>-->
         <Nullable>enable</Nullable>

--- a/src/Hazelcast.Net.DependencyInjection/Hazelcast.Net.DependencyInjection.csproj
+++ b/src/Hazelcast.Net.DependencyInjection/Hazelcast.Net.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <RootNamespace>Hazelcast.DependencyInjection</RootNamespace>
   </PropertyGroup>
 

--- a/src/Hazelcast.Net.Examples/Hazelcast.Net.Examples.csproj
+++ b/src/Hazelcast.Net.Examples/Hazelcast.Net.Examples.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net462;net48;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Hazelcast.Net.Linq.Async/Hazelcast.Net.Linq.Async.csproj
+++ b/src/Hazelcast.Net.Linq.Async/Hazelcast.Net.Linq.Async.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <RootNamespace>Hazelcast.Linq</RootNamespace>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
+++ b/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net462;net48;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Hazelcast.Net.Win32/Hazelcast.Net.Win32.csproj
+++ b/src/Hazelcast.Net.Win32/Hazelcast.Net.Win32.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <RootNamespace>Hazelcast</RootNamespace>
   </PropertyGroup>
 

--- a/src/Hazelcast.Net/Hazelcast.Net.csproj
+++ b/src/Hazelcast.Net/Hazelcast.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <RootNamespace>Hazelcast</RootNamespace>
   </PropertyGroup>
 
@@ -93,12 +93,10 @@
     <!-- note: requires analyzer version 3.3.4+ in order to support merging files -->
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
-    <AdditionalFiles Include="PublicAPI/net6.0/PublicAPI.Shipped.txt" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <AdditionalFiles Include="PublicAPI/net8.0/PublicAPI.Shipped.txt" Condition=" '$(TargetFramework)' == 'net8.0' " />
     <AdditionalFiles Include="PublicAPI/netstandard2.0/PublicAPI.Shipped.txt" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <AdditionalFiles Include="PublicAPI/netstandard2.1/PublicAPI.Shipped.txt" Condition=" '$(TargetFramework)' == 'netstandard2.1' " />
-
-    <AdditionalFiles Include="PublicAPI/net6.0/PublicAPI.Unshipped.txt" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    
     <AdditionalFiles Include="PublicAPI/net8.0/PublicAPI.Unshipped.txt" Condition=" '$(TargetFramework)' == 'net8.0' " />
     <AdditionalFiles Include="PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <AdditionalFiles Include="PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt" Condition=" '$(TargetFramework)' == 'netstandard2.1' " />


### PR DESCRIPTION
The .NET 6 support was ended at November 12, 2024, [source](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).