### PR TITLE
Attempt to fix flaky ClusterEvents and MembersLifecycleTests

### DIFF
--- a/src/Hazelcast.Net.Tests/Clustering/MembersLifecycleTests.cs
+++ b/src/Hazelcast.Net.Tests/Clustering/MembersLifecycleTests.cs
@@ -170,12 +170,17 @@ namespace Hazelcast.Tests.Clustering
             while (RcMembers.Count > 1)
             {
                 var (memberId, member) = RcMembers.First();
+                var expectedCount = RcMembers.Count - 1;
                 HConsole.WriteLine(this, $"Remove member {member.Uuid.Substring(0, 7)} at {member.Host}:{member.Port}...");
                 stopwatch.Restart();
                 await RemoveMember(memberId);
                 HConsole.WriteLine(this, $"Removed member {member.Uuid.Substring(0, 7)} ({(int)stopwatch.Elapsed.TotalSeconds}s)");
 
-                await Task.Delay(1000);
+                // wait for MembersUpdated event to reflect the removal before proceeding
+                await AssertEx.SucceedsEventually(() =>
+                {
+                    Assert.That(Volatile.Read(ref membersCount), Is.EqualTo(expectedCount));
+                }, 20000, 200);
 
                 await UseClientOnce(map);
             }

--- a/src/Hazelcast.Net/Clustering/ClusterEvents.cs
+++ b/src/Hazelcast.Net/Clustering/ClusterEvents.cs
@@ -746,6 +746,7 @@ namespace Hazelcast.Clustering
         {
             lock (_collectMutex)
             {
+                if (_disposed == 1) return;
                 foreach (var memberSubscription in subscription)
                     _collectSubscriptions.Add(memberSubscription);
                 _collectTask ??= CollectSubscriptionsAsync(_cancel.Token);
@@ -757,6 +758,7 @@ namespace Hazelcast.Clustering
         {
             lock (_collectMutex)
             {
+                if (_disposed == 1) return;
                 _collectSubscriptions.Add(subscription);
                 _collectTask ??= CollectSubscriptionsAsync(_cancel.Token);
             }


### PR DESCRIPTION
Stabilized ClusterEvents and  MembersLifecycleTests  tests with some basic guards.