### PR TITLE
[Breaking Change] Upgrade LINQ dependency [API-2335]

### DIFF
--- a/src/Hazelcast.Net.Examples/Hazelcast.Net.Examples.csproj
+++ b/src/Hazelcast.Net.Examples/Hazelcast.Net.Examples.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- no XML documentation here -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Hazelcast.Examples</RootNamespace>
     <AssemblyName>hx</AssemblyName>
@@ -35,21 +40,4 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />    
   </ItemGroup>
-
-  <!-- START - This section is required to resolve reference ambigutity raised in NET10
-  https://github.com/dotnet/docs/issues/44886
-  -->
-  <ItemGroup Condition="'$(TargetFramework)' != 'net10.0' and '$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'net48'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
-  </ItemGroup>
-
-  <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-      <Reference Condition="'%(Reference.AssemblyName)' == 'System.Linq.AsyncEnumerable'">
-        <Aliases>SystemLinqAsyncEnumerable</Aliases>
-      </Reference>
-    </ItemGroup>
-  </Target>
-  <!-- END - This section is required to resolve refence ambigutity raised in NET10 -->
-
 </Project>

--- a/src/Hazelcast.Net.Linq.Async/Hazelcast.Net.Linq.Async.csproj
+++ b/src/Hazelcast.Net.Linq.Async/Hazelcast.Net.Linq.Async.csproj
@@ -51,13 +51,10 @@
         </None>            
     </ItemGroup>
 
-  <!-- Note: async linq interfaces are moved to NET after net10.0. So, users must arrange references accordingly.       
-       https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/asyncenumerable   -->
-  <ItemGroup>
-    <PackageReference Include="System.Linq.Async" Version="6.0.3">      
+  <ItemGroup >
+    <PackageReference Include="System.Linq.Async" Version="7.0.0">
     </PackageReference>
-    <PackageReference Include="System.Linq.Async.Queryable" Version="6.0.3">
+    <PackageReference Include="System.Linq.Async.Queryable" Version="7.0.0">
     </PackageReference>
-  </ItemGroup>   
-  
+  </ItemGroup>
 </Project>

--- a/src/Hazelcast.Net.Testing/Hazelcast.Net.Testing.csproj
+++ b/src/Hazelcast.Net.Testing/Hazelcast.Net.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -33,9 +33,20 @@
     </PackageReference>
     <PackageReference Include="NuGet.Versioning" Version="6.14.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
-    <PackageReference Include="System.Linq.Async.Queryable" Version="6.0.3" />
+    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />        
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.0" Aliases="MicrosoftBclMemory" />
+  </ItemGroup>
+  
+  <Target Name="_SetAliasOnBuiltInSystemMemory" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <Reference Condition="'%(Reference.AssemblyName)' == 'Microsoft.Bcl.Memory'" Version="10.0.0">
+        <Aliases>MicrosoftBclMemory</Aliases>
+      </Reference>
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\Hazelcast.Net.Linq.Async\Hazelcast.Net.Linq.Async.csproj" />

--- a/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
+++ b/src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
@@ -49,21 +49,9 @@
     <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />    
   </ItemGroup>
 
-  <!-- START - This section is required to resolve reference ambigutity raised in NET10
-  https://github.com/dotnet/docs/issues/44886
-  -->  
-  <ItemGroup Condition="'$(TargetFramework)' != 'net10.0' and '$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'net48'">    
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net48'">
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.0" Aliases="MicrosoftBclMemory" />
   </ItemGroup>
-  
-  <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-      <Reference Condition="'%(Reference.AssemblyName)' == 'System.Linq.AsyncEnumerable'">
-        <Aliases>SystemLinqAsyncEnumerable</Aliases>
-      </Reference>
-    </ItemGroup>
-  </Target>
-  <!-- END - This section is required to resolve refence ambigutity raised in NET10 -->
 
   <Choose>
     <When Condition="'$(TargetFramework)' != 'net462' or '$(TargetFramework)' != 'net48'">


### PR DESCRIPTION
This PR upgrades `System.Linq.Async` and `System.Linq.Async.Queryable` to resolve clashes on .NET10 runtime.



**If you are targeting runtimes  like `net462;net48;net8.0;net9.0;net10.0` directly, you can ignore the note below.** 

#### Note to `netstandart2.0` users on .NET10 runtime;
`Hazelcast.Net` package has some poly fills to adapt some features on legacy framework. This is presented over `netstandart2.0` target. However, if you are running `netstandart2.0` built over .NET10 runtime, you should override the transient dependency `Microsoft.Bcl.Memory` package which comes with `Hazelcast.Net.Linq.Async` to escape from any clashes on .NET10 runtime.

In your `csproj` file;
```
  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.0" Aliases="MicrosoftBclMemory" />
  </ItemGroup>
  
  <Target Name="_SetAliasOnBuiltInSystemMemory" BeforeTargets="ResolveAssemblyReferences">
    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
      <Reference Condition="'%(Reference.AssemblyName)' == 'Microsoft.Bcl.Memory'" Version="10.0.0">
        <Aliases>MicrosoftBclMemory</Aliases>
      </Reference>
    </ItemGroup>
  </Target>
```

We present the `netstandart2.0` target for legacy framework support as intention of `netstandart2.0`. If you are trying to run it on modern runtimes, please consider to target `netstandart2.1` or such as .NET10 for better performance and user experience.