### PR TITLE
Enable Detailed Logging for Flaky Tests

### DIFF
--- a/src/Hazelcast.Net.Tests/CP/SemaphoreTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/SemaphoreTests.cs
@@ -283,6 +283,8 @@ public class SemaphoreTests : MultiMembersRemoteTestBase
     [Test]
     public async Task CanAcquireAtParallel([Values] bool sessionLess)
     {
+        HConsole.Configure(c=>c.ConfigureDefaults(this));
+        
         await using var semaphore = await GetSemaphore(sessionLess);
 
         Assert.That(await semaphore.GetAvailablePermitsAsync(), Is.EqualTo(0));
@@ -325,6 +327,8 @@ public class SemaphoreTests : MultiMembersRemoteTestBase
     [Test]
     public async Task CanAcquireAtParallelOnSameSemaphoreObject([Values] bool sessionLess)
     {
+        HConsole.Configure(c=> c.ConfigureDefaults(this));
+        
         await using var semaphore = await GetSemaphore(sessionLess);
 
         Assert.That(await semaphore.GetAvailablePermitsAsync(), Is.EqualTo(0));

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -84,7 +84,7 @@ namespace Hazelcast.Tests.Clustering
                 AssertClientOnlySees(client1, address1);
                 AssertClientOnlySees(client2, address2);
                 AssertClientOnlySees(client3, address3);
-            }, 10_000, 500, "Client1 did not see the correct members");
+            }, 20_000, 500, "Client1 did not see the correct members"); 
 
             // Kill a member and check if clients are still connected correct members
             var memberId3 = RcMembers.Values.Where(m => address3.Equals($"{m.Host}:{m.Port}")).Select(m => m.Uuid).First();

--- a/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MemberPartitionGroupServerTests.cs
@@ -82,10 +82,9 @@ namespace Hazelcast.Tests.Clustering
             await AssertEx.SucceedsEventually(() =>
             {
                 AssertClientOnlySees(client1, address1);
+                AssertClientOnlySees(client2, address2);
+                AssertClientOnlySees(client3, address3);
             }, 10_000, 500, "Client1 did not see the correct members");
-
-            AssertClientOnlySees(client2, address2);
-            AssertClientOnlySees(client3, address3);
 
             // Kill a member and check if clients are still connected correct members
             var memberId3 = RcMembers.Values.Where(m => address3.Equals($"{m.Host}:{m.Port}")).Select(m => m.Uuid).First();

--- a/src/Hazelcast.Net.Tests/Remote/ClientMapTest.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientMapTest.cs
@@ -1204,6 +1204,8 @@ namespace Hazelcast.Tests.Remote
         [Test]
         public async Task TestPutTransient()
         {
+            HConsole.Configure(c=>c.ConfigureDefaults(this));
+            
             var dictionary = await Client.GetMapAsync<string, string>(CreateUniqueName());
             await using var _ = DestroyAndDispose(dictionary);
 

--- a/src/Hazelcast.Net.Tests/Remote/UnisocketTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/UnisocketTests.cs
@@ -61,6 +61,8 @@ namespace Hazelcast.Tests.Remote
         [Test]
         public async Task TestDistributedObjectEventsWithDummyClient()
         {
+            HConsole.Configure(c => c.ConfigureDefaults(this));
+            
             var memberA = await AddMember();
             var memberB = await AddMember();
 

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToDataFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToDataFirstTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Hazelcast.Core;
 using Hazelcast.DistributedObjects;
 using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
@@ -80,6 +81,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task AddNothing()
         {
+            HConsole.Configure(c=> c.ConfigureDefaults(this));
             var options = GetHazelcastOptions();
 
             // writing a totally unregistered type works

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToDataFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToDataFirstTests.cs
@@ -24,6 +24,7 @@ using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
 using Hazelcast.Testing;
 using Hazelcast.Testing.Conditions;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
 namespace Hazelcast.Tests.Serialization.Compact
@@ -66,7 +67,11 @@ namespace Hazelcast.Tests.Serialization.Compact
                 {
                     options.ClusterName = RcCluster?.Id ?? options.ClusterName;
                     options.Networking.Addresses.Add("127.0.0.1:5701");
+                    
+                    options.LoggerFactory.Creator = ()=> 
+                        Microsoft.Extensions.Logging.LoggerFactory.Create((conf)=>conf.AddConsole());
                 })
+                .WithDefault("Logging:LogLevel:Hazelcast", "Debug")
                 .Build();
 
         // the constant values, ie values that the user specifies
@@ -94,6 +99,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task AddSerializer()
         {
+            HConsole.Configure(c=> c.ConfigureDefaults(this));
             var options = GetHazelcastOptions();
 
             // add a serializer - which provides the type name - the schema will derive from the serializer
@@ -107,6 +113,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task AddSerializerAndSchema()
         {
+            HConsole.Configure(c=> c.ConfigureDefaults(this));
             var options = GetHazelcastOptions();
 
             var schema = SchemaBuilder
@@ -128,6 +135,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task SetTypeName()
         {
+            HConsole.Configure(c=> c.ConfigureDefaults(this));
             var options = GetHazelcastOptions();
 
             // set the type name - will use the reflection serializer, but with that type name
@@ -142,6 +150,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task SetSchema()
         {
+            HConsole.Configure(c=> c.ConfigureDefaults(this));
             var options = GetHazelcastOptions();
 
             var schema = SchemaBuilder
@@ -280,6 +289,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [TestCase(2)]
         public async Task TypeHierarchySupport(int serializersMode)
         {
+            HConsole.Configure(c=> c.ConfigureDefaults(this));
             var options = GetHazelcastOptions();
 
             // ThingWrapper has a property which is an IThing

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Hazelcast.Core;
 using Hazelcast.DistributedObjects;
@@ -35,6 +36,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [SetUp]
         public async Task SetUp()
         {
+            Trace.Listeners.Add(new ConsoleTraceListener());
             _rcMember = await RcClient.StartMemberAsync(RcCluster);
         }
 
@@ -46,6 +48,7 @@ namespace Hazelcast.Tests.Serialization.Compact
                 await RcClient.StopMemberAsync(RcCluster, _rcMember);
                 _rcMember = null;
             }
+            Trace.Flush();
         }
 
         private static string GetRandomName(string prefix) => $"{prefix}-{Guid.NewGuid().ToString("N")[..7]}";

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 using System;
 using System.Threading.Tasks;
+using Hazelcast.Core;
 using Hazelcast.DistributedObjects;
 using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
@@ -115,6 +116,8 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task AddTypeName_FetchSchema_MatchingName()
         {
+            HConsole.Configure(c=>c.ConfigureDefaults(this));
+            
             var mapName = await SetUpCluster(SchemaBuilder
                 .For("thing")
                 .WithField("name", FieldKind.String)
@@ -134,6 +137,8 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task SetSchema_InvalidTypeName()
         {
+            HConsole.Configure(c=>c.ConfigureDefaults(this));
+            
             var mapName = await SetUpCluster(SchemaBuilder
                 .For("thing")
                 .WithField(Thing.FieldNames.Name, FieldKind.String)
@@ -200,6 +205,8 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task AddSerializer_InvalidTypeName()
         {
+            HConsole.Configure(c=> c.ConfigureDefaults(this));
+            
             var mapName = await SetUpCluster(SchemaBuilder
                 .For("thing")
                 .WithField("name", FieldKind.String)

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
@@ -19,7 +19,9 @@ using Hazelcast.Serialization;
 using Hazelcast.Serialization.Compact;
 using Hazelcast.Testing;
 using Hazelcast.Testing.Conditions;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Hazelcast.Tests.Serialization.Compact
 {
@@ -73,6 +75,8 @@ namespace Hazelcast.Tests.Serialization.Compact
                 {
                     options.ClusterName = RcCluster?.Id ?? options.ClusterName;
                     options.Networking.Addresses.Add("127.0.0.1:5701");
+                    options.LoggerFactory.Creator = () => Microsoft.Extensions.Logging.LoggerFactory
+                        .Create(conf => conf.AddConsole().SetMinimumLevel(LogLevel.Debug));
                 })
                 .Build();
 

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
@@ -52,6 +52,7 @@ namespace Hazelcast.Tests.Serialization.Compact
 
         private async Task<string> SetUpCluster(Schema schema)
         {
+            HConsole.Configure(c=>c.ConfigureDefaults(this));
             var options = GetHazelcastOptions();
 
             // note: do *not* provide the ThingCompactSerializer<Thing> so that we force-use the
@@ -83,6 +84,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task AddNothing_FetchSchema_ValidTypeName()
         {
+            HConsole.Configure(c=>c.ConfigureDefaults(this));
             var mapName = await SetUpCluster(SchemaBuilder
                 .For(CompactOptions.GetDefaultTypeName<Thing>())
                 .WithField("name", FieldKind.String)
@@ -101,6 +103,8 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task AddNothing_FetchSchema_InvalidTypeName()
         {
+            HConsole.Configure(c=>c.ConfigureDefaults(this));
+            
             var mapName = await SetUpCluster(SchemaBuilder
                 .For("thing")
                 .WithField("name", FieldKind.String)

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
@@ -186,6 +186,7 @@ namespace Hazelcast.Tests.Serialization.Compact
         [Test]
         public async Task SetSchemaAndTypeName()
         {
+            HConsole.Configure(c=> c.ConfigureDefaults(this));
             var mapName = await SetUpCluster(SchemaBuilder
                 .For("thing")
                 .WithField(Thing.FieldNames.Name, FieldKind.String)


### PR DESCRIPTION
- Stabilized `TestMultiMemberRoutingWorks` by using eventually assertion during cluster scaling.