### PR TITLE
Updated Server Test Version from `5.6.0-SNAPSHOT` to `5.6.0`

### DIFF
--- a/src/Hazelcast.Net/Networking/SslLayer.cs
+++ b/src/Hazelcast.Net/Networking/SslLayer.cs
@@ -47,9 +47,18 @@ namespace Hazelcast.Networking
             // because it is supported with framework 4.7+ but not 4.6.2.
             //
             // https://referencesource.microsoft.com/#System/net/System/Net/SecureProtocols/_SslState.cs,5d0d274f6285d5dd
-
+#if !NET9_0_OR_GREATER
             var p = typeof(ServicePointManager).GetProperty("DisableSystemDefaultTlsVersions", BindingFlags.Static | BindingFlags.NonPublic);
             return p == null || !(bool)p.GetValue(null);
+#else
+            // ServicePointManager became obsoleted in .NET 9. 
+            // And, where >.NET9, SslProtocols.None is default option in the framework. 
+            // By trusting framework implementation, we don't check if SslProtocols.None is supported anymore.
+            // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs#L14
+            // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteNwContext.cs#L388
+
+            return true;
+#endif
         }
 
         public SslLayer(SslOptions options, IPAddress ipAddress, ILoggerFactory loggerFactory)
@@ -77,7 +86,7 @@ namespace Hazelcast.Networking
 
                 // assume there's only going to be 1 cert with a private key, and pick it
                 // should we work with more than 1 PK certs, we'd need a more complex logic
-                selectCertificate = (_, _, certificates, _, _) 
+                selectCertificate = (_, _, certificates, _, _)
                     => certificates.Cast<X509Certificate2>().FirstOrDefault(x => x.HasPrivateKey);
 
                 // for the whole cert chain to be sent as part of the handshake we need to copy the
@@ -92,8 +101,8 @@ namespace Hazelcast.Networking
                         if (!cert.HasPrivateKey)
                         {
                             _logger.LogInformation($"Adding certificate Subject='{cert.Subject}' Issuer='{cert.Issuer}' to the current user CA"
-                                + " store (at ~/.dotnet/corefx/cryptography/x509stores/ca). This is a mandatory workaround for .NET TLS/SSL to function"
-                                + " on the Linux operating system. Make sure that the store directory is correctly secured.");
+                                                   + " store (at ~/.dotnet/corefx/cryptography/x509stores/ca). This is a mandatory workaround for .NET TLS/SSL to function"
+                                                   + " on the Linux operating system. Make sure that the store directory is correctly secured.");
                             store.Add(cert);
                         }
                     }
@@ -159,13 +168,19 @@ namespace Hazelcast.Networking
         /// </summary>
         internal X509Certificate2Collection GetClientCertificates()
         {
-            var clientCertificates = new X509Certificate2Collection();
+            if (_options.CertificatePath == null) return new X509Certificate2Collection();
 
-            if (_options.CertificatePath == null) return clientCertificates;
+            X509Certificate2Collection clientCertificates;
 
             try
             {
+#if !NET9_0_OR_GREATER                
+                clientCertificates = new X509Certificate2Collection();
                 clientCertificates.Import(_options.CertificatePath, _options.CertificatePassword, _options.KeyStorageFlags);
+#else
+                clientCertificates = X509CertificateLoader
+                    .LoadPkcs12CollectionFromFile(_options.CertificatePath, _options.CertificatePassword, _options.KeyStorageFlags);
+#endif
             }
             catch (Exception e)
             {
@@ -209,7 +224,9 @@ namespace Hazelcast.Networking
                     {
                         name = $" (cert name: '{cert.Subject}')";
                     }
-                    catch { /* bah */ }
+                    catch
+                    { /* bah */
+                    }
                     _logger.IfWarning()?.LogWarning("SSL certificate error: {PolicyErrors}{Name}.", policyErrors, name);
                     validation = false;
                 }


### PR DESCRIPTION
Since `5.6.0` released, we can run the tests against released server version until the client is released.