### PR TITLE
Stabilize some flaky tests [HZ-5295]

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -204,7 +204,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Test-Results ${{ inputs.os }}-${{ matrix.fwk }}
-          path: './temp/tests/results/*.trx'
+          path: |
+            ./temp/tests/results/*.trx
+            ./temp/tests/results/*.log
 
       # upload test coverage artifact
       - name: Upload test coverage artifact
@@ -213,6 +215,17 @@ jobs:
         with:
           name: Test-Coverage ${{ inputs.os }}-${{ matrix.fwk }}
           path: './temp/tests/cover/' # entire directory
+
+      # upload RC and server logs for post-mortem analysis of server-side failures
+      - name: Upload server logs artifact
+        if: (success() || failure()) && steps.build.conclusion == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Server-Logs ${{ inputs.os }}-${{ matrix.fwk }}
+          path: |
+            ./temp/rc/*.log
+            ./temp/server/*.log
+          if-no-files-found: ignore
 
       # and then, everything below is for releases only
       # and need only be done on 1 environment (windows-latest + latest fwk) 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -218,7 +218,7 @@ jobs:
 
       # upload RC and server logs for post-mortem analysis of server-side failures
       - name: Upload server logs artifact
-        if: (success() || failure()) && steps.build.conclusion == 'success'
+        if: failure() && steps.build.conclusion == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: Server-Logs ${{ inputs.os }}-${{ matrix.fwk }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -206,6 +206,7 @@ jobs:
           name: Test-Results ${{ inputs.os }}-${{ matrix.fwk }}
           path: |
             ./temp/tests/results/*.trx
+            ./temp/tests/results/*.xml
             ./temp/tests/results/*.log
 
       # upload test coverage artifact
@@ -218,7 +219,7 @@ jobs:
 
       # upload RC and server logs for post-mortem analysis of server-side failures
       - name: Upload server logs artifact
-        if: failure() && steps.build.conclusion == 'success'
+        if: (success() || failure()) && steps.build.conclusion == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: Server-Logs ${{ inputs.os }}-${{ matrix.fwk }}

--- a/.github/workflows/create-checks.yml
+++ b/.github/workflows/create-checks.yml
@@ -217,7 +217,7 @@ jobs:
           echo "move.results      = ${{ steps.move.outputs.results }}"
           echo "move.coverage     = ${{ steps.move.outputs.coverage }}"
 
-      # report test results - always
+      # report test results via TRX - always (pass/fail summary + annotations)
       # see https://github.com/marketplace/actions/test-reporter
       - name: Report test results
         if: steps.unzip.outputs.results == 'true' || steps.move.outputs.results == 'true'
@@ -226,6 +226,18 @@ jobs:
           name: Test Results
           path: ./temp/test-results/*/results-*.trx
           reporter: dotnet-trx
