### PR TITLE
Fix Test Failures[HZ-5275]

### DIFF
--- a/src/Hazelcast.Net.Tests/Clustering/ConnectMembersTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/ConnectMembersTests.cs
@@ -217,7 +217,7 @@ namespace Hazelcast.Tests.Clustering
             {
                 await foreach (var request in memberConnectionQueue.WithCancellation(cancellationToken))
                 {
-                    dequeuedRequests++;
+                    Interlocked.Increment(ref dequeuedRequests);
                     if (!memberCount.TryGetValue(request.Member.Id, out var count)) count = 0;
                     memberCount[request.Member.Id] = ++count;
                     logger.LogDebug($"Connect request={dequeuedRequests} member={request.Member.Id.ToShortString()} count={count} result={(count == successCount ? "success" : "failed")}");

--- a/src/Hazelcast.Net/Models/VectorSearchOptions.cs
+++ b/src/Hazelcast.Net/Models/VectorSearchOptions.cs
@@ -34,7 +34,7 @@ namespace Hazelcast.Models
             IncludeValue = includeValue;
             IncludeVectors = includeVectors;
             Limit = limit;
-            Hints = hints;
+            Hints = hints ?? new Dictionary<string, string>();
         }
 
         /// <summary>


### PR DESCRIPTION
The PR fixes vector vector search hint null failure. Also, decreases instability of `TestDelayedQueue` test by using atomic increment instead ++ operation.