### PR TITLE
Add missing copyright header to `CancellationTokenSourceExtensions`

### DIFF
--- a/src/Hazelcast.Net/Polyfills/CancellationTokenSourceExtensions.cs
+++ b/src/Hazelcast.Net/Polyfills/CancellationTokenSourceExtensions.cs
@@ -1,4 +1,17 @@
-﻿using System;
+// Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;


### PR DESCRIPTION
File should have header, makes change in https://github.com/hazelcast/hazelcast-csharp-client/pull/1052 easier to review.