+          list-suites: failed
+          list-tests: failed
+          fail-on-error: false
+
+      # report test results via NUnit XML - always (includes full stack traces that TRX drops)
+      - name: Report test results (NUnit XML)
+        if: steps.unzip.outputs.results == 'true' || steps.move.outputs.results == 'true'
+        uses: dorny/test-reporter@v1
+        with:
+          name: Test Results (details)
+          path: ./temp/test-results/*/results-*.xml
+          reporter: java-junit
           list-suites: failed
           list-tests: failed
           fail-on-error: false

--- a/.github/workflows/create-checks.yml
+++ b/.github/workflows/create-checks.yml
@@ -87,12 +87,12 @@ jobs:
           for i in ./temp/artifacts/Test-Results\ ubuntu-latest-*; do
             echo "Move $i"
             found=1
-            mv "$i/"* "./temp/test-results/ubuntu/"
+            for f in "$i"/*; do mv "$f" "./temp/test-results/ubuntu/"; done
           done
           for i in ./temp/artifacts/Test-Results\ windows-latest-*; do
             echo "Move $i"
             found=1
-            mv "$i/"* "./temp/test-results/windows/"
+            for f in "$i"/*; do mv "$f" "./temp/test-results/windows/"; done
           done
           if [ $found -eq 1 ]; then
             echo "results=true" >> $GITHUB_OUTPUT
@@ -105,12 +105,12 @@ jobs:
           for i in ./temp/artifacts/Test-Coverage\ ubuntu-latest-*; do
             echo "Move $i"
             found=1
-            mv "$i/"* "./temp/test-coverage/ubuntu/"
+            for f in "$i"/*; do mv "$f" "./temp/test-coverage/ubuntu/"; done
           done
           for i in ./temp/artifacts/Test-Coverage\ windows-latest-*; do
             echo "Move $i"
             found=1
-            mv "$i/"* "./temp/test-coverage/windows/"
+            for f in "$i"/*; do mv "$f" "./temp/test-coverage/windows/"; done
           done
           if [ $found -eq 1 ]; then
             echo "coverage=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-checks.yml
+++ b/.github/workflows/create-checks.yml
@@ -82,11 +82,11 @@ jobs:
         if: inputs.run_id == ''
         shell: bash
         run: |
+          shopt -s nullglob
           found=0
           for i in ./temp/artifacts/Test-Results\ ubuntu-latest-*; do
             echo "Move $i"
             found=1
-            echo "MOVE:"
             mv "$i/"* "./temp/test-results/ubuntu/"
           done
           for i in ./temp/artifacts/Test-Results\ windows-latest-*; do

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ build/hazelcast-*.xml
 
 /_ReSharper.Caches
 .github/secrets
+
+.worktrees/

--- a/hz.ps1
+++ b/hz.ps1
@@ -2091,6 +2091,10 @@ function stop-server() {
 # runs tests for a specified framework
 function run-tests ( $f ) {
 
+    # ensure the results directory exists before Tee-Object tries to write the console log
+    # (dotnet test creates it lazily via --results-directory, but Tee-Object needs it upfront)
+    New-Item -ItemType Directory -Force -Path "$tmpDir/tests/results" | Out-Null
+
     # run .NET Core unit tests
     # note:
     #   on some machines (??) MSBuild does not copy the NUnit adapter to the bin directory,

--- a/hz.ps1
+++ b/hz.ps1
@@ -1932,19 +1932,42 @@ function start-remote-controller() {
         -RedirectStandardOutput "$tmpDir/rc/stdout-$serverVersion.log" `
         -RedirectStandardError "$tmpDir/rc/stderr-$serverVersion.log" `
         -PassThru
-    Start-Sleep -Seconds 4
 
     if ($script:remoteController.HasExited) {
         Write-Output "stderr:"
         Write-Output $(get-content "$tmpDir/rc/stderr-$serverVersion.log")
         Write-Output ""
         Die "Remote controller has exited immediately."
-	}
-    else {
-        set-content "$tmpDir/rc/pid" $script:remoteController.Id
-        set-content "$tmpDir/rc/version" $serverVersion
-        Write-Output "Started remote controller for version $serverVersion with pid=$($script:remoteController.Id)"
     }
+
+    set-content "$tmpDir/rc/pid" $script:remoteController.Id
+    set-content "$tmpDir/rc/version" $serverVersion
+    Write-Output "Started remote controller for version $serverVersion with pid=$($script:remoteController.Id)"
+
+    # poll port 9701 until the RC is actually accepting connections (replaces the old blind
+    # Start-Sleep -Seconds 4 which was unreliable on slow CI or after a restart)
+    Write-Output "Waiting for remote controller to be ready..."
+    $rcReady = $false
+    for ($attempt = 0; $attempt -lt 60; $attempt++) {
+        if ($script:remoteController.HasExited) {
+            Write-Output "stderr:"
+            Write-Output $(get-content "$tmpDir/rc/stderr-$serverVersion.log")
+            Die "Remote controller exited while waiting for it to become ready."
+        }
+        try {
+            $tcp = [System.Net.Sockets.TcpClient]::new()
+            $tcp.Connect("127.0.0.1", 9701)
+            $tcp.Close()
+            $rcReady = $true
+            break
+        } catch {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+    if (-not $rcReady) {
+        Die "Remote controller did not become ready within 30 seconds."
+    }
+    Write-Output "Remote controller is ready."
 }
 
 # starts the server

--- a/hz.ps1
+++ b/hz.ps1
@@ -2126,7 +2126,7 @@ function run-tests ( $f ) {
 
         Write-Output "> dotnet dotcover $testArgs"
         pushd "$srcDir/Hazelcast.Net.Tests"
-        &dotnet dotcover $testArgs
+        &dotnet dotcover $testArgs 2>&1 | Tee-Object -FilePath "$tmpDir/tests/results/console-$f.log"
         popd
     }
     else {
@@ -2136,7 +2136,7 @@ function run-tests ( $f ) {
         $testArgs += $nunitArgs
 
         Write-Output "> dotnet test $testArgs"
-        &dotnet test $testArgs
+        &dotnet test $testArgs 2>&1 | Tee-Object -FilePath "$tmpDir/tests/results/console-$f.log"
     }
 
     # NUnit adapter does not support configuring the file name, move

--- a/hz.ps1
+++ b/hz.ps1
@@ -2000,7 +2000,36 @@ function start-server() {
 
 # tests the remote controller
 function test-remote-controller() {
-    return test-path "$tmpDir/rc/pid"
+    if (-not (test-path "$tmpDir/rc/pid")) { return $false }
+
+    # pid file exists - verify the process is still alive (it may have exited cleanly when
+    # all test-fixture clients called ExitAsync, but the pid file is not removed in that case)
+    if ($script:remoteController -and $script:remoteController.HasExited) {
+        Write-Output "Remote controller (pid=$($script:remoteController.Id)) has exited; removing stale pid file."
+        remove-item "$tmpDir/rc/pid" -ErrorAction SilentlyContinue
+        remove-item "$tmpDir/rc/version" -ErrorAction SilentlyContinue
+        return $false
+    }
+
+    # if we don't own the process reference, fall back to probing the pid in the file
+    $rcPid = [int](get-content "$tmpDir/rc/pid" -ErrorAction SilentlyContinue)
+    if ($rcPid -gt 0) {
+        try {
+            $proc = Get-Process -Id $rcPid -ErrorAction Stop
+            if ($proc.HasExited) {
+                remove-item "$tmpDir/rc/pid" -ErrorAction SilentlyContinue
+                remove-item "$tmpDir/rc/version" -ErrorAction SilentlyContinue
+                return $false
+            }
+        } catch {
+            # process not found at all
+            remove-item "$tmpDir/rc/pid" -ErrorAction SilentlyContinue
+            remove-item "$tmpDir/rc/version" -ErrorAction SilentlyContinue
+            return $false
+        }
+    }
+
+    return $true
 }
 
 # stops the remote controller
@@ -2217,6 +2246,15 @@ function hz-test {
         foreach ($framework in $testFrameworks) {
             Write-Output ""
             Write-Output "Run tests for $framework..."
+
+            # the RC may have exited between framework runs (when all test-fixture clients
+            # called ExitAsync the RC process exits cleanly but the pid file is not removed);
+            # restart it if we own it and it is no longer alive
+            if ($ownsrc -and -not (test-remote-controller)) {
+                Write-Output "Remote controller exited between runs, restarting..."
+                start-remote-controller
+            }
+
             run-tests $framework
         }
     }

--- a/hz.ps1
+++ b/hz.ps1
@@ -2149,7 +2149,7 @@ function run-tests ( $f ) {
         "NUnit.TestOutputXml=.",
         "NUnit.Labels=Off", # quiet please
         "NUnit.DefaultTestNamePattern=$($testName.Replace("<FRAMEWORK>", $f))",
-        "NUnit.ConsoleOut=0" # quiet please
+        "NUnit.ConsoleOut=1" # write test-level console output to the captured log file
     )
 
     if (-not [string]::IsNullOrEmpty($options.testFilter)) { $nunitArgs += "NUnit.Where=$($options.testFilter.Replace("<FRAMEWORK>", $f))" }

--- a/hz.ps1
+++ b/hz.ps1
@@ -2138,7 +2138,7 @@ function run-tests ( $f ) {
         "-f", "$f",
         "-v", "normal",
         "--logger", "trx;LogFileName=results-$f.trx", # log to file
-        "--logger", "console;verbosity=minimal", # and *not* to console (values: quiet|minimal|normal|detailed|diagnostic)
+        "--logger", "console;verbosity=normal", # and *not* to console (values: quiet|minimal|normal|detailed|diagnostic)
         "--results-directory", "$tmpDir/tests/results"
     )
 

--- a/src/Hazelcast.Net.Tests/CP/SemaphoreTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/SemaphoreTests.cs
@@ -300,7 +300,7 @@ public class SemaphoreTests : MultiMembersRemoteTestBase
 
             var sm = await _client.CPSubsystem.GetSemaphore(smName);
 
-            var acquired = await sm.TryAcquireAsync(1, 5_00);
+            var acquired = await sm.TryAcquireAsync(1, 5_000);
 
             if (acquired)
             {
@@ -339,7 +339,7 @@ public class SemaphoreTests : MultiMembersRemoteTestBase
             // Each run will bw in different thread. So, new context is a must.
             AsyncContext.New();
 
-            var acquired = await semaphore.TryAcquireAsync(1, 5_00);
+            var acquired = await semaphore.TryAcquireAsync(1, 5_000);
 
             if (acquired)
             {

--- a/src/Hazelcast.Net.Tests/Clustering/MembersLifecycleTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MembersLifecycleTests.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.Core;
 using Hazelcast.DistributedObjects;
@@ -133,7 +134,7 @@ namespace Hazelcast.Tests.Clustering
                 .MembersUpdated((sender, args) =>
                 {
                     HConsole.WriteLine(this, $"Handle MembersUpdated ({args.Members.Count} members)");
-                    membersCount = args.Members.Count;
+                    Volatile.Write(ref membersCount, args.Members.Count);
                 })
                 .ObjectCreated((sender, args) =>
                 {
@@ -174,7 +175,7 @@ namespace Hazelcast.Tests.Clustering
                 await RemoveMember(memberId);
                 HConsole.WriteLine(this, $"Removed member {member.Uuid.Substring(0, 7)} ({(int)stopwatch.Elapsed.TotalSeconds}s)");
 
-                await Task.Delay(500);
+                await Task.Delay(1000);
 
                 await UseClientOnce(map);
             }
@@ -188,8 +189,8 @@ namespace Hazelcast.Tests.Clustering
             // all members but one are gone
             await AssertEx.SucceedsEventually(() =>
             {
-                Assert.That(membersCount, Is.EqualTo(1));
-            }, 8000, 200);
+                Assert.That(Volatile.Read(ref membersCount), Is.EqualTo(1));
+            }, 20000, 200);
 
             // now terminate the client
             HConsole.WriteLine(this, "Dispose client...");

--- a/src/Hazelcast.Net.Tests/Networking/NetworkingTests.cs
+++ b/src/Hazelcast.Net.Tests/Networking/NetworkingTests.cs
@@ -312,11 +312,7 @@ namespace Hazelcast.Tests.Networking
             var message = ClientPingServerCodec.EncodeRequest();
 
             var token = new CancellationTokenSource(3_000).Token;
-#if NET8_0_OR_GREATER
             await AssertEx.ThrowsAsync<OperationCanceledException>(async () => await client.Cluster.Messaging.SendAsync(message, token).CfAwait());
-#else
-            await AssertEx.ThrowsAsync<TaskCanceledException>(async () => await client.Cluster.Messaging.SendAsync(message, token).CfAwait());
-#endif
             // TODO dispose the client, the server
             await server.StopAsync().CfAwait();
         }

--- a/src/Hazelcast.Net.Tests/Remote/ClientReliableTopicTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientReliableTopicTests.cs
@@ -453,7 +453,7 @@ public class ClientReliableTopicTests : SingleMemberRemoteTestBase
     }
 
     [Test]
-    [Timeout(80_000)]
+    [Timeout(120_000)]
     public async Task TestClusterRestartWhenSubscribed()
     {
         var topicName = "rtTestTopic2";
@@ -478,9 +478,20 @@ public class ClientReliableTopicTests : SingleMemberRemoteTestBase
         await RestartCluster(async () =>
             await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Disconnected, client.State); }, 15_000, 100));
 
-        await rt2.PublishAsync(1);
+        // Wait for both clients to reconnect before publishing — the executor needs to be
+        // alive and re-syncing its sequence, and client2 must be able to publish.
+        await AssertEx.SucceedsEventually(() => Assert.AreEqual(ClientState.Connected, client.State), 30_000, 100);
+        await AssertEx.SucceedsEventually(() => Assert.AreEqual(ClientState.Connected, client2.State), 30_000, 100);
 
-        Assert.True(await mne.WaitOneAsync());
+        // Publish multiple messages: the executor may miss the first one while adjusting its
+        // sequence after the ring buffer reset, so keep publishing until the mne is set.
+        for (var i = 1; i <= 10 && !mne.WaitOne(0); i++)
+        {
+            await rt2.PublishAsync(i);
+            await Task.Delay(500);
+        }
+
+        Assert.True(await mne.WaitOneAsync(30_000));
         await rt.DestroyAsync();
     }
 

--- a/src/Hazelcast.Net.Tests/Remote/ClientReliableTopicTests.cs
+++ b/src/Hazelcast.Net.Tests/Remote/ClientReliableTopicTests.cs
@@ -478,18 +478,11 @@ public class ClientReliableTopicTests : SingleMemberRemoteTestBase
         await RestartCluster(async () =>
             await AssertEx.SucceedsEventually(() => { Assert.AreEqual(ClientState.Disconnected, client.State); }, 15_000, 100));
 
-        // Wait for both clients to reconnect before publishing — the executor needs to be
-        // alive and re-syncing its sequence, and client2 must be able to publish.
+        // Wait for both clients to reconnect before publishing 
         await AssertEx.SucceedsEventually(() => Assert.AreEqual(ClientState.Connected, client.State), 30_000, 100);
         await AssertEx.SucceedsEventually(() => Assert.AreEqual(ClientState.Connected, client2.State), 30_000, 100);
 
-        // Publish multiple messages: the executor may miss the first one while adjusting its
-        // sequence after the ring buffer reset, so keep publishing until the mne is set.
-        for (var i = 1; i <= 10 && !mne.WaitOne(0); i++)
-        {
-            await rt2.PublishAsync(i);
-            await Task.Delay(500);
-        }
+        await rt2.PublishAsync(1);
 
         Assert.True(await mne.WaitOneAsync(30_000));
         await rt.DestroyAsync();

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
@@ -33,6 +33,10 @@ namespace Hazelcast.Tests.Serialization.Compact
         public async Task SetUp()
         {
             _rcMember = await RcClient.StartMemberAsync(RcCluster);
+            // Allow the newly started member time to stabilize and complete
+            // partition migration before the test begins. On slow CI machines,
+            // skipping this can cause transient failures in schema publication.
+            await Task.Delay(500);
         }
 
         [TearDown]

--- a/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
+++ b/src/Hazelcast.Net.Tests/Serialization/Compact/RemoteToObjectFirstTests.cs
@@ -24,7 +24,7 @@ namespace Hazelcast.Tests.Serialization.Compact
 {
     [TestFixture]
     [ServerCondition("[5.2,)")]
-    public class RemoteToObjectFirstTests : SingleMemberRemoteTestBase
+    public class RemoteToObjectFirstTests : ClusterRemoteTestBase
     {
         // we have to have 1 member per test else the schemas may end up being cached
         private Hazelcast.Testing.Remote.Member _rcMember;
@@ -33,10 +33,6 @@ namespace Hazelcast.Tests.Serialization.Compact
         public async Task SetUp()
         {
             _rcMember = await RcClient.StartMemberAsync(RcCluster);
-            // Allow the newly started member time to stabilize and complete
-            // partition migration before the test begins. On slow CI machines,
-            // skipping this can cause transient failures in schema publication.
-            await Task.Delay(500);
         }
 
         [TearDown]

--- a/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterMessaging.cs
@@ -242,19 +242,11 @@ namespace Hazelcast.Clustering
                         connection = GetInvocationConnection(invocation); // non-null, throws if no connections
                         return await connection.SendAsync(invocation, cancellationToken).CfAwait();
                     }
-#if NET8_0_OR_GREATER
                     catch (OperationCanceledException)
                     {
                         HConsole.WriteLine(this, "Canceled.");
                         throw;
                     }
-#else
-                catch (TaskCanceledException)
-                {
-                    HConsole.WriteLine(this, "Canceled.");
-                    throw;
-                }
-#endif
                     catch (Exception exception)
                     {
                         HConsole.WriteLine(this, $"Exception ({connection?.Id.ToShortString() ?? "null"}):{invocation.CorrelationId} {MessageTypeConstants.GetMessageTypeName(invocation.RequestMessage.MessageType)} {exception}");

--- a/src/Hazelcast.Net/Sql/SqlService.cs
+++ b/src/Hazelcast.Net/Sql/SqlService.cs
@@ -63,7 +63,6 @@ namespace Hazelcast.Sql
             {
                 (metadata, firstPage, partitionId) = await FetchFirstPageAsync(queryId, sql, parameters, options, cancellationToken).CfAwait();
             }
-#if NET8_0_OR_GREATER
             catch (OperationCanceledException)
             {
                 // maybe, the server is running the query, so better notify it
@@ -72,16 +71,6 @@ namespace Hazelcast.Sql
                 await CloseAsync(queryId).CfAwaitNoThrow(); // swallow the exception, nothing we can do really
                 throw;
             }
-#else
-            catch (TaskCanceledException)
-            {
-                // maybe, the server is running the query, so better notify it
-                // for any other exception: assume that the query did not start
-
-                await CloseAsync(queryId).CfAwaitNoThrow(); // swallow the exception, nothing we can do really
-                throw;
-            }
-#endif
 
             return new SqlQueryResult(_serializationService, metadata, firstPage, options.CursorBufferSize, FetchNextPageAsync, queryId, CloseAsync, partitionId, cancellationToken);
         }


### PR DESCRIPTION
Stabilized the flaky tests. I just catch that `RemoteToObjectFirstTests ` were creating number of members tough aim is single member. It was causing the instability. Also, improved the some volatile read/writes.

The changes in `hz.ps1` and GitHub actions are to keep tests logs accessible in case of debugging. 

closes #1026 
closes #1017 
closes #1016 
closes #1010 
closes #1009 
closes #966 
closes #